### PR TITLE
Integers convert to plain number strings.

### DIFF
--- a/src/core/inttypes.c
+++ b/src/core/inttypes.c
@@ -49,13 +49,13 @@ static void int64_unmarshal(void *p, JanetMarshalContext *ctx) {
 
 static void it_s64_tostring(void *p, JanetBuffer *buffer) {
     char str[32];
-    sprintf(str, "<core/s64 %" PRId64 ">", *((int64_t *)p));
+    sprintf(str, "%" PRId64, *((int64_t *)p));
     janet_buffer_push_cstring(buffer, str);
 }
 
 static void it_u64_tostring(void *p, JanetBuffer *buffer) {
     char str[32];
-    sprintf(str, "<core/u64 %" PRIu64 ">", *((uint64_t *)p));
+    sprintf(str, "%" PRIu64, *((uint64_t *)p));
     janet_buffer_push_cstring(buffer, str);
 }
 

--- a/test/suite6.janet
+++ b/test/suite6.janet
@@ -65,6 +65,9 @@
 (assert (:== (:/ (u64 "0xffff_ffff_ffff_ffff") 8 2) "0xfffffffffffffff") "bigint operations")
 (assert (let [a (u64 0xff)] (:== (:+ a a a a) (:* a 2 2))) "bigint operations")
 
+(assert (= (string (i64 -123)) "-123") "i64 prints reasonably")
+(assert (= (string (u64 123)) "123") "u64 prints reasonably")
+
 (assert-error
  "trap INT64_MIN / -1"
  (:/ (int/s64 "-0x8000_0000_0000_0000") -1))


### PR DESCRIPTION
A user can use (type n) to find the true type, the old behavior did not
seem useful for most uses of the string function.