### PR TITLE
Don't call mandb during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,6 @@ install: $(JANET_TARGET)
 	cp tools/highlight.janet $(JANET_PATH)
 	mkdir -p $(MANPATH)
 	cp janet.1 $(MANPATH)
-	mandb
 
 uninstall:
 	-rm $(BINDIR)/../$(JANET_TARGET)


### PR DESCRIPTION
Fixes #45 - make install fails on some platforms when calling mandb