### PR TITLE
Make alt-backspace behave like ctrl-w.

### DIFF
--- a/src/mainclient/shell.c
+++ b/src/mainclient/shell.c
@@ -765,6 +765,9 @@ static int line() {
                         case '.': /* Alt-. */
                             historymove(-JANET_HISTORY_MAX);
                             break;
+                        case 127: /* Alt-backspace */
+                            kbackspacew();
+                            break;
                     }
                 }
                 break;


### PR DESCRIPTION
Another common binding in readline and its clones.