### PR TITLE
Add snapcraft packaging

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: janet
+adopt-info: janet
+summary: functional and imperative programming language and bytecode interpreter
+description: |
+    **Janet** is a functional and imperative programming language and bytecode interpreter. It is a
+    modern lisp, but lists are replaced
+    by other data structures (arrays, tables (hash table), struct (immutable hash table), tuples).
+    The language also supports bridging to native code written in C, meta-programming with macros, and bytecode assembly.
+base: core18
+confinement: classic
+grade: stable
+apps:
+    janet:
+        command: usr/bin/janet
+        adapter: none
+    jpm:
+        command: usr/bin/jpm
+        adapter: none
+parts:
+    janet:
+        plugin: make
+        source: .
+        make-parameters: [PREFIX=/usr]
+        build-packages: [build-essential]
+        override-build: |
+            snapcraftctl build
+            snapcraftctl set-version "$($SNAPCRAFT_PART_INSTALL/usr/bin/janet -e '(print "Version: " janet/version)' | awk '{ print $2 }')"


### PR DESCRIPTION
Snapcraft allows the latest version of Janet to be immediately available
to developers on most popular Linux distributions. This patch provides
the snapcraft.yaml file, which provides information about the package,
how to build it and how to install it.

Both janet and jpm are exposed, though the latter requires a store side
alias to be provided, as snap names also control application names, to
avoid clashes between applications.

For this prototype I've selected classic confinement. Application
language packages are usually provided with classic confinement, as that
is most flexible for developers.

Snaps do not support providing manual pages yet, so no entries for those
were created.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>