### PR TITLE
Use siphash for string hashing.

### DIFF
--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1303,6 +1303,7 @@ JANET_API JanetBuffer *janet_pretty(JanetBuffer *buffer, int depth, int flags, J
 
 /* Misc */
 JANET_API int janet_equals(Janet x, Janet y);
+JANET_API void janet_init_hash_key(uint8_t key[16]);
 JANET_API int32_t janet_hash(Janet x);
 JANET_API int janet_compare(Janet x, Janet y);
 JANET_API int janet_cstrcmp(JanetString str, const char *other);


### PR DESCRIPTION
The hash key still needs to randomly initialized
for the security advantage, but this patch is a
step closer to avoiding hash based DOS.

Further work may including exposing the raw hash
function for use by abstract types who also choose to
implement hash.