### PR TITLE
Defuse tarbomb: wrap tar file contents in directory, fix #163

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,10 @@ build/janet-%.tar.gz: $(JANET_TARGET) \
 	src/include/janet.h src/conf/janetconf.h \
 	jpm.1 janet.1 LICENSE CONTRIBUTING.md $(JANET_LIBRARY) $(JANET_STATIC_LIBRARY) \
 	build/doc.html README.md build/janet.c
-	tar -czvf $@ $^
+	$(eval JANET_DIST_DIR = "janet-$(shell basename $*)")
+	mkdir -p build/$(JANET_DIST_DIR)
+	cp -r $^ build/$(JANET_DIST_DIR)/
+	cd build && tar -czvf ../$@ $(JANET_DIST_DIR)
 
 #########################
 ##### Documentation #####


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Tar_(computing)#Tarbomb
http://www.linfo.org/tarbomb.html

The `--transform` option requires GNU tar: BSD tar uses the option `-s` instead, and its value must omit the initial `s`.
If GNU tar is not an acceptable requirement, another way would be to create a temporary `janet-<version>` directory and put the files there before archiving it.

Edit: add link to issue #163