### PR TITLE
update janetconf.h path in README embedding section

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ If installed, you can also run `man janet` and `man jpm` to get usage informatio
 Janet can be embedded in a host program very easily. The normal build
 will create a file `build/janet.c`, which is a single C file
 that contains all the source to Janet. This file, along with
-`src/include/janet.h` and `src/include/janetconf.h` can dragged into any C
+`src/include/janet.h` and `src/conf/janetconf.h` can be dragged into any C
 project and compiled into the project. Janet should be compiled with `-std=c99`
 on most compilers, and will need to be linked to the math library, `-lm`, and
 the dynamic linker, `-ldl`, if one wants to be able to load dynamic modules. If


### PR DESCRIPTION
`janetconf.h` doesn't exist in `src/include` anymore, it looks like it's in `conf`. 