### PR TITLE
Fix buffer (and string) used as callee for indexing.

### DIFF
--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -228,7 +228,8 @@ static Janet call_nonfn(JanetFiber *fiber, Janet callee) {
     int32_t argn = fiber->stacktop - fiber->stackstart;
     Janet ds, key;
     if (argn != 1) janet_panicf("%v called with arity %d, expected 1", callee, argn);
-    if (janet_checktypes(callee, JANET_TFLAG_INDEXED | JANET_TFLAG_DICTIONARY | JANET_TFLAG_ABSTRACT)) {
+    if (janet_checktypes(callee, JANET_TFLAG_INDEXED | JANET_TFLAG_DICTIONARY |
+			 JANET_TFLAG_STRING | JANET_TFLAG_BUFFER | JANET_TFLAG_ABSTRACT)) {
         ds = callee;
         key = fiber->data[fiber->stackstart];
     } else {


### PR DESCRIPTION

```
janet:78:> (@"abc" 0)
error: expected string|symbol|keyword|array|tuple|table|struct|buffer, got 0
  in _thunk [repl] (tailcall) at (79:88)
```

after the patch :

```
janet:0:> (@"abc" 0)
97
```
