### PR TITLE
Add a dbg macro for easy var dumping

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -945,7 +945,7 @@
     (array/push parts (tuple apply f $args)))
   (tuple 'fn (tuple '& $args) (tuple/slice parts 0)))
 
-(defmacro trace-pp
+(defmacro tracev
   "Displays the variables or literals listed, providing both the name and
   and the value for variables. Designed for quick debugging of values. Returns
   the traced forms: nil for none, the form itself for one, and a tuple of the
@@ -955,13 +955,12 @@
     ~(do
       (def ,results @[])
       ,;(map (fn [form]
-               (def preface (if (symbol? form)
-                              (string form " is")
-                              "Expression is"))
                ~(do
                  (def ,var ,form)
-                 (eprintf (string "%s " (dyn :pretty-format "%q"))
-                          ,preface
+                 (eprintf (string (dyn :pretty-format "%q")
+                                  " is "
+                                  (dyn :pretty-format "%q"))
+                          ',form
                           ,var)
                  (eflush)
                  (array/push ,results ,var)))

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -945,6 +945,22 @@
     (array/push parts (tuple apply f $args)))
   (tuple 'fn (tuple '& $args) (tuple/slice parts 0)))
 
+(defmacro dbg
+  "Displays the variables or literals listed, providing both the name and
+  and the value for variables. Designed for quick debugging of values and
+  nothing else."
+  [& forms]
+  ~(do
+    ,;(map (fn [arg]
+            (def preface (if (symbol? arg)
+                           (string "`" arg "` has value ")
+                           "Literal has value "))
+            ~(do
+              (prin ,preface)
+              (pp ,arg)
+              nil))
+          forms)))
+
 (defmacro ->
   "Threading macro. Inserts x as the second value in the first form
   in forms, and inserts the modified first form into the second form

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -957,7 +957,7 @@
       ,;(map (fn [form]
                (def preface (if (symbol? form)
                               (string form " is")
-                              "is"))
+                              "Literal is"))
                ~(do
                  (def ,var ,form)
                  (eprintf (string "%s " (dyn :pretty-format "%q"))

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -950,16 +950,23 @@
   and the value for variables. Designed for quick debugging of values and
   nothing else."
   [& forms]
-  ~(do
-    ,;(map (fn [arg]
-            (def preface (if (symbol? arg)
-                           (string "`" arg "` has value ")
-                           "Literal has value "))
-            ~(do
-              (prin ,preface)
-              (pp ,arg)
-              nil))
-          forms)))
+  (with-syms [results var]
+    ~(do
+      (def ,results @[])
+      ,;(map (fn [form]
+              (def preface (if (symbol? form)
+                             (string "`" form "` has value ")
+                             "Literal has value "))
+              ~(do
+                (prin ,preface)
+                (def ,var ,form)
+                (pp ,var)
+                (array/push ,results ,var)))
+            forms)
+      (case (length ,results)
+        0 nil
+        1 (,results 0)
+        ,results))))
 
 (defmacro ->
   "Threading macro. Inserts x as the second value in the first form

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -957,7 +957,8 @@
       ,;(map (fn [form]
                ~(do
                  (def ,var ,form)
-                 (eprintf (string (dyn :pretty-format "%q")
+                 (eprintf (string "trace "
+                                  (dyn :pretty-format "%q")
                                   " is "
                                   (dyn :pretty-format "%q"))
                           ',form

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -966,7 +966,7 @@
       (case (length ,results)
         0 nil
         1 (,results 0)
-        ,results))))
+        (tuple ;,results)))))
 
 (defmacro ->
   "Threading macro. Inserts x as the second value in the first form

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -957,7 +957,7 @@
       ,;(map (fn [form]
                (def preface (if (symbol? form)
                               (string form " is")
-                              "Literal is"))
+                              "Expression is"))
                ~(do
                  (def ,var ,form)
                  (eprintf (string "%s " (dyn :pretty-format "%q"))

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -945,24 +945,27 @@
     (array/push parts (tuple apply f $args)))
   (tuple 'fn (tuple '& $args) (tuple/slice parts 0)))
 
-(defmacro dbg
+(defmacro trace-pp
   "Displays the variables or literals listed, providing both the name and
-  and the value for variables. Designed for quick debugging of values and
-  nothing else."
+  and the value for variables. Designed for quick debugging of values. Returns
+  the traced forms: nil for none, the form itself for one, and a tuple of the
+  forms for many."
   [& forms]
   (with-syms [results var]
     ~(do
       (def ,results @[])
       ,;(map (fn [form]
-              (def preface (if (symbol? form)
-                             (string "`" form "` has value ")
-                             "Literal has value "))
-              ~(do
-                (prin ,preface)
-                (def ,var ,form)
-                (pp ,var)
-                (array/push ,results ,var)))
-            forms)
+               (def preface (if (symbol? form)
+                              (string form " is")
+                              "is"))
+               ~(do
+                 (def ,var ,form)
+                 (eprintf (string "%s " (dyn :pretty-format "%q"))
+                          ,preface
+                          ,var)
+                 (eflush)
+                 (array/push ,results ,var)))
+             forms)
       (case (length ,results)
         0 nil
         1 (,results 0)


### PR DESCRIPTION
I've been playing with this language and, as you'd expect, making mistakes. This `dbg` macro has helped to debug them. It dumps values like `pp`, but allows multiple values at once and also displays the variable name.

Sometimes dumping a variable solves a bug more quickly than opening up a full-blown debugger.

```
$ make repl
Janet 1.9.1-d6cd69e  Copyright (C) 2017-2020 Calvin Rose
janet:1:> (def x 42)
42
janet:2:> (def y @[1 :abc 'foo-bar])
(1 :abc foo-bar)
janet:3:> (dbg x "Hello, world!" y)
`x` has value 42
Literal has value "Hello, world!"
`y` has value @[1 :abc foo-bar]
(42 "Hello, world!" @[1 :abc foo-bar])
janet:4:> 
```

If the name is too similar to the existing `debug` function, it could also be named `dump` or `dump-values`.

It is inspired by Rust: https://github.com/rust-lang/rfcs/blob/master/text/2361-dbg-macro.md