### PR TITLE
Register core/file abstract type

### DIFF
--- a/src/core/io.c
+++ b/src/core/io.c
@@ -416,4 +416,7 @@ void janet_lib_io(JanetTable *env) {
     janet_core_def(env, "stdin",
                    makef(stdin, IO_READ | IO_NOT_CLOSEABLE | IO_SERIALIZABLE),
                    JDOC("The standard input file."));
+
+    janet_register_abstract_type(&cfun_io_filetype);
+    
 }

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -400,6 +400,14 @@ static const JanetReg io_cfuns[] = {
     {NULL, NULL, NULL}
 };
 
+/* C API */
+
+FILE *janet_getfile(const Janet *argv, int32_t n, int *flags) {
+    IOFile *iof = janet_getabstract(argv, n, &cfun_io_filetype);
+    *flags = iof->flags;
+    return iof->file;
+}
+
 /* Module entry point */
 void janet_lib_io(JanetTable *env) {
     janet_core_cfuns(env, NULL, io_cfuns);
@@ -417,6 +425,4 @@ void janet_lib_io(JanetTable *env) {
                    makef(stdin, IO_READ | IO_NOT_CLOSEABLE | IO_SERIALIZABLE),
                    JDOC("The standard input file."));
 
-    janet_register_abstract_type(&cfun_io_filetype);
-    
 }

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1250,6 +1250,8 @@ JANET_API JanetRange janet_getslice(int32_t argc, const Janet *argv);
 JANET_API int32_t janet_gethalfrange(const Janet *argv, int32_t n, int32_t length, const char *which);
 JANET_API int32_t janet_getargindex(const Janet *argv, int32_t n, int32_t length, const char *which);
 
+JANET_API FILE *janet_getfile(const Janet *argv, int32_t n, int *flags);
+
 
 /* Marshal API */
 JANET_API void janet_marshal_int(JanetMarshalContext *ctx, int32_t value);


### PR DESCRIPTION
Register `core/file` abstract type to allow acccess to janet file object in native C module.

For example in a native module we can do something like :

```C
struct IOFile {
    FILE *file;
    int flags;
};

FILE * get_janet_iostream(const Janet *argv, int32_t n) {
  const JanetAbstractType *iof_at=janet_get_abstract_type(janet_ckeywordv("core/file"));
  if (iof_at==NULL)
    janet_panic("core/file abstract type  not registered");
  struct IOFile * iof =(struct IOFile *)janet_getabstract(argv,n,iof_at);
  return iof->file;
}
```

