### PR TITLE
Add a Dockerfile file and document its usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:10.4-slim as build
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update --yes \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+        gcc \
+        libc6-dev \
+        git \
+        make \
+    && rm -fr /var/lib/apt/lists/*
+
+RUN ["useradd", "-m", "janet"]
+RUN mkdir /home/janet/janet-src \
+    && chown janet:janet /home/janet/janet-src
+USER janet
+WORKDIR /home/janet/janet-src
+
+COPY --chown=janet:janet . .
+
+RUN ["make"]
+RUN ["make", "test"]
+
+
+FROM debian:10.4-slim
+
+RUN ["useradd", "-m", "janet"]
+USER janet
+WORKDIR /home/janet
+
+COPY --from=build /home/janet/janet-src/build/janet /usr/local/bin/
+
+ENTRYPOINT /usr/local/bin/janet
+

--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ make test
 make repl
 ```
 
+### Docker
+
+If you'd rather build and run Janet within an isolated container, you can use
+the provided Dockerfile to build it yourself and jump straight into a REPL:
+
+```sh
+docker build -t janet .
+docker run -it --rm janet
+```
+
 ### 32-bit Haiku
 
 32-bit Haiku build instructions are the same as the unix-like build instructions,


### PR DESCRIPTION
Add a Dockerfile to allow building and running Janet within an isolated environment. This could be expanded in the future by supporting different OSes, C compilers, and architectures in the container, or by uploading a pre-built image to a DockerHub account controlled by Janet's maintainers.

A terminal capture of it being used from a fresh clone of Janet on Debian GNU/Linux:
```
user@debian:~/Desktop$ git clone https://github.com/LouisJackman/janet
Cloning into 'janet'...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 15224 (delta 0), reused 2 (delta 0), pack-reused 15220
Receiving objects: 100% (15224/15224), 9.43 MiB | 3.00 MiB/s, done.
Resolving deltas: 100% (10822/10822), done.
user@debian:~/Desktop$ cd janet/
user@debian:~/Desktop/janet$ git checkout add-dockerfile
Branch 'add-dockerfile' set up to track remote branch 'add-dockerfile' from 'origin'.
Switched to a new branch 'add-dockerfile'
user@debian:~/Desktop/janet$ docker build -t janet .
Sending build context to Docker daemon  12.57MB
Step 1/15 : FROM debian:10.4-slim as build
 ---> 02dcc8aeaee7
Step 2/15 : RUN DEBIAN_FRONTEND=noninteractive apt-get update --yes     && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends         gcc         libc6-dev         git         make     && rm -fr /var/lib/apt/lists/*
 ---> Using cache
 ---> a89f61add65b
Step 3/15 : RUN ["useradd", "-m", "janet"]
 ---> Using cache
 ---> e64aea5a3fe2
Step 4/15 : RUN mkdir /home/janet/janet-src     && chown janet:janet /home/janet/janet-src
 ---> Using cache
 ---> c19afdd1a8a8
Step 5/15 : USER janet
 ---> Using cache
 ---> e76b04157b41
Step 6/15 : WORKDIR /home/janet/janet-src
 ---> Using cache
 ---> a8b43633800d
Step 7/15 : COPY --chown=janet:janet . .
 ---> c5b98317b541
Step 8/15 : RUN ["make"]
 ---> Running in 03cbff4a78c7
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/abstract.boot.o -c src/core/abstract.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/array.boot.o -c src/core/array.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/asm.boot.o -c src/core/asm.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/buffer.boot.o -c src/core/buffer.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/bytecode.boot.o -c src/core/bytecode.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/capi.boot.o -c src/core/capi.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/cfuns.boot.o -c src/core/cfuns.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/compile.boot.o -c src/core/compile.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/corelib.boot.o -c src/core/corelib.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/debug.boot.o -c src/core/debug.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/emit.boot.o -c src/core/emit.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/fiber.boot.o -c src/core/fiber.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/gc.boot.o -c src/core/gc.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/inttypes.boot.o -c src/core/inttypes.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/io.boot.o -c src/core/io.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/marsh.boot.o -c src/core/marsh.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/math.boot.o -c src/core/math.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/net.boot.o -c src/core/net.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/os.boot.o -c src/core/os.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/parse.boot.o -c src/core/parse.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/peg.boot.o -c src/core/peg.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/pp.boot.o -c src/core/pp.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/regalloc.boot.o -c src/core/regalloc.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/run.boot.o -c src/core/run.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/specials.boot.o -c src/core/specials.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/string.boot.o -c src/core/string.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/strtod.boot.o -c src/core/strtod.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/struct.boot.o -c src/core/struct.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/symcache.boot.o -c src/core/symcache.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/table.boot.o -c src/core/table.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/thread.boot.o -c src/core/thread.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/tuple.boot.o -c src/core/tuple.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/typedarray.boot.o -c src/core/typedarray.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/util.boot.o -c src/core/util.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/value.boot.o -c src/core/value.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/vector.boot.o -c src/core/vector.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/vm.boot.o -c src/core/vm.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/core/wrap.boot.o -c src/core/wrap.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/boot/array_test.boot.o -c src/boot/array_test.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/boot/boot.boot.o -c src/boot/boot.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/boot/buffer_test.boot.o -c src/boot/buffer_test.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/boot/number_test.boot.o -c src/boot/number_test.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/boot/system_test.boot.o -c src/boot/system_test.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/boot/table_test.boot.o -c src/boot/table_test.c
cc -DJANET_BOOTSTRAP -DJANET_BUILD="\"98c04ca\""  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/janet_boot build/core/abstract.boot.o build/core/array.boot.o build/core/asm.boot.o build/core/buffer.boot.o build/core/bytecode.boot.o build/core/capi.boot.o build/core/cfuns.boot.o build/core/compile.boot.o build/core/corelib.boot.o build/core/debug.boot.o build/core/emit.boot.o build/core/fiber.boot.o build/core/gc.boot.o build/core/inttypes.boot.o build/core/io.boot.o build/core/marsh.boot.o build/core/math.boot.o build/core/net.boot.o build/core/os.boot.o build/core/parse.boot.o build/core/peg.boot.o build/core/pp.boot.o build/core/regalloc.boot.o build/core/run.boot.o build/core/specials.boot.o build/core/string.boot.o build/core/strtod.boot.o build/core/struct.boot.o build/core/symcache.boot.o build/core/table.boot.o build/core/thread.boot.o build/core/tuple.boot.o build/core/typedarray.boot.o build/core/util.boot.o build/core/value.boot.o build/core/vector.boot.o build/core/vm.boot.o build/core/wrap.boot.o build/boot/array_test.boot.o build/boot/boot.boot.o build/boot/buffer_test.boot.o build/boot/number_test.boot.o build/boot/system_test.boot.o build/boot/table_test.boot.o -lm -lpthread -lrt -ldl
build/janet_boot . JANET_PATH '/usr/local/lib/janet' JANET_HEADERPATH '/usr/local/include/janet' > build/janet.c
cp src/include/janet.h build/janet.h
cp src/conf/janetconf.h build/janetconf.h
cc  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -c build/janet.c -o build/janet.o -I build
cp src/mainclient/shell.c build/shell.c
cc  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -c build/shell.c -o build/shell.o -I build
cc  -rdynamic  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -o build/janet build/janet.o build/shell.o -lm -lpthread -lrt -ldl
cc  -rdynamic  -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fPIC -O2 -fvisibility=hidden -Wl,-soname,libjanet.so.1.9 -shared -o build/libjanet.so build/janet.o build/shell.o -lm -lpthread -lrt -ldl
ar rcs build/libjanet.a build/janet.o build/shell.o
Removing intermediate container 03cbff4a78c7
 ---> 7a16bbb93e44
Step 9/15 : RUN ["make", "test"]
 ---> Running in e6f76d925501
for f in test/suite*.janet; do ./build/janet "$f" || exit; done

Running test suite 0 tests...

✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔

Test suite 0 finished in 0.002 seconds
130 of 130 tests passed.


Running test suite 1 tests...

✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔

Test suite 1 finished in 0.006 seconds
106 of 106 tests passed.


Running test suite 2 tests...

✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔

Test suite 2 finished in 0.001 seconds
132 of 132 tests passed.


Running test suite 3 tests...

✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔

Test suite 3 finished in 0.007 seconds
157 of 157 tests passed.


Running test suite 4 tests...

✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔

Test suite 4 finished in 0.000 seconds
22 of 22 tests passed.


Running test suite 5 tests...

✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔

Test suite 5 finished in 0.002 seconds
47 of 47 tests passed.


Running test suite 6 tests...

✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔

Test suite 6 finished in 0.003 seconds
52 of 52 tests passed.


Running test suite 7 tests...

✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔

Test suite 7 finished in 0.039 seconds
209 of 209 tests passed.


Running test suite 8 tests...

✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔

Test suite 8 finished in 0.007 seconds
71 of 71 tests passed.


Running test suite 9 tests...

✔✔✔✔

Test suite 9 finished in 0.002 seconds
4 of 4 tests passed.

for f in examples/*.janet; do ./build/janet -k "$f"; done
./build/janet -k jpm
Removing intermediate container e6f76d925501
 ---> f0300cc2ab8b
Step 10/15 : FROM debian:10.4-slim
 ---> 02dcc8aeaee7
Step 11/15 : RUN ["useradd", "-m", "janet"]
 ---> Using cache
 ---> 26a41ed136ef
Step 12/15 : USER janet
 ---> Using cache
 ---> e295481be050
Step 13/15 : WORKDIR /home/janet
 ---> Using cache
 ---> 4da30bb0f58b
Step 14/15 : COPY --from=build /home/janet/janet-src/build/janet /usr/local/bin/
 ---> b3c5ce62b3fe
Step 15/15 : ENTRYPOINT /usr/local/bin/janet
 ---> Running in 8de3d74212f8
Removing intermediate container 8de3d74212f8
 ---> e2c16d9a1a93
Successfully built e2c16d9a1a93
Successfully tagged janet:latest
user@debian:~/Desktop/janet$ docker run -it --rm janet
Janet 1.9.1-98c04ca  Copyright (C) 2017-2020 Calvin Rose
janet:1:> janet/version
"1.9.1"
janet:2:> (os/arch)
:x64
janet:3:>
```