### PR TITLE
Correct old name all-symbols to all-bindings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ documentation for symbols in the core library. For example,
 Shows documentation for the doc macro.
 
 To get a list of all bindings in the default
-environment, use the `(all-symbols)` function.
+environment, use the `(all-bindings)` function.
 
 ## Source
 


### PR DESCRIPTION
```
janet:0:> (all-symbols)
compile error: unknown symbol "all-symbols" at (1:13) while compiling repl
```