### PR TITLE
Added :lflags option to cook/make-native

### DIFF
--- a/tools/cook.janet
+++ b/tools/cook.janet
@@ -112,11 +112,12 @@
   [opts target & objects]
   (def ld (or (opts :linker) LD))
   (def cflags (or (opts :cflags) CFLAGS))
+  (def lflags (or (opts :lflags) ""))
   (def olist (string/join objects " "))
   (if (older-than-some target objects)
     (if is-win
       (shell ld " /DLL /OUT:" target " " olist " %JANET_PATH%\\janet.lib")
-      (shell ld " " cflags " -o " target " " olist))))
+      (shell ld " " cflags " -o " target " " olist " " lflags))))
 
 (defn- create-buffer-c
   "Inline raw byte file as a c file."


### PR DESCRIPTION
To link a module to dynamic libraries I need add -l... options at the end of the link command.
for example :

````
>:~/janet/gsl$ janet build
mkdir -p build
cc -c gsl_janet.c  -std=c99 -Wall -Wextra -fpic -O2 -o build/gsl_janet.o
cc -c build/gsl_lib.janet.c  -std=c99 -Wall -Wextra -fpic -O2 -o build/gsl_lib.janet.o
cc -shared -std=c99 -Wall -Wextra -fpic -O2 -o build/gsl.so build/gsl_janet.o build/gsl_lib.janet.o  -lgsl -lblas
````

````
>:~/janet/gsl$ cat build.janet
(import cook)

(cook/make-native
    :name "gsl"
    :embedded @["gsl_lib.janet"]
    :source @["gsl_janet.c"]
    :cflags (string cook/CFLAGS)
    :lflags " -lgsl -lblas")
````
This change has to be completed for windows (I know almost nothing about dev on windows ...)  
