### PR TITLE
Unexpected behaviour of examples for tcpclient and server

### DIFF
--- a/examples/tcpclient.janet
+++ b/examples/tcpclient.janet
@@ -1,6 +1,6 @@
 (with [conn (net/connect "127.0.0.1" "8000")]
   (printf "Connected to %q!" conn)
-  (:write conn "Echo...")
+  (:write conn "hoho")
   (print "Wrote to connection...")
   (def res (:read conn 1024))
   (pp res))

--- a/examples/tcpserver.janet
+++ b/examples/tcpserver.janet
@@ -6,6 +6,7 @@
     (def b @"")
     (print "Connection " id "!")
     (while (:read stream 1024 b)
+      (pp b)
       (:write stream b)
       (buffer/clear b))
     (printf "Done %v!" id)))


### PR DESCRIPTION
This PR is a reproduction of an issue with the development version of the net branch.

First of all the message "hoho" is not received well on the tcp server for me example five runs of the tcpclient.janet prints: 

```
Connection _000002!
@"hohohohohohohohohohohohohohohohohohohohohohohohohohohohohohohohohoho"
Connection _000003!
@"hohohohohohohohohohohohohohohohohohohohohohohohohohohohohohohohohoho"
Connection _000004!
@"hohohohohohohohohohohohohohohohohohohohohohohohohohohoho"
Connection _000005!
@"hohohohohohohohohohohohohohohohohohohohohohohohohohohoho"
Connection _000006!
@"hohohohohohohohohohohohohohohohohohohohohohohohohohohohohohohohohoho"
```
on the server-side with the `pp` I have added. 

The second issue is that the client never prints the answer.