### PR TITLE
Fix last for empty collection, add tests

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -648,7 +648,7 @@
 (defn last
   "Get the last element from an indexed data structure."
   [xs]
-  (in xs (- (length xs) 1)))
+  (get xs (- (length xs) 1)))
 
 ###
 ###

--- a/test/suite8.janet
+++ b/test/suite8.janet
@@ -237,4 +237,8 @@ neldb\0\0\0\xD8\x05printG\x01\0\xDE\xDE\xDE'\x03\0marshal_tes/\x02
   load-image-dict))
 (gccollect)
 
+# in vs get regression
+(assert (nil? (first @"")) "in vs get 1")
+(assert (nil? (last @"")) "in vs get 1")
+
 (end-suite)


### PR DESCRIPTION
There was the same problem in the `last` implementation, you already fixed in `first`. It adds tests for both cases