### PR TITLE
Add support for Haiku

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ else ifeq ($(UNAME), Linux)
 	CLIBS:=$(CLIBS) -lrt -ldl
 endif
 # For other unix likes, add flags here!
+ifeq ($(UNAME),Haiku)
+	LDFLAGS=-Wl,--export-dynamic
+endif
 
 $(shell mkdir -p build/core build/mainclient build/webclient build/boot)
 all: $(JANET_TARGET) $(JANET_LIBRARY)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ make test
 make repl
 ```
 
+### 32-bit Haiku
+
+32-bit Haiku build instructions are the same as the unix-like build instructions,
+but you need to specify an alternative compiler, such as `gcc-x86`.
+
+```
+cd somewhere/my/projects/janet
+make CC=gcc-x86
+make test
+make repl
+```
+
 ### FreeBSD
 
 FreeBSD build instructions are the same as the unix-like build instuctions,

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -51,6 +51,7 @@ extern "C" {
     || defined(__FreeBSD__) || defined(__DragonFly__) \
     || defined(__FreeBSD_kernel__) \
     || defined(__GNU__) /* GNU/Hurd */ \
+    || defined(__HAIKU__) \
     || defined(__linux__) \
     || defined(__NetBSD__) \
     || defined(__OpenBSD__) \


### PR DESCRIPTION
Other defaults could be set in the Makefile, like the default installation path, but it would probably mess up the structure. This gets it to build successfully by default on 64-bit Haiku (instructions for 32-bit are included).