### PR TITLE
Primes example fixed

### DIFF
--- a/examples/primes.janet
+++ b/examples/primes.janet
@@ -13,4 +13,4 @@
     (if isprime? (array/push list i)))
   list)
 
-(print (string/pretty (primes 100)))
+(pp (primes 100))


### PR DESCRIPTION
"Primes" compilation was failing due to `compile error: unknown symbol "string/pretty" at (386:413) while compiling ./examples/primes.janet`. I changed `(print (string/pretty (primes 100)))` to '(pp (primes 100))` and it is working properly now. 

```
@[2   
  3   
  5   
  7   
  11  
  13  
  17  
  19  
  23  
  29  
  31  
  37  
  41  
  43  
  47  
  53  
  59  
  61  
  67  
  71  
  73  
  79  
  83  
  89  
  97] 
```