### PR TITLE
Do not recurse into symlinks when cleaning.

### DIFF
--- a/auxbin/jpm
+++ b/auxbin/jpm
@@ -267,7 +267,7 @@
   "Remove a directory and all sub directories."
   [path]
   (try
-    (if (= (os/stat path :mode) :directory)
+    (if (= (os/lstat path :mode) :directory)
       (do
         (each subpath (os/dir path)
           (rm (string path sep subpath)))


### PR DESCRIPTION
I think this is closer to the intended behavior, otherwise we may be deleting things outside the build dir by accident.