### PR TITLE
Remove amalg.janet dependency on os/date

### DIFF
--- a/tools/amalg.janet
+++ b/tools/amalg.janet
@@ -1,10 +1,8 @@
 # Creates an amalgamated janet.c
 
 # Head
-(def {:year YY :month MM :month-day DD} (os/date))
 (print "/* Amalgamated build - DO NOT EDIT */")
-(print "/* Generated " YY "-" (inc MM) "-" (inc DD)
-       " with janet version " janet/version "-" janet/build " */")
+(print "/* Generated from janet version " janet/version "-" janet/build " */")
 (print "#define JANET_BUILD \"" janet/build "\"")
 (print ```#define JANET_AMALG```)
 (print ```#include "janet.h"```)


### PR DESCRIPTION
When compiling Janet with `JANET_REDUCED_OS`, `os/date` will not be available which breaks the tool amalg.janet. One can check file modification time on the filesystem instead.