### PR TITLE
Add oob protection to unmarshal (slightly breaking for code using marshal).

### DIFF
--- a/src/core/inttypes.c
+++ b/src/core/inttypes.c
@@ -67,7 +67,8 @@ static const JanetAbstractType it_s64_type = {
     NULL,
     int64_marshal,
     int64_unmarshal,
-    it_s64_tostring
+    it_s64_tostring,
+    sizeof(int64_t),
 };
 
 static const JanetAbstractType it_u64_type = {
@@ -78,7 +79,8 @@ static const JanetAbstractType it_u64_type = {
     NULL,
     int64_marshal,
     int64_unmarshal,
-    it_u64_tostring
+    it_u64_tostring,
+    sizeof(uint64_t),
 };
 
 int64_t janet_unwrap_s64(Janet x) {

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -63,7 +63,8 @@ JanetAbstractType cfun_io_filetype = {
     NULL,
     NULL,
     NULL,
-    NULL
+    NULL,
+    -1,
 };
 
 /* Check arguments to fopen */

--- a/src/core/math.c
+++ b/src/core/math.c
@@ -57,7 +57,8 @@ static JanetAbstractType JanetRNG_type = {
     NULL,
     janet_rng_marshal,
     janet_rng_unmarshal,
-    NULL
+    NULL,
+    sizeof(JanetRNG),
 };
 
 JanetRNG *janet_default_rng(void) {

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -740,7 +740,8 @@ static JanetAbstractType janet_parse_parsertype = {
     NULL,
     NULL,
     NULL,
-    NULL
+    NULL,
+    -1,
 };
 
 /* C Function parser */

--- a/src/core/peg.c
+++ b/src/core/peg.c
@@ -1191,7 +1191,8 @@ static const JanetAbstractType peg_type = {
     NULL,
     peg_marshal,
     peg_unmarshal,
-    NULL
+    NULL,
+    sizeof(Peg)
 };
 
 /* Convert Builder to Peg (Janet Abstract Value) */

--- a/src/core/typedarray.c
+++ b/src/core/typedarray.c
@@ -115,7 +115,8 @@ static const JanetAbstractType ta_buffer_type = {
     NULL,
     ta_buffer_marshal,
     ta_buffer_unmarshal,
-    NULL
+    NULL,
+    sizeof(JanetTArrayBuffer),
 };
 
 static int ta_mark(void *p, size_t s) {
@@ -277,7 +278,8 @@ static const JanetAbstractType ta_view_type = {
     ta_setter,
     ta_view_marshal,
     ta_view_unmarshal,
-    NULL
+    NULL,
+    sizeof(JanetTArrayView)
 };
 
 JanetTArrayBuffer *janet_tarray_buffer(size_t size) {

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -295,7 +295,8 @@ static const JanetAbstractType type_wrap = {
     NULL,
     NULL,
     NULL,
-    NULL
+    NULL,
+    -1,
 };
 
 typedef struct {

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -898,6 +898,7 @@ struct JanetAbstractType {
     void (*marshal)(void *p, JanetMarshalContext *ctx);
     void (*unmarshal)(void *p, JanetMarshalContext *ctx);
     void (*tostring)(void *p, JanetBuffer *buffer);
+    int min_size;
 };
 
 struct JanetReg {


### PR DESCRIPTION
Add OOB checking to unmarshal (slightly breaking).

The new field was added to the end to hopefully
avoid breaking most sensible libs. I think unmarshalling
is rarely used in the package ecosystem so far.