### PR TITLE
Unbreak Meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -221,7 +221,7 @@ test_files = [
   'test/suite5.janet',
   'test/suite6.janet',
   'test/suite7.janet',
-  'test/suite8.janet'
+  'test/suite8.janet',
   'test/suite9.janet'
 ]
 foreach t : test_files


### PR DESCRIPTION
```
The Meson build system
Version: 0.54.0
Source dir: /wrkdirs/usr/ports/lang/janet/work/janet-1.9.0
Build dir: /wrkdirs/usr/ports/lang/janet/work/janet-1.9.0/_build
Build type: native build

meson.build:225:2: ERROR: Expecting rbracket got string.
  'test/suite9.janet'
  ^
For a block that started at 215,13
test_files = [
             ^
```