### PR TITLE
Correct 'in' documentation.

### DIFF
--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -744,7 +744,7 @@ static const JanetReg corelib_cfuns[] = {
         "get", janet_core_get,
         JDOC("(get ds key &opt dflt)\n\n"
              "Get the value mapped to key in data structure ds, and return dflt or nil if not found. "
-             "Similar to get, but will not throw an error if the key is invalid for the data structure "
+             "Similar to 'in', but will not throw an error if the key is invalid for the data structure "
              "unless the data structure is an abstract type. In that case, the abstract type getter may throw "
              "an error.")
     },
@@ -1025,7 +1025,7 @@ JanetTable *janet_core_env(JanetTable *replacements) {
                          "the fiber's dispatch function, or the value from the next yield call in fiber."));
     janet_quick_asm(env, JANET_FUN_IN,
                     "in", 3, 2, 3, 4, get_asm, sizeof(get_asm),
-                    JDOC("(get ds key &opt dflt)\n\n"
+                    JDOC("(in ds key &opt dflt)\n\n"
                          "Get a value from any associative data structure. Arrays, tuples, tables, structs, strings, "
                          "symbols, and buffers are all associative and can be used with get. Order structures, name "
                          "arrays, tuples, strings, buffers, and symbols must use integer keys. Structs and tables can "


### PR DESCRIPTION
(side notes)
- It is very confusing that fact that the OP_GET actually implements in, and not get.
- Not a massive fan of the 'in' name to be honest, to me it sounds like something that should check for set membership and return a boolean (I suppose it sort of works like that for tuples and structs, but the default value makes much less sense for that interpretation too).

