### PR TITLE
Add support for getting more detailed parser state 

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1788,7 +1788,7 @@
   (default chunks (fn [buf p] (getline (string "repl:"
                                                (parser/where p)
                                                ":"
-                                               (parser/state p) "> ")
+                                               (parser/state p :delimiters) "> ")
                                        buf)))
   (default onsignal (fn [f x]
                       (case (fiber/status f)
@@ -1806,7 +1806,7 @@ _fiber is bound to the suspended fiber
 
 ```)
                           (repl (fn [buf p]
-                                  (def status (parser/state p))
+                                  (def status (parser/state p :delimiters))
                                   (def c (parser/where p))
                                   (def prompt (string "debug[" level "]:" c ":" status "> "))
                                   (getline prompt buf))

--- a/src/mainclient/init.janet
+++ b/src/mainclient/init.janet
@@ -80,7 +80,7 @@
     (defn noprompt [_] "")
     (defn getprompt [p]
       (def offset (parser/where p))
-      (string "janet:" offset ":" (parser/state p) "> "))
+      (string "janet:" offset ":" (parser/state p :delimiters) "> "))
     (def prompter (if *quiet* noprompt getprompt))
     (defn getstdin [prompt buf]
       (file/write stdout prompt)


### PR DESCRIPTION
Implements #121

I think this could use some more tests, but I wanted to go ahead and get it up for review. I'm not 100% sure the `memcpy` on 877 is sound, as I'm not exactly sure of the gc rules for Janet. Also not sure about the key names, if you have an suggestions, I'm open.