### PR TITLE
Fix nil error on drop-until fn

### DIFF
--- a/src/core/core.janet
+++ b/src/core/core.janet
@@ -703,7 +703,9 @@
   the predicate, and abort on first failure. Returns a new array."
   [pred ind]
   (def i (find-index pred ind))
-  (array/slice ind i))
+  (if i
+    (array/slice ind i)
+    @[]))
 
 (defn drop-while
   "Same as (drop-until (complement pred) ind)."

--- a/test/suite5.janet
+++ b/test/suite5.janet
@@ -80,4 +80,12 @@
 (assert-no-error "break 3" (for i 0 10 (if (> i 8) (break i))))
 (assert-no-error "break 4" ((fn [i] (if (> i 8) (break i))) 100))
 
+# drop-until
+
+(assert (deep= (drop-until pos? @[]) @[]) "drop-until 1")
+(assert (deep= (drop-until pos? @[1 2 3]) @[1 2 3]) "drop-until 2")
+(assert (deep= (drop-until pos? @[-1 -2 -3]) @[]) "drop-until 3")
+(assert (deep= (drop-until pos? @[-1 -2 3]) @[3]) "drop-until 4")
+(assert (deep= (drop-until pos? @[-1 1 -2]) @[1 -2]) "drop-until 5")
+
 (end-suite)


### PR DESCRIPTION
Handle case when index `i` is nil in `drop-until` function, to fix this error:
```clj
(drop-until pos? @[-1 -2 -3])

error: bad slot #1, expected integer, got nil
  in <cfunction>
  in drop-until [core.janet] at (21740:21758)
  in _thunk [repl] (tailcall) at (1:29)
```