### PR TITLE
Improve REPL key bindings in janet.1 man page

### DIFF
--- a/janet.1
+++ b/janet.1
@@ -29,56 +29,68 @@ most new platforms.
 .SH REPL KEY-BINDINGS
 
 .TP 16
-.BR Home/Ctrl\-A
-Move cursor to the beginning of input line
+.BR Home
+Move cursor to the beginning of input line.
 
 .TP 16
 .BR End
-Move cursor to the end of input line
+Move cursor to the end of input line.
 
 .TP 16
 .BR Left/Right
-Move cursor in input line
+Move cursor in input line.
 
 .TP 16
 .BR Up/Down
 Go backwards and forwards through history.
 
 .TP 16
-.BR Ctrl\-,
-Go to earliest item in history
-
-.TP 16
-.BR Ctrl\-.
-Go to last item in history
-
-.TP 16
 .BR Tab
-Complete current symbol, or show available completion
+Complete current symbol, or show available completions.
+
+.TP 16
+.BR Delete
+Delete one character on cursor.
+
+.TP 16
+.BR Backspace
+Delete one character before the cursor.
+
+.TP 16
+.BR Ctrl\-A
+Move cursor to the beginning of input line.
+
+.TP 16
+.BR Ctrl\-E
+Move cursor to the end of input line.
 
 .TP 16
 .BR Ctrl\-H
-Delete one character behind the cursor.
+Delete one character before the cursor.
 
 .TP 16
 .BR Ctrl\-L
 Clear the screen.
 
 .TP 16
+.BR Ctrl\-N/Ctrl\-P
+Go forwards and backwards through history.
+
+.TP 16
+.BR Ctrl\-U
+Clear the input line.
+
+.TP 16
 .BR Ctrl\-W
-Delete a word behind the cursor
+Delete one word before the cursor.
 
 .TP 16
-.BR Alt\-A
-Move cursor forward one word.
+.BR Alt\-B/Alt\-F
+Move cursor backwards and forwards one word.
 
 .TP 16
-.BR Alt\-B
-Move cursor backwards one word.
-
-.TP 16
-.BR Delete
-Delete character on cursor.
+.BR Alt\-D
+Delete one word after the cursor.
 
 .TP 16
 .BR Alt\-H
@@ -89,8 +101,12 @@ Move cursor one character to the left.
 Move cursor one character to the right.
 
 .TP 16
-.BR Alt\-D
-Delete word at cursor.
+.BR Alt\-,
+Go to earliest item in history.
+
+.TP 16
+.BR Alt\-.
+Go to last item in history.
 
 .LP
 


### PR DESCRIPTION
A few things worth mentioning

* `Alt-H` and `Alt-L` don't seem necessary because
  * `Ctrl-F` and `Ctrl-B` do the same things.
  * GNU readline doesn't bind `Alt-H` and `Alt-L` by default.
* `Home` and `End` don't work yet.