### PR TITLE
Compiling Janet to wasm using wasienv to run on wasmer

### DIFF
--- a/src/conf/janetconf.h
+++ b/src/conf/janetconf.h
@@ -35,7 +35,7 @@
 /* #define JANET_BUILD "local" */
 
 /* These settings all affect linking, so use cautiously. */
-/* #define JANET_SINGLE_THREADED  */
+/* #define JANET_SINGLE_THREADED */
 /* #define JANET_NO_DYNAMIC_MODULES */
 /* #define JANET_NO_NANBOX */
 /* #define JANET_API __attribute__((visibility ("default"))) */

--- a/src/conf/janetconf.h
+++ b/src/conf/janetconf.h
@@ -35,7 +35,7 @@
 /* #define JANET_BUILD "local" */
 
 /* These settings all affect linking, so use cautiously. */
-/* #define JANET_SINGLE_THREADED */
+/* #define JANET_SINGLE_THREADED  */
 /* #define JANET_NO_DYNAMIC_MODULES */
 /* #define JANET_NO_NANBOX */
 /* #define JANET_API __attribute__((visibility ("default"))) */
@@ -58,5 +58,8 @@
 /* #define JANET_STACK_MAX 16384 */
 /* #define JANET_OS_NAME my-custom-os */
 /* #define JANET_ARCH_NAME pdp-8 */
+/* #define JANET_NO_SETJMP */
+/* #define JANET_NO_PIPES */
+/* #define JANET_NO_TERMIOS */
 
 #endif /* end of include guard: JANETCONF_H */

--- a/src/core/capi.c
+++ b/src/core/capi.c
@@ -30,10 +30,12 @@
 void janet_panicv(Janet message) {
     if (janet_vm_return_reg != NULL) {
         *janet_vm_return_reg = message;
+#ifndef JANET_NO_SETJMP
 #if defined(JANET_BSD) || defined(JANET_APPLE)
         _longjmp(*janet_vm_jmp_buf, 1);
 #else
         longjmp(*janet_vm_jmp_buf, 1);
+#endif
 #endif
     } else {
         fputs((const char *)janet_formatc("janet top level panic - %v\n", message), stdout);

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -1156,6 +1156,9 @@ JanetSignal janet_continue(JanetFiber *fiber, Janet in, Janet *out) {
 
     /* Run loop */
     JanetSignal signal;
+#ifdef JANET_NO_SETJMP
+    signal = run_vm(fiber, in, old_status);
+#else
 #if defined(JANET_BSD) || defined(JANET_APPLE)
     if (_setjmp(buf)) {
 #else
@@ -1165,6 +1168,7 @@ JanetSignal janet_continue(JanetFiber *fiber, Janet in, Janet *out) {
     } else {
         signal = run_vm(fiber, in, old_status);
     }
+#endif
 
     /* Tear down fiber */
     janet_fiber_set_status(fiber, signal);

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -250,13 +250,21 @@ typedef struct {
 #include <stdint.h>
 #include <string.h>
 #include <stdarg.h>
+
+#ifndef JANET_NO_SETJMP
 #include <setjmp.h>
+#else 
+#define jmp_buf long
+#endif
+
 #include <stddef.h>
 #include <stdio.h>
 
 #ifdef JANET_BSD
+#ifndef JANET_NO_SETJMP
 int _setjmp(jmp_buf);
 JANET_NO_RETURN void _longjmp(jmp_buf, int);
+#endif
 #endif
 
 /* Names of all of the types */
@@ -1465,7 +1473,10 @@ JANET_API void janet_setdyn(const char *name, Janet value);
 #define JANET_FILE_CLOSED 32
 #define JANET_FILE_BINARY 64
 #define JANET_FILE_SERIALIZABLE 128
+
+#ifndef JANET_NO_PIPES
 #define JANET_FILE_PIPED 256
+#endif
 
 JANET_API Janet janet_makefile(FILE *f, int flags);
 JANET_API FILE *janet_getfile(const Janet *argv, int32_t n, int *flags);

--- a/src/mainclient/line.c
+++ b/src/mainclient/line.c
@@ -51,8 +51,7 @@ static void simpleline(JanetBuffer *buffer) {
     }
 }
 
-/* Windows */
-#ifdef JANET_WINDOWS
+#if defined(JANET_WINDOWS) || defined(JANET_NO_TERMIOS)
 
 void janet_line_init() {
     ;
@@ -69,7 +68,6 @@ void janet_line_get(const char *p, JanetBuffer *buffer) {
     simpleline(buffer);
 }
 
-/* Posix */
 #else
 
 /*


### PR DESCRIPTION
Greetings, I've successfully compiled janet to wasm using wasienv adding some preprocessor guards to remove unsupported features like setjmps, pipes and termios.

To compile just uncomment the defines `JANET_SINGLE_THREADED`, `JANET_NO_DYNAMIC_MODULES`, `JANET_REDUCED_OS`, and the newly created ones `JANET_NO_SETJMP`, `JANET_NO_PIPES`, `JANET_NO_TERMIOS`.

I can't really how much the integrity of janet is compromised without setjmps because it is used for error handling. Maybe there is a better way of dealing with setjmps on targets that do not support them. Threads are very experimental on wasm, and they were not compiling in janet because of three internal functions (pthread_getspecific, pthread_key_create, pthread_setspecific), hopefully it will be fixed in the future.

Wasmer could definitely improve janet user experience, providing portable binaries, increase the availability using wapm and https://webassembly.sh/

To compile with the above configs I just typed `wasimake make repl` on janet root folder.

Edit:
To run the janet.wasm I was using:
`wasmer run build/janet.wasm --dir=examples/ -- examples/primes.janet`