### PR TITLE
New capi janet_get_permissive

### DIFF
--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1285,6 +1285,7 @@ JANET_API int32_t janet_hash(Janet x);
 JANET_API int janet_compare(Janet x, Janet y);
 JANET_API int janet_cstrcmp(const uint8_t *str, const char *other);
 JANET_API Janet janet_get(Janet ds, Janet key);
+JANET_API Janet janet_get_permissive(Janet ds, Janet key);
 JANET_API Janet janet_getindex(Janet ds, int32_t index);
 JANET_API int32_t janet_length(Janet x);
 JANET_API Janet janet_lengthv(Janet x);


### PR DESCRIPTION
The janet_get_permissive function implements the core semantics
of the 'get' function. The original janet_get implements the semantics of
the 'in' function and also the OP_GET opcode. This slight oddity is
to avoid a backwards incompatible change.