### PR TITLE
Make REPL key bindings more similar to those on GNU readline.

### DIFF
--- a/janet.1
+++ b/janet.1
@@ -29,68 +29,88 @@ most new platforms.
 .SH REPL KEY-BINDINGS
 
 .TP 16
-.BR Home/Ctrl\-A
-Move cursor to the beginning of input line
+.BR Home
+Move cursor to the beginning of input line.
 
 .TP 16
 .BR End
-Move cursor to the end of input line
+Move cursor to the end of input line.
 
 .TP 16
 .BR Left/Right
-Move cursor in input line
+Move cursor in input line.
 
 .TP 16
 .BR Up/Down
 Go backwards and forwards through history.
 
 .TP 16
-.BR Ctrl\-,
-Go to earliest item in history
-
-.TP 16
-.BR Ctrl\-.
-Go to last item in history
-
-.TP 16
 .BR Tab
-Complete current symbol, or show available completion
+Complete current symbol, or show available completions.
+
+.TP 16
+.BR Delete
+Delete one character after the cursor.
+
+.TP 16
+.BR Backspace
+Delete one character before the cursor.
+
+.TP 16
+.BR Ctrl\-A
+Move cursor to the beginning of input line.
+
+.TP 16
+.BR Ctrl\-B
+Move cursor one character to the left.
+
+.TP 16
+.BR Ctrl\-E
+Move cursor to the end of input line.
+
+.TP 16
+.BR Ctrl\-F
+Move cursor one character to the right.
 
 .TP 16
 .BR Ctrl\-H
-Delete one character behind the cursor.
+Delete one character before the cursor.
+
+.TP 16
+.BR Ctrl\-K
+Delete everything after the cursor on the input line.
 
 .TP 16
 .BR Ctrl\-L
 Clear the screen.
 
 .TP 16
+.BR Ctrl\-N/Ctrl\-P
+Go forwards and backwards through history.
+
+.TP 16
+.BR Ctrl\-U
+Delete everything before the cursor on the input line.
+
+.TP 16
 .BR Ctrl\-W
-Delete a word behind the cursor
+Delete one word before the cursor.
 
 .TP 16
-.BR Alt\-A
-Move cursor forward one word.
-
-.TP 16
-.BR Alt\-B
-Move cursor backwards one word.
-
-.TP 16
-.BR Delete
-Delete character on cursor.
-
-.TP 16
-.BR Alt\-H
-Move cursor one character to the left.
-
-.TP 16
-.BR Alt\-L
-Move cursor one character to the right.
+.BR Alt\-B/Alt\-F
+Move cursor backwards and forwards one word.
 
 .TP 16
 .BR Alt\-D
-Delete word at cursor.
+Delete one word after the cursor.
+
+.TP 16
+.BR Alt\-,
+Go to earliest item in history.
+
+.TP 16
+.BR Alt\-.
+Go to last item in history.
 
 .LP
 


### PR DESCRIPTION
* I deleted Alt-H and Alt-L because Ctrl-F and Ctrl-B serve the same roles.
* Ctrl-W, Alt-D, Alt-F, and Alt-B behave more similarly to the same key bindings on GNU readline.
* Improved documentation of REPL keybindings on man page.
* Home and End keys now work on more terminal environments.
* Removed bindings for `Esc OH` and `Esc OF` because andrewchambers doesn't need those bindings and the bindings don't seem to make much sense for Home and End. `Esc O` is Single Shift Select of G3 Character Set in xterm. https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
