### PR TITLE
Add make help target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,5 +306,25 @@ test-install:
 	cd test/install && jpm --verbose --test --modpath=./modpath install https://github.com/janet-lang/path.git
 	cd test/install && jpm --verbose --test --modpath=./modpath install https://github.com/janet-lang/argparse.git
 
+help:
+	@echo
+	@echo 'Janet: A Dynamic Language & Bytecode VM'
+	@echo
+	@echo Usage:
+	@echo '   make            Build Janet'
+	@echo '   make repl       Start a REPL from a built Janet'
+	@echo
+	@echo '   make test       Test a built Janet'
+	@echo '   make valgrind   Assess Janet with Valgrind'
+	@echo '   make callgrind  Assess Janet with Valgrind, using Callgrind'
+	@echo '   make dist       Create a distribution tarball'
+	@echo '   make docs       Generate documentation'
+	@echo '   make install    Install into the current filesystem'
+	@echo '   make uninstall  Uninstall from the current filesystem'
+	@echo '   make clean      Clean intermediate build artifacts'
+	@echo "   make format     Format Janet's own source files"
+	@echo '   make grammar    Generate a TextMate language grammar'
+	@echo
+
 .PHONY: clean install repl debug valgrind test \
-	valtest emscripten dist uninstall docs grammar format
+	valtest emscripten dist uninstall docs grammar format help

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ make test
 make repl
 ```
 
+Find out more about the available make targets by running `make help`.
+
 ### 32-bit Haiku
 
 32-bit Haiku build instructions are the same as the unix-like build instructions,


### PR DESCRIPTION
Add and document a make target for providing help on the available targets.

This might not be so useful for experienced make users, but could be useful for new contributors who aren't so comfortable with make. I first saw this idea in [Pelican](https://github.com/getpelican/pelican), and have since borrowed it for other projects: https://github.com/getpelican/pelican/blob/bf85991ee648665f2abc224b9d3719c27470e696/pelican/tools/templates/Makefile.jinja2#L61
