### PR TITLE
Feature/alternative splice char

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -11,7 +11,7 @@
   "(defn name & more)\n\nDefine a function. Equivalent to (def name (fn name [args] ...))."
   (fn defn [name & more]
     (def len (length more))
-    (def modifiers @[])
+    (def modifiers #[])
     (var docstr "")
     (def fstart
       (fn recur [i]
@@ -62,14 +62,14 @@
   "Dynamically create a global def."
   [name value]
   (def name* (symbol name))
-  (setdyn name* @{:value value})
+  (setdyn name* #{:value value})
   nil)
 
 (defn varglobal
   "Dynamically create a global var."
   [name init]
   (def name* (symbol name))
-  (setdyn name* @{:ref @[init]})
+  (setdyn name* #{:ref #[init]})
   nil)
 
 ; Basic predicates
@@ -197,7 +197,7 @@
   (if (odd? (length bindings)) (error "expected even number of bindings to let"))
   (def len (length bindings))
   (var i 0)
-  (var accum @['do])
+  (var accum #['do])
   (while (< i len)
     (def {i k (+ i 1) v} bindings)
     (array/push accum (tuple 'def k v))
@@ -258,7 +258,7 @@
   [syms & body]
   (var i 0)
   (def len (length syms))
-  (def accum @[])
+  (def accum #[])
   (while (< i len)
     (array/push accum (get syms i) [gensym])
     (++ i))
@@ -425,7 +425,7 @@
   See loop for details."
   [head & body]
   (def $accum (gensym))
-  ~(do (def ,$accum @[]) (loop ,head (array/push ,$accum (do ,.body))) ,$accum))
+  ~(do (def ,$accum #[]) (loop ,head (array/push ,$accum (do ,.body))) ,$accum))
 
 (defmacro generate
   "Create a generator expression using the loop syntax. Returns a fiber
@@ -625,7 +625,7 @@
   "Map a function over every element in an array or tuple and
   use array to concatenate the results."
   [f ind]
-  (def res @[])
+  (def res #[])
   (each x ind
     (array/concat res (f x)))
   res)
@@ -634,7 +634,7 @@
   "Given a predicate, take only elements from an array or tuple for
   which (pred element) is truthy. Returns a new array."
   [pred ind]
-  (def res @[])
+  (def res #[])
   (each item ind
     (if (pred item)
       (array/push res item)))
@@ -654,7 +654,7 @@
   "Given a predicate, take only elements from an array or tuple for
   which (pred element) is truthy. Returns a new array of truthy predicate results."
   [pred ind]
-  (def res @[])
+  (def res #[])
   (each item ind
     (if-let [y (pred item)]
       (array/push res y)))
@@ -757,7 +757,7 @@
   ((juxt* a b c) x) evaluates to [(a x) (b x) (c x)]."
   [& funs]
   (fn [& args]
-    (def ret @[])
+    (def ret #[])
     (each f funs
       (array/push ret (f .args)))
     (tuple/slice ret 0)))
@@ -765,7 +765,7 @@
 (defmacro juxt
   "Macro form of juxt*. Same behavior but more efficient."
   [& funs]
-  (def parts @['tuple])
+  (def parts #['tuple])
   (def $args (gensym))
   (each f funs
     (array/push parts (tuple apply f $args)))
@@ -779,8 +779,8 @@
   (defn fop [last n]
     (def [h t] (if (= :tuple (type n))
                  (tuple (get n 0) (array/slice n 1))
-                 (tuple n @[])))
-    (def parts (array/concat @[h last] t))
+                 (tuple n #[])))
+    (def parts (array/concat #[h last] t))
     (tuple/slice parts 0))
   (reduce fop x forms))
 
@@ -792,8 +792,8 @@
   (defn fop [last n]
     (def [h t] (if (= :tuple (type n))
                  (tuple (get n 0) (array/slice n 1))
-                 (tuple n @[])))
-    (def parts (array/concat @[h] t @[last]))
+                 (tuple n #[])))
+    (def parts (array/concat #[h] t #[last]))
     (tuple/slice parts 0))
   (reduce fop x forms))
 
@@ -807,9 +807,9 @@
   (defn fop [last n]
     (def [h t] (if (= :tuple (type n))
                  (tuple (get n 0) (array/slice n 1))
-                 (tuple n @[])))
+                 (tuple n #[])))
     (def sym (gensym))
-    (def parts (array/concat @[h sym] t))
+    (def parts (array/concat #[h sym] t))
     ~(let [,sym ,last] (if ,sym ,(tuple/slice parts 0))))
   (reduce fop x forms))
 
@@ -823,9 +823,9 @@
   (defn fop [last n]
     (def [h t] (if (= :tuple (type n))
                  (tuple (get n 0) (array/slice n 1))
-                 (tuple n @[])))
+                 (tuple n #[])))
     (def sym (gensym))
-    (def parts (array/concat @[h] t @[sym]))
+    (def parts (array/concat #[h] t #[sym]))
     ~(let [,sym ,last] (if ,sym ,(tuple/slice parts 0))))
   (reduce fop x forms))
 
@@ -836,7 +836,7 @@
   ret)
 
 (defn walk-dict [f form]
-  (def ret @{})
+  (def ret #{})
   (loop [k :keys form]
     (put ret (f k) (f (get form k))))
   ret)
@@ -935,7 +935,7 @@
   are the values, and the values of the keys. If multiple keys have the same
   value, one key will be ignored."
   [ds]
-  (def ret @{})
+  (def ret #{})
   (loop [k :keys ds]
     (put ret (get ds k) k))
   ret)
@@ -944,7 +944,7 @@
   "Creates a table from two arrays/tuples.
   Returns a new table."
   [keys vals]
-  (def res @{})
+  (def res #{})
   (def lk (length keys))
   (def lv (length vals))
   (def len (if (< lk lv) lk lv))
@@ -975,7 +975,7 @@
   collection, then later values replace any previous ones.
   Returns a new table."
   [& colls]
-  (def container @{})
+  (def container #{})
   (loop [c :in colls
          key :keys c]
     (set (container key) (get c key)))
@@ -1014,7 +1014,7 @@
 (defn frequencies
   "Get the number of occurrences of each value in a indexed structure."
   [ind]
-  (def freqs @{})
+  (def freqs #{})
   (each x ind
     (def n (get freqs x))
     (set (freqs x) (if n (+ 1 n) 1)))
@@ -1024,7 +1024,7 @@
   "Returns an array of the first elements of each col,
   then the second, etc."
   [& cols]
-  (def res @[])
+  (def res #[])
   (def ncol (length cols))
   (when (> ncol 0)
     (def len (min .(map length cols)))
@@ -1036,8 +1036,8 @@
 (defn distinct
   "Returns an array of the deduplicated values in xs."
   [xs]
-  (def ret @[])
-  (def seen @{})
+  (def ret #[])
+  (def seen #{})
   (each x xs (if (get seen x) nil (do (put seen x true) (array/push ret x))))
   ret)
 
@@ -1055,11 +1055,11 @@
   "Takes a nested array (tree), and returns the depth first traversal of
   that array. Returns a new array."
   [xs]
-  (flatten-into @[] xs))
+  (flatten-into #[] xs))
 
 (defn kvs
   "Takes a table or struct and returns and array of key value pairs
-  like @[k v k v ...]. Returns a new array."
+  like #[k v k v ...]. Returns a new array."
   [dict]
   (def ret (array/new (* 2 (length dict))))
   (loop [k :keys dict] (array/push ret k (get dict k)))
@@ -1124,12 +1124,12 @@
   "Print formatted strings to stdout, followed by
   a new line."
   [f & args]
-  (file/write stdout (buffer/format @"" f .args)))
+  (file/write stdout (buffer/format #"" f .args)))
 
 (defn pp
   "Pretty print to stdout."
   [x]
-  (print (buffer/format @"" (dyn :pretty-format "%p") x)))
+  (print (buffer/format #"" (dyn :pretty-format "%p") x)))
 
 
 ;;;
@@ -1171,7 +1171,7 @@
         ~(if (= nil (def ,pattern ,expr)) ,sentinel ,(onmatch))))
 
     (and (tuple? pattern) (= :parens (tuple/type pattern)))
-    (if (and (= (pattern 0) '@) (symbol? (pattern 1)))
+    (if (and (= (pattern 0) '#) (symbol? (pattern 1)))
       ; Unification with external values
       ~(if (= ,(pattern 1) ,expr) ,(onmatch) ,sentinel)
       (match-1
@@ -1226,7 +1226,7 @@
        (cond
          (= i len-1) (get cases i)
          (< i len-1) (with-syms [$res]
-                       ~(if (= ,sentinel (def ,$res ,(match-1 (get cases i) $x (fn [] (get cases (inc i))) @{})))
+                       ~(if (= ,sentinel (def ,$res ,(match-1 (get cases i) $x (fn [] (get cases (inc i))) #{})))
                           ,(aux (+ 2 i))
                           ,$res)))) 0)))
 
@@ -1245,8 +1245,8 @@
   [text]
 
   (def maxcol (- (dyn :doc-width 80) 8))
-  (var buf @"    ")
-  (var word @"")
+  (var buf #"    ")
+  (var word #"")
   (var current 0)
 
   (defn pushword
@@ -1324,7 +1324,7 @@
   (defn recur [y] (macex1 y on-binding))
 
   (defn dotable [t on-value]
-    (def newt @{})
+    (def newt #{})
     (var key (next t nil))
     (while (not= nil key)
       (put newt (recur key) (on-value (get t key)))
@@ -1344,9 +1344,9 @@
     (def bound (get t 1))
     (tuple/slice
       (array/concat
-        @[(get t 0) (expand-bindings bound)]
+        #[(get t 0) (expand-bindings bound)]
         (tuple/slice t 2 -2)
-        @[(recur last)])))
+        #[(recur last)])))
 
   (defn expandall [t]
     (def args (map recur (tuple/slice t 1)))
@@ -1510,7 +1510,7 @@
 ;;;
 
 ; Get boot options
-(def- boot/opts @{})
+(def- boot/opts #{})
 (each [k v] (partition 2 (tuple/slice boot/args 2))
   (put boot/opts k v))
 
@@ -1520,7 +1520,7 @@
   bindings will not pollute the parent environment."
   [&opt parent]
   (def parent (if parent parent _env))
-  (def newenv (table/setproto @{} parent))
+  (def newenv (table/setproto #{} parent))
   newenv)
 
 (defn bad-parse
@@ -1600,7 +1600,7 @@
     (when good (if going (onstatus f res))))
 
   ; Loop
-  (def buf @"")
+  (def buf #"")
   (while going
     (buffer/clear buf)
     (chunks buf p)
@@ -1682,7 +1682,7 @@
   from searching that path template if the filter doesn't match the input
   path. The filter can be a string or a predicate function, and
   is often a file extension, including the period."
-  @[; Relative to (dyn :current-file "./."). Path must start with .
+  #[; Relative to (dyn :current-file "./."). Path must start with .
     [":cur:/:all:.jimage" :image check-.]
     [":cur:/:all:.janet" :source check-.]
     [":cur:/:all:/init.janet" :source check-.]
@@ -1759,12 +1759,12 @@
 
 (def module/cache
   "Table mapping loaded module identifiers to their environments."
-  @{})
+  #{})
 
 (def module/loading
   "Table mapping currently loading modules to true. Used to prevent
   circular dependencies."
-  @{})
+  #{})
 
 (defn dofile
   "Evaluate a file and return the resulting environment."
@@ -1804,7 +1804,7 @@
   "A table of loading method names to loading functions.
   This table lets require and import load many different kinds
   of files as module."
-  @{:native (fn [path &] (native path (make-env)))
+  #{:native (fn [path &] (native path (make-env)))
     :source (fn [path args]
               (put module/loading path true)
               (def newenv (dofile path .args))
@@ -1840,7 +1840,7 @@
   (def newenv (require path .args))
   (def prefix (or (and as (string as "/")) prefix (string path "/")))
   (loop [[k v] :pairs newenv :when (symbol? k) :when (not (v :private))]
-    (def newv (table/setproto @{:private (not ep)} v))
+    (def newv (table/setproto #{:private (not ep)} v))
     (put env (symbol prefix k) newv)))
 
 (defmacro import
@@ -1882,9 +1882,9 @@
                       (case (fiber/status f)
                         :dead (do
                                 (pp x)
-                                (put env '_ @{:value x}))
+                                (put env '_ #{:value x}))
                         :debug (let [nextenv (make-env env)]
-                                 (put nextenv '_fiber @{:value f})
+                                 (put nextenv '_fiber #{:value f})
                                  (setdyn :debug-level level)
                                  (debug/stacktrace f x)
                                  (print ```
@@ -1908,9 +1908,9 @@ _fiber is bound to the suspended fiber
 (defn- env-walk
   [pred &opt env]
   (default env (fiber/getenv (fiber/current)))
-  (def envs @[])
+  (def envs #[])
   (do (var e env) (while e (array/push envs e) (set e (table/getproto e))))
-  (def ret-set @{})
+  (def ret-set #{})
   (loop [envi :in envs
          k :keys envi
          :when (pred k)]
@@ -1956,7 +1956,7 @@ _fiber is bound to the suspended fiber
   ; Modify env based on some options.
   (loop [[k v] :pairs env
          :when (symbol? k)]
-    (def flat (proto-flatten @{} v))
+    (def flat (proto-flatten #{} v))
     (when (boot/config :no-docstrings)
       (put flat :doc nil))
     (when (boot/config :no-sourcemaps)

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -36,7 +36,7 @@
       (set index (+ index 1)))
     (array/push modifiers (string buf ")\n\n" docstr))
     ; Build return value
-    ~(def ,name ,.modifiers (fn ,name ,.(tuple/slice more start)))))
+    ~(def ,name ,@modifiers (fn ,name ,@(tuple/slice more start)))))
 
 (defn defmacro :macro
   "Define a macro."
@@ -56,7 +56,7 @@
 (defmacro def-
   "Define a private value that will not be exported."
   [name & more]
-  ~(def ,name :private ,.more))
+  ~(def ,name :private ,@more))
 
 (defn defglobal
   "Dynamically create a global def."
@@ -147,12 +147,12 @@
 (defmacro when
   "Evaluates the body when the condition is true. Otherwise returns nil."
   [condition & body]
-  ~(if ,condition (do ,.body)))
+  ~(if ,condition (do ,@body)))
 
 (defmacro unless
-  "Shorthand for (when (not condition) .body). "
+  "Shorthand for (when (not condition) @body). "
   [condition & body]
-  ~(if ,condition nil (do ,.body)))
+  ~(if ,condition nil (do ,@body)))
 
 (defmacro cond
   "Evaluates conditions sequentially until the first true condition
@@ -218,7 +218,7 @@
     ~(let [,f (,fiber/new (fn [] ,body) :ie)
            ,r (resume ,f)]
        (if (= (,fiber/status ,f) :error)
-         (do (def ,err ,r) ,(if fib ~(def ,fib ,f)) ,.(tuple/slice catch 1))
+         (do (def ,err ,r) ,(if fib ~(def ,fib ,f)) ,@(tuple/slice catch 1))
          ,r))))
 
 (defmacro and
@@ -262,7 +262,7 @@
   (while (< i len)
     (array/push accum (get syms i) [gensym])
     (++ i))
-  ~(let (,.accum) ,.body))
+  ~(let (,@accum) ,@body))
 
 (defmacro with
   "Evaluate body with some resource, which will be automatically cleaned up
@@ -272,7 +272,7 @@
   [[binding ctor dtor] & body]
   (with-syms [res f]
     ~(let [,binding ,ctor
-           ,f (,fiber/new (fn [] ,.body) :ie)
+           ,f (,fiber/new (fn [] ,@body) :ie)
            ,res (,resume ,f)]
        (,(or dtor :close) ,binding)
        (if (,= (,fiber/status ,f) :error)
@@ -287,7 +287,7 @@
        (def ,s ,stop)
        (while (,comparison ,i ,s)
          (def ,binding ,i)
-         ,.body
+         ,@body
          (set ,i (,delta ,i ,step))))))
 
 (defn- each-template
@@ -300,7 +300,7 @@
        (def ,len (,length ,ds))
        (while (,< ,i ,len)
          (def ,binding (get ,ds ,i))
-         ,.body
+         ,@body
          (++ ,i)))))
 
 (defn- keys-template
@@ -312,7 +312,7 @@
        (var ,k (,next ,ds nil))
        (while ,k
          (def ,binding ,(if pair? ~(tuple ,k (get ,ds ,k)) k))
-         ,.body
+         ,@body
          (set ,k (,next ,ds ,k))))))
 
 (defn- iterate-template
@@ -335,7 +335,7 @@
 
     ; Terminate recursion
     (<= (length head) i)
-    ~(do ,.body)
+    ~(do ,@body)
 
     ; 2 term expression
     (keyword? binding)
@@ -425,18 +425,18 @@
   See loop for details."
   [head & body]
   (def $accum (gensym))
-  ~(do (def ,$accum #[]) (loop ,head (array/push ,$accum (do ,.body))) ,$accum))
+  ~(do (def ,$accum #[]) (loop ,head (array/push ,$accum (do ,@body))) ,$accum))
 
 (defmacro generate
   "Create a generator expression using the loop syntax. Returns a fiber
   that yields all values inside the loop in order. See loop for details."
   [head & body]
-  ~(fiber/new (fn [] (loop ,head (yield (do ,.body)))) :yi))
+  ~(fiber/new (fn [] (loop ,head (yield (do ,@body)))) :yi))
 
 (defmacro coro
-  "A wrapper for making fibers. Same as (fiber/new (fn [] .body) :yi)."
+  "A wrapper for making fibers. Same as (fiber/new (fn [] @body) :yi)."
   [& body]
-  (tuple fiber/new (tuple 'fn '[] .body) :yi))
+  (tuple fiber/new (tuple 'fn '[] @body) :yi))
 
 (defn sum
   "Returns the sum of xs. If xs is empty, returns 0."
@@ -484,9 +484,9 @@
   (aux 0))
 
 (defmacro when-let
-  "Same as (if-let bindings (do .body))."
+  "Same as (if-let bindings (do @body))."
   [bindings & body]
-  ~(if-let ,bindings (do ,.body)))
+  ~(if-let ,bindings (do ,@body)))
 
 (defn comp
   "Takes multiple functions and returns a function that is the composition
@@ -495,12 +495,12 @@
   (case (length functions)
     0 nil
     1 (get functions 0)
-    2 (let [[f g]       functions] (fn [& x] (f (g .x))))
-    3 (let [[f g h]     functions] (fn [& x] (f (g (h .x)))))
-    4 (let [[f g h i]   functions] (fn [& x] (f (g (h (i .x))))))
+    2 (let [[f g]       functions] (fn [& x] (f (g @x))))
+    3 (let [[f g h]     functions] (fn [& x] (f (g (h @x)))))
+    4 (let [[f g h i]   functions] (fn [& x] (f (g (h (i @x))))))
     (let [[f g h i] functions]
       (comp (fn [x] (f (g (h (i x)))))
-            .(tuple/slice functions 4 -1)))))
+            @(tuple/slice functions 4 -1)))))
 
 (defn identity
   "A function that returns its first argument."
@@ -618,7 +618,7 @@
     (for i 0 limit
       (def args (array/new ninds))
       (for j 0 ninds (set (args j) (get (get inds j) i)))
-      (set (res i) (f .args))))
+      (set (res i) (f @args))))
   res)
 
 (defn mapcat
@@ -759,7 +759,7 @@
   (fn [& args]
     (def ret #[])
     (each f funs
-      (array/push ret (f .args)))
+      (array/push ret (f @args)))
     (tuple/slice ret 0)))
 
 (defmacro juxt
@@ -902,13 +902,13 @@
   (def dyn-forms
     (seq [i :range [0 (length bindings) 2]]
          ~(setdyn ,(bindings i) ,(bindings (+ i 1)))))
-  ~(,resume (,fiber/new (fn [] ,.dyn-forms ,.body) :p)))
+  ~(,resume (,fiber/new (fn [] ,@dyn-forms ,@body) :p)))
 
 (defn partial
   "Partial function application."
   [f & more]
   (if (zero? (length more)) f
-    (fn [& r] (f .more .r))))
+    (fn [& r] (f @more @r))))
 
 (defn every?
   "Returns true if each value in is truthy, otherwise the first
@@ -958,7 +958,7 @@
   data structure ds."
   [ds key func & args]
   (def old (get ds key))
-  (set (ds key) (func old .args)))
+  (set (ds key) (func old @args)))
 
 (defn merge-into
   "Merges multiple tables/structs into a table. If a key appears in more than one
@@ -1027,7 +1027,7 @@
   (def res #[])
   (def ncol (length cols))
   (when (> ncol 0)
-    (def len (min .(map length cols)))
+    (def len (min @(map length cols)))
     (loop [i :range [0 len]
            ci :range [0 ncol]]
       (array/push res (get (get cols ci) i))))
@@ -1124,7 +1124,7 @@
   "Print formatted strings to stdout, followed by
   a new line."
   [f & args]
-  (file/write stdout (buffer/format #"" f .args)))
+  (file/write stdout (buffer/format #"" f @args)))
 
 (defn pp
   "Pretty print to stdout."
@@ -1150,7 +1150,7 @@
   ~(do
      (def ,$form ,form)
      (def ,binding (if (idempotent? ,$form) ,$form (gensym)))
-     (def ,$result (do ,.body))
+     (def ,$result (do ,@body))
      (if (= ,$form ,binding)
        ,$result
        (tuple 'do (tuple 'def ,binding ,$form) ,$result))))
@@ -1177,7 +1177,7 @@
       (match-1
         (get pattern 0) expr
         (fn []
-          ~(if (and ,.(tuple/slice pattern 1)) ,(onmatch) ,sentinel)) seen))
+          ~(if (and ,@(tuple/slice pattern 1)) ,(onmatch) ,sentinel)) seen))
 
     (indexed? pattern)
     (do
@@ -1350,17 +1350,17 @@
 
   (defn expandall [t]
     (def args (map recur (tuple/slice t 1)))
-    (tuple (get t 0) .args))
+    (tuple (get t 0) @args))
 
   (defn expandfn [t]
     (def t1 (get t 1))
     (if (symbol? t1)
       (do
         (def args (map recur (tuple/slice t 3)))
-        (tuple 'fn t1 (get t 2) .args))
+        (tuple 'fn t1 (get t 2) @args))
       (do
         (def args (map recur (tuple/slice t 2)))
-        (tuple 'fn t1 .args))))
+        (tuple 'fn t1 @args))))
 
   (defn expandqq [t]
     (defn qq [x]
@@ -1395,13 +1395,13 @@
     (def m? (entry :macro))
     (cond
       s (s t)
-      m? (m .(tuple/slice t 1))
+      m? (m @(tuple/slice t 1))
       (tuple/slice (map recur t))))
 
   (def ret
     (case (type x)
       :tuple (if (= (tuple/type x) :brackets)
-               (tuple/brackets .(map recur x))
+               (tuple/brackets @(map recur x))
                (dotup x))
       :array (map recur x)
       :struct (table/to-struct (dotable x recur))
@@ -1501,7 +1501,7 @@
       x))
   (def expanded (macex arg on-binding))
   (def fn-args (seq [i :range [0 (+ 1 max-param-seen)]] (symbol '$ i)))
-  ~(fn [,.fn-args ,.(if vararg ['& '$&] [])] ,expanded))
+  ~(fn [,@fn-args ,@(if vararg ['& '$&] [])] ,expanded))
 
 ;;;
 ;;;
@@ -1749,7 +1749,7 @@
                          (module/expand-path path t))))
           paths (filter identity (map expander module/paths))
           str-parts (interpose "\n    " paths)]
-      [nil (string "could not find module " path ":\n    " .str-parts)])))
+      [nil (string "could not find module " path ":\n    " @str-parts)])))
 
 (put _env 'fexists nil)
 (put _env 'nati nil)
@@ -1772,7 +1772,7 @@
   (def {:exit exit-on-error
         :source source
         :env env
-        :compile-only compile-only} (table .args))
+        :compile-only compile-only} (table @args))
   (def f (if (= (type path) :core/file)
            path
            (file/open path :rb)))
@@ -1807,7 +1807,7 @@
   #{:native (fn [path &] (native path (make-env)))
     :source (fn [path args]
               (put module/loading path true)
-              (def newenv (dofile path .args))
+              (def newenv (dofile path @args))
               (put newenv :source path)
               (put module/loading path nil)
               newenv)
@@ -1836,8 +1836,8 @@
   (def env (fiber/getenv (fiber/current)))
   (def {:as as
         :prefix prefix
-        :export ep} (table .args))
-  (def newenv (require path .args))
+        :export ep} (table @args))
+  (def newenv (require path @args))
   (def prefix (or (and as (string as "/")) prefix (string path "/")))
   (loop [[k v] :pairs newenv :when (symbol? k) :when (not (v :private))]
     (def newv (table/setproto #{:private (not ep)} v))
@@ -1857,13 +1857,13 @@
                      x
                      (string x)))
                  args))
-  (tuple import* (string path) .argm))
+  (tuple import* (string path) @argm))
 
 (defmacro use
   "Similar to import, but imported bindings are not prefixed with a namespace
   identifier. Can also import multiple modules in one shot."
   [& modules]
-  ~(do ,.(map (fn [x] ~(,import* ,(string x) :prefix "")) modules)))
+  ~(do ,@(map (fn [x] ~(,import* ,(string x) :prefix "")) modules)))
 
 (defn repl
   "Run a repl. The first parameter is an optional function to call to
@@ -1967,7 +1967,7 @@ _fiber is bound to the suspended fiber
   (put env 'boot/args nil)
   (def image (let [env-pairs (pairs (env-lookup env))
                    essential-pairs (filter (fn [[k v]] (or (cfunction? v) (abstract? v))) env-pairs)
-                   lookup (table .(mapcat identity essential-pairs))
+                   lookup (table @(mapcat identity essential-pairs))
                    reverse-lookup (invert lookup)]
                (marshal env reverse-lookup)))
 
@@ -1982,7 +1982,7 @@ _fiber is bound to the suspended fiber
               "#endif\n"
               "static const unsigned char janet_core_image_bytes[] = {\n")
   (loop [line :in (partition 10 chunks)]
-    (def str (string .(interpose ", " (map (partial string/format "0x%.2X") line))))
+    (def str (string @(interpose ", " (map (partial string/format "0x%.2X") line))))
     (file/write image-file "    " str ",\n"))
   (file/write image-file
               "    0\n};\n\n"

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1,11 +1,11 @@
-# The core janet library
-# Copyright 2019 © Calvin Rose
+; The core janet library
+; Copyright 2019 © Calvin Rose
 
-###
-###
-### Macros and Basic Functions
-###
-###
+;;;
+;;;
+;;; Macros and Basic Functions
+;;;
+;;;
 
 (def defn :macro
   "(defn name & more)\n\nDefine a function. Equivalent to (def name (fn name [args] ...))."
@@ -26,7 +26,7 @@
             (if (< i len) (recur (+ i 1)))))))
     (def start (fstart 0))
     (def args (get more start))
-    # Add function signature to docstring
+    ; Add function signature to docstring
     (var index 0)
     (def arglen (length args))
     (def buf (buffer "(" name))
@@ -35,7 +35,7 @@
       (buffer/format buf "%p" (get args index))
       (set index (+ index 1)))
     (array/push modifiers (string buf ")\n\n" docstr))
-    # Build return value
+    ; Build return value
     ~(def ,name ,.modifiers (fn ,name ,.(tuple/slice more start)))))
 
 (defn defmacro :macro
@@ -72,7 +72,7 @@
   (setdyn name* @{:ref @[init]})
   nil)
 
-# Basic predicates
+; Basic predicates
 (defn even? "Check if x is even." [x] (== 0 (% x 2)))
 (defn odd? "Check if x is odd." [x] (not= 0 (% x 2)))
 (defn zero? "Check if x is zero." [x] (== x 0))
@@ -118,7 +118,7 @@
        :struct true})
     (fn idempotent? [x] (not (get non-atomic-types (type x))))))
 
-# C style macros and functions for imperative sugar. No bitwise though.
+; C style macros and functions for imperative sugar. No bitwise though.
 (defn inc "Returns x + 1." [x] (+ x 1))
 (defn dec "Returns x - 1." [x] (- x 1))
 (defmacro ++ "Increments the var x by 1." [x] ~(set ,x (,+ ,x ,1)))
@@ -333,11 +333,11 @@
 
   (cond
 
-    # Terminate recursion
+    ; Terminate recursion
     (<= (length head) i)
     ~(do ,.body)
 
-    # 2 term expression
+    ; 2 term expression
     (keyword? binding)
     (let [rest (loop1 body head (+ i 2))]
       (case binding
@@ -351,7 +351,7 @@
         :when ~(when ,verb ,rest)
         (error (string "unexpected loop modifier " binding))))
 
-    # 3 term expression
+    ; 3 term expression
     (let [rest (loop1 body head (+ i 3))]
       (case verb
         :range (let [[start stop step] object]
@@ -469,11 +469,11 @@
         (def atm (idempotent? bl))
         (def sym (if atm bl (gensym)))
         (if atm
-          # Simple binding
+          ; Simple binding
           (tuple 'do
                  (tuple 'def sym br)
                  (tuple 'if sym (aux (+ 2 i)) fal))
-          # Destructured binding
+          ; Destructured binding
           (tuple 'do
                  (tuple 'def sym br)
                  (tuple 'if sym
@@ -549,11 +549,11 @@
   [xs]
   (get xs (- (length xs) 1)))
 
-###
-###
-### Indexed Combinators
-###
-###
+;;;
+;;;
+;;; Indexed Combinators
+;;;
+;;;
 
 (def sort
   "(sort xs [, by])\n\nSort an array in-place. Uses quick-sort and is not a stable sort."
@@ -707,7 +707,7 @@
   [n ind]
   (def use-str (bytes? ind))
   (def f (if use-str string/slice tuple/slice))
-  # make sure end is in [0, len]
+  ; make sure end is in [0, len]
   (def end (max 0 (min n (length ind))))
   (f ind 0 end))
 
@@ -732,7 +732,7 @@
   [n ind]
   (def use-str (bytes? ind))
   (def f (if use-str string/slice tuple/slice))
-  # make sure start is in [0, len]
+  ; make sure start is in [0, len]
   (def start (max 0 (min n (length ind))))
   (f ind start -1))
 
@@ -1093,11 +1093,11 @@
   (if (not= i len) (array/push ret (slicer ind i)))
   ret)
 
-###
-###
-### IO Helpers
-###
-###
+;;;
+;;;
+;;; IO Helpers
+;;;
+;;;
 
 (defn slurp
   "Read all data from a file with name path
@@ -1132,11 +1132,11 @@
   (print (buffer/format @"" (dyn :pretty-format "%p") x)))
 
 
-###
-###
-### Pattern Matching
-###
-###
+;;;
+;;;
+;;; Pattern Matching
+;;;
+;;;
 
 (defmacro- with-idemp
   "Return janet code body that has been prepended
@@ -1156,7 +1156,7 @@
        (tuple 'do (tuple 'def ,binding ,$form) ,$result))))
 
 
-# Sentinel value for mismatches
+; Sentinel value for mismatches
 (def- sentinel ~',(gensym))
 
 (defn- match-1
@@ -1172,7 +1172,7 @@
 
     (and (tuple? pattern) (= :parens (tuple/type pattern)))
     (if (and (= (pattern 0) '@) (symbol? (pattern 1)))
-      # Unification with external values
+      ; Unification with external values
       ~(if (= ,(pattern 1) ,expr) ,(onmatch) ,sentinel)
       (match-1
         (get pattern 0) expr
@@ -1234,11 +1234,11 @@
 (put _env 'match-1 nil)
 (put _env 'with-idemp nil)
 
-###
-###
-### Documentation
-###
-###
+;;;
+;;;
+;;; Documentation
+;;;
+;;;
 
 (defn doc-format
   "Reformat text to wrap at a given line."
@@ -1273,7 +1273,7 @@
           (buffer/push-string buf "\n    ")
           (set current 0)))))
 
-  # Last word
+  ; Last word
   (pushword)
 
   buf)
@@ -1306,11 +1306,11 @@
   [sym]
   ~(,doc* ',sym))
 
-###
-###
-### Macro Expansion
-###
-###
+;;;
+;;;
+;;; Macro Expansion
+;;;
+;;;
 
 (defn macex1
   "Expand macros in a form, but do not recursively expand macros.
@@ -1461,11 +1461,11 @@
     (set current (macex1 current on-binding)))
   current)
 
-###
-###
-### Function shorthand
-###
-###
+;;;
+;;;
+;;; Function shorthand
+;;;
+;;;
 
 (defmacro short-fn
   "fn shorthand.\n\n
@@ -1503,13 +1503,13 @@
   (def fn-args (seq [i :range [0 (+ 1 max-param-seen)]] (symbol '$ i)))
   ~(fn [,.fn-args ,.(if vararg ['& '$&] [])] ,expanded))
 
-###
-###
-### Evaluation and Compilation
-###
-###
+;;;
+;;;
+;;; Evaluation and Compilation
+;;;
+;;;
 
-# Get boot options
+; Get boot options
 (def- boot/opts @{})
 (each [k v] (partition 2 (tuple/slice boot/args 2))
   (put boot/opts k v))
@@ -1571,13 +1571,13 @@
   (default on-parse-error bad-parse)
   (default where "<anonymous>")
 
-  # Are we done yet?
+  ; Are we done yet?
   (var going true)
 
-  # The parser object
+  ; The parser object
   (def p (parser/new))
 
-  # Evaluate 1 source form in a protected manner
+  ; Evaluate 1 source form in a protected manner
   (defn eval1 [source]
     (var good true)
     (def f
@@ -1599,7 +1599,7 @@
     (def res (resume f nil))
     (when good (if going (onstatus f res))))
 
-  # Loop
+  ; Loop
   (def buf @"")
   (while going
     (buffer/clear buf)
@@ -1616,7 +1616,7 @@
         (eval1 (parser/produce p)))
       (when (= (parser/status p) :error)
         (on-parse-error p where))))
-  # Check final parser state
+  ; Check final parser state
   (while (parser/has-more p)
     (eval1 (parser/produce p)))
   (when (= (parser/status p) :error)
@@ -1682,19 +1682,19 @@
   from searching that path template if the filter doesn't match the input
   path. The filter can be a string or a predicate function, and
   is often a file extension, including the period."
-  @[# Relative to (dyn :current-file "./."). Path must start with .
+  @[; Relative to (dyn :current-file "./."). Path must start with .
     [":cur:/:all:.jimage" :image check-.]
     [":cur:/:all:.janet" :source check-.]
     [":cur:/:all:/init.janet" :source check-.]
     [(string ":cur:/:all:" nati) :native check-.]
 
-    # As a path from (os/cwd)
+    ; As a path from (os/cwd)
     [":all:.jimage" :image not-check-.]
     [":all:.janet" :source not-check-.]
     [":all:/init.janet" :source not-check-.]
     [(string ":all:" nati) :native not-check-.]
 
-    # System paths
+    ; System paths
     [":sys:/:all:.jimage" :image not-check-.]
     [":sys:/:all:.janet" :source not-check-.]
     [":sys:/:all:/init.janet" :source not-check-.]
@@ -1703,7 +1703,7 @@
 (setdyn :syspath (boot/opts "JANET_PATH"))
 (setdyn :headerpath (boot/opts "JANET_HEADERPATH"))
 
-# Version of fexists that works even with a reduced OS
+; Version of fexists that works even with a reduced OS
 (if-let [has-stat (_env 'os/stat)]
   (let [stat (has-stat :value)]
     (defglobal "fexists" (fn fexists [path] (= :file (stat path :mode)))))
@@ -1929,16 +1929,16 @@ _fiber is bound to the suspended fiber
   [&opt env]
   (env-walk keyword? env))
 
-# Clean up some extra defs
+; Clean up some extra defs
 (put _env 'boot/opts nil)
 (put _env 'env-walk nil)
 (put _env '_env nil)
 
-###
-###
-### Bootstrap
-###
-###
+;;;
+;;;
+;;; Bootstrap
+;;;
+;;;
 
 (do
 
@@ -1953,7 +1953,7 @@ _fiber is bound to the suspended fiber
 
   (def env (fiber/getenv (fiber/current)))
 
-  # Modify env based on some options.
+  ; Modify env based on some options.
   (loop [[k v] :pairs env
          :when (symbol? k)]
     (def flat (proto-flatten @{} v))
@@ -1971,9 +1971,9 @@ _fiber is bound to the suspended fiber
                    reverse-lookup (invert lookup)]
                (marshal env reverse-lookup)))
 
-  # Create C source file that contains images a uint8_t buffer. This
-  # can be compiled and linked statically into the main janet library
-  # and example client.
+  ; Create C source file that contains images a uint8_t buffer. This
+  ; can be compiled and linked statically into the main janet library
+  ; and example client.
   (def chunks (string/bytes image))
   (def image-file (file/open (boot/args 1) :wb))
   (file/write image-file

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -178,7 +178,7 @@ static void popstate(JanetParser *p, Janet val) {
             const char *which =
                 (c == '\'') ? "quote" :
                 (c == ',') ? "unquote" :
-                (c == '.') ? "splice" :
+                (c == '@') ? "splice" :
                 (c == '|') ? "short-fn" :
                 (c == '~') ? "quasiquote" : "<unknown>";
             t[0] = janet_csymbolv(which);
@@ -491,7 +491,7 @@ static int root(JanetParser *p, JanetParseState *state, uint8_t c) {
             return 0;
         case '\'':
         case ',':
-        case '.':
+        case '@':
         case '~':
         case '|':
             pushstate(p, root, PFLAG_READERMAC | c);
@@ -912,7 +912,7 @@ static Janet janet_wrap_parse_state(JanetParseState *s, Janet *args,
         int c = s->flags & 0xFF;
         type = (c == '\'') ? "quote" :
                (c == ',') ? "unquote" :
-               (c == '.') ? "splice" :
+               (c == '@') ? "splice" :
                (c == '~') ? "quasiquote" : "<reader>";
     } else {
         type = "root";

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -474,7 +474,7 @@ static int atsign(JanetParser *p, JanetParseState *state, uint8_t c) {
             break;
     }
     pushstate(p, tokenchar, PFLAG_TOKEN);
-    push_buf(p, '@'); /* Push the leading at-sign that was dropped */
+    push_buf(p, '#'); /* Push the leading at-sign that was dropped */
     return 0;
 }
 
@@ -502,7 +502,7 @@ static int root(JanetParser *p, JanetParseState *state, uint8_t c) {
         case ';':
             pushstate(p, comment, PFLAG_COMMENT);
             return 1;
-        case '@':
+        case '#':
             pushstate(p, atsign, PFLAG_ATSYM);
             return 1;
         case '`':

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -499,7 +499,7 @@ static int root(JanetParser *p, JanetParseState *state, uint8_t c) {
         case '"':
             pushstate(p, stringchar, PFLAG_STRING);
             return 1;
-        case '#':
+        case ';':
             pushstate(p, comment, PFLAG_COMMENT);
             return 1;
         case '@':

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -178,7 +178,7 @@ static void popstate(JanetParser *p, Janet val) {
             const char *which =
                 (c == '\'') ? "quote" :
                 (c == ',') ? "unquote" :
-                (c == ';') ? "splice" :
+                (c == '.') ? "splice" :
                 (c == '|') ? "short-fn" :
                 (c == '~') ? "quasiquote" : "<unknown>";
             t[0] = janet_csymbolv(which);
@@ -491,7 +491,7 @@ static int root(JanetParser *p, JanetParseState *state, uint8_t c) {
             return 0;
         case '\'':
         case ',':
-        case ';':
+        case '.':
         case '~':
         case '|':
             pushstate(p, root, PFLAG_READERMAC | c);
@@ -912,7 +912,7 @@ static Janet janet_wrap_parse_state(JanetParseState *s, Janet *args,
         int c = s->flags & 0xFF;
         type = (c == '\'') ? "quote" :
                (c == ',') ? "unquote" :
-               (c == ';') ? "splice" :
+               (c == '.') ? "splice" :
                (c == '~') ? "quasiquote" : "<reader>";
     } else {
         type = "root";

--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -170,7 +170,7 @@ static void janet_escape_string_b(JanetBuffer *buffer, const uint8_t *str) {
 }
 
 static void janet_escape_buffer_b(JanetBuffer *buffer, JanetBuffer *bx) {
-    janet_buffer_push_u8(buffer, '@');
+    janet_buffer_push_u8(buffer, '#');
     janet_escape_string_impl(buffer, bx->data, bx->count);
 }
 
@@ -381,7 +381,7 @@ static void janet_pretty_one(struct pretty *S, Janet x, int is_dict_value) {
             }
             if (janet_checktype(x, JANET_BUFFER) && janet_unwrap_buffer(x) == S->buffer) {
                 janet_buffer_ensure(S->buffer, S->buffer->count + S->bufstartlen * 4 + 3, 1);
-                janet_buffer_push_u8(S->buffer, '@');
+                janet_buffer_push_u8(S->buffer, '#');
                 janet_escape_string_impl(S->buffer, S->buffer->data, S->bufstartlen);
             } else {
                 janet_description_b(S->buffer, x);
@@ -398,7 +398,7 @@ static void janet_pretty_one(struct pretty *S, Janet x, int is_dict_value) {
             int isarray = janet_checktype(x, JANET_ARRAY);
             janet_indexed_view(x, &arr, &len);
             int hasbrackets = !isarray && (janet_tuple_flag(arr) & JANET_TUPLE_FLAG_BRACKETCTOR);
-            const char *startstr = isarray ? "@[" : hasbrackets ? "[" : "(";
+            const char *startstr = isarray ? "#[" : hasbrackets ? "[" : "(";
             const char endchar = isarray ? ']' : hasbrackets ? ']' : ')';
             janet_buffer_push_cstring(S->buffer, startstr);
             S->depth--;
@@ -422,7 +422,7 @@ static void janet_pretty_one(struct pretty *S, Janet x, int is_dict_value) {
         case JANET_STRUCT:
         case JANET_TABLE: {
             int istable = janet_checktype(x, JANET_TABLE);
-            janet_buffer_push_cstring(S->buffer, istable ? "@" : "{");
+            janet_buffer_push_cstring(S->buffer, istable ? "#" : "{");
 
             /* For object-like tables, print class name */
             if (istable) {

--- a/src/mainclient/init.janet
+++ b/src/mainclient/init.janet
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 (C) Calvin Rose
+; Copyright 2017-2019 (C) Calvin Rose
 
 (do
 
@@ -15,7 +15,7 @@
   (if-let [jp (os/getenv "JANET_HEADERPATH")] (setdyn :headerpath jp))
   (def args (dyn :args))
 
-  # Flag handlers
+  ; Flag handlers
   (def handlers :private
     {"h" (fn [&]
            (print "usage: " (get args 0) " [options] script args...")
@@ -63,7 +63,7 @@
     (def h (get handlers n))
     (if h (h i) (do (print "unknown flag -" n) ((get handlers "h")))))
 
-  # Process arguments
+  ; Process arguments
   (var i 0)
   (def lenargs (length args))
   (while (< i lenargs)


### PR DESCRIPTION
I have strong doubts you would consider this request, as I'm sure the original decisions that went into parse syntax were a combination of your personal preference + technical reasons, but I'd like to propose Janet re-work the parse syntax to be more lisp-like as defined in this pull request.

The reasons in favor (in my opinion) are:

- Strong / better integration with existing "lisp" (Emacs lisp, Common Lisp, Clojure, Scheme) like tooling systems
- More familiar / less jarring syntax for people coming from said lisp environments
- More readable / less surprising symbols for new-comers (in most non-lisps, semi-colon tends to delimit a line or statement, and in lisps it is the comment character.  In both cases the semi itself has very little "effect" on the evaluation results of the code.  In Janet, it is very impactful.

The overall change set should be as such:

- Splice character changed from `;` to `@` (parity with *-lisp)
- Mutable data type prefix changed from `@` to `#` (parity / similarity with other lisps using that as a value to indicate what succeeds it is a unique datatype or form)
- Comment character changed from `#` to `;` (much more lisp-like)

Thoughts?