### PR TITLE
Fix with-vars doesnt allow fresh variables.

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1084,16 +1084,11 @@
   [vars & body]
   (def len (length vars))
   (unless (even? len) (error "expected even number of argument to vars"))
-  (def temp (seq [i :range [0 len 2]] (gensym)))
-  (def saveold (seq [i :range [0 len 2]] ['def (temp (/ i 2)) (vars i)]))
-  (def setnew (seq [i :range [0 len 2]] ['set (vars i) (vars (+ i 1))]))
-  (def restoreold (seq [i :range [0 len 2]] ['set (vars i) (temp (/ i 2))]))
+  (def new-vars (seq [i :range [0 len 2]] ['var (vars i) (vars (+ i 1))]))
   (with-syms [ret f s]
     ~(do
-       ,;saveold
-       (def ,f (,fiber/new (fn [] ,;setnew ,;body) :ti))
+       (def ,f (,fiber/new (fn [] ,;new-vars ,;body) :ti))
        (def ,ret (,resume ,f))
-       ,;restoreold
        (if (= (,fiber/status ,f) :dead) ,ret (,propagate ,ret ,f)))))
 
 (defn partial

--- a/test/suite7.janet
+++ b/test/suite7.janet
@@ -185,10 +185,13 @@
 (assert (= (string '()) (string [])) "empty bracket tuple literal")
 
 # with-vars
+(assert (= [356 221] (with-vars [abc 456 cba 321] [(- abc 100) (- cba 100)]))
+  "with-vars fresh variable")
 (var abc 123)
-(assert (= 356 (with-vars [abc 456] (- abc 100))) "with-vars 1")
-(assert-error "with-vars 2" (with-vars [abc 456] (error :oops)))
-(assert (= abc 123) "with-vars 3")
+(assert (= 356 (with-vars [abc 456] (- abc 100)))
+  "with-vars variable shadowing")
+(assert-error "with-vars error propagation" (with-vars [abc 456] (error :oops)))
+(assert (= abc 123) "with-vars check initial variable")
 
 # Trim empty string
 (assert (= "" (string/trim " ")) "string/trim regression")

--- a/test/suite7.janet
+++ b/test/suite7.janet
@@ -190,8 +190,10 @@
 (var abc 123)
 (assert (= 356 (with-vars [abc 456] (- abc 100)))
   "with-vars variable shadowing")
+(assert (= 356 (with-vars [abc 456] (set abc (- abc 100)) abc))
+  "with-vars setting inner varible")
 (assert-error "with-vars error propagation" (with-vars [abc 456] (error :oops)))
-(assert (= abc 123) "with-vars check initial variable")
+(assert (= abc 123) "with-vars check outer scope variable")
 
 # Trim empty string
 (assert (= "" (string/trim " ")) "string/trim regression")


### PR DESCRIPTION
I found this behavior of ```with-vars``` wrong:
``` lisp
janet:2:> (with-vars [abc 456] (- abc 100))
compile error: unknown symbol abc on line 2, column 1 while compiling repl
```
It only works with names that already declared as variables, but I expect this macro to declare fresh variables too as mentioned in the docs this will work in same logic as ```let``` macro.

I simplify ```with-vars``` macro so it works as I expect it to and added more tests on ```with-vars``` with both fresh variables and variables shadowing.