### PR TITLE
Make Ctrl-C Cancel the Current Form; Only Exit if Column 0 Outside of Form

### DIFF
--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -33,6 +33,12 @@
 extern const unsigned char *janet_gen_boot;
 extern int32_t janet_gen_boot_size;
 
+static Janet janet_set_repl_within_form(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 1);
+    (void) argv;
+    return janet_wrap_nil();
+}
+
 int main(int argc, const char **argv) {
 
     /* Init janet */
@@ -52,6 +58,8 @@ int main(int argc, const char **argv) {
     JanetTable *env;
 
     env = janet_core_env(NULL);
+
+    janet_def(env, "set-repl-within-form", janet_wrap_cfunction(janet_set_repl_within_form), "");
 
     /* Create args tuple */
     JanetArray *args = janet_array(argc);

--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -33,12 +33,6 @@
 extern const unsigned char *janet_gen_boot;
 extern int32_t janet_gen_boot_size;
 
-static Janet janet_set_repl_within_form(int32_t argc, Janet *argv) {
-    janet_fixarity(argc, 1);
-    (void) argv;
-    return janet_wrap_nil();
-}
-
 int main(int argc, const char **argv) {
 
     /* Init janet */
@@ -58,8 +52,6 @@ int main(int argc, const char **argv) {
     JanetTable *env;
 
     env = janet_core_env(NULL);
-
-    janet_def(env, "set-repl-within-form", janet_wrap_cfunction(janet_set_repl_within_form), "");
 
     /* Create args tuple */
     JanetArray *args = janet_array(argc);

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2020,8 +2020,7 @@
     (if (nil? (chunks buf p))
       (do
         # Nil chunks represents a cancelled form in the REPL, so reset.
-        (set-repl-within-form false)
-        (set p (parser/new))
+        (parser/flush p)
         (buffer/clear buf))
       (do
         (var pindex 0)
@@ -2030,11 +2029,7 @@
         (when (= len 0)
           (parser/eof p)
           (set going false))
-        (if (= len 1)
-          (set-repl-within-form false)
-          (set-repl-within-form true))
         (while (> len pindex)
-          (set-repl-within-form true)
           (+= pindex (parser/consume p buf pindex))
           (while (parser/has-more p)
             (eval1 (parser/produce p)))

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2017,7 +2017,8 @@
   (while going
     (if (env :exit) (break))
     (buffer/clear buf)
-    (if (nil? (chunks buf p))
+    (if (= (chunks buf p)
+           :cancel)
       (do
         # Nil chunks represents a cancelled form in the REPL, so reset.
         (parser/flush p)

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1978,7 +1978,7 @@
   (var going true)
 
   # The parser object
-  (var p (parser/new))
+  (def p (parser/new))
 
   # Evaluate 1 source form in a protected manner
   (defn eval1 [source]
@@ -2020,7 +2020,7 @@
     (if (= (chunks buf p)
            :cancel)
       (do
-        # Nil chunks represents a cancelled form in the REPL, so reset.
+        # A :cancel chunk represents a cancelled form in the REPL, so reset.
         (parser/flush p)
         (buffer/clear buf))
       (do

--- a/src/mainclient/shell.c
+++ b/src/mainclient/shell.c
@@ -63,8 +63,7 @@ Janet janet_line_getter(int32_t argc, Janet *argv) {
         gbl_cancel_current_repl_form = false;
 
         // Signal that the user bailed out of the current form
-        static const char *const msg = "cancel";
-        result = janet_ckeywordv(msg);
+        result = janet_ckeywordv("cancel");
     } else {
         result = janet_wrap_buffer(buf);
     }
@@ -960,16 +959,12 @@ void janet_line_get(const char *p, JanetBuffer *buffer) {
     }
     if (line()) {
         norawmode();
-        if (gbl_cancel_current_repl_form) {
-            fputc('\n', out);
+        if (gbl_sigint_flag) {
+            raise(SIGINT);
         } else {
-            if (gbl_sigint_flag) {
-                raise(SIGINT);
-            } else {
-                fputc('\n', out);
-            }
-            return;
+            fputc('\n', out);
         }
+        return;
     }
     fflush(stdin);
     norawmode();

--- a/src/mainclient/shell.c
+++ b/src/mainclient/shell.c
@@ -63,7 +63,7 @@ Janet janet_line_getter(int32_t argc, Janet *argv) {
         gbl_cancel_current_repl_form = false;
 
         // Signal that the user bailed out of the current form
-        const static char *const msg = "cancel";
+        static const char *const msg = "cancel";
         result = janet_ckeywordv(msg);
     } else {
         result = janet_wrap_buffer(buf);

--- a/src/mainclient/shell.c
+++ b/src/mainclient/shell.c
@@ -25,6 +25,7 @@
 #endif
 
 #include <janet.h>
+#include <stdbool.h>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -39,6 +40,10 @@ void janet_line_deinit();
 
 void janet_line_get(const char *p, JanetBuffer *buffer);
 Janet janet_line_getter(int32_t argc, Janet *argv);
+static Janet janet_set_repl_within_form(int32_t argc, Janet *argv);
+
+static JANET_THREAD_LOCAL bool gbl_cancel_current_repl_form = false;
+static JANET_THREAD_LOCAL bool gbl_repl_within_form = false;
 
 /*
  * Line Editing
@@ -54,7 +59,17 @@ Janet janet_line_getter(int32_t argc, Janet *argv) {
     gbl_complete_env = (argc >= 3) ? janet_gettable(argv, 2) : NULL;
     janet_line_get(str, buf);
     gbl_complete_env = NULL;
-    return janet_wrap_buffer(buf);
+
+    Janet result;
+    if (gbl_cancel_current_repl_form) {
+        gbl_cancel_current_repl_form = false;
+
+        // Signal that the user bailed out of the current form
+        result = janet_wrap_nil();
+    } else {
+        result = janet_wrap_buffer(buf);
+    }
+    return result;
 }
 
 static void simpleline(JanetBuffer *buffer) {
@@ -69,6 +84,12 @@ static void simpleline(JanetBuffer *buffer) {
         janet_buffer_push_u8(buffer, (uint8_t) c);
         if (c == '\n') break;
     }
+}
+
+static Janet janet_set_repl_within_form(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 1);
+    gbl_repl_within_form = janet_unwrap_boolean(argv[0]) != 0;
+    return janet_wrap_nil();
 }
 
 /* Windows */
@@ -746,8 +767,15 @@ static int line() {
                 kleft();
                 break;
             case 3:     /* ctrl-c */
-                errno = EAGAIN;
-                gbl_sigint_flag = 1;
+                if (
+                        (gbl_len == 0)
+                        && !gbl_repl_within_form
+                ) {   /* quit on empty line */
+                    errno = EAGAIN;
+                    gbl_sigint_flag = 1;
+                } else {              /* interrupt expression on non-empty line */
+                    gbl_cancel_current_repl_form = true;
+                }
                 clearlines();
                 return -1;
             case 4:     /* ctrl-d, eof */
@@ -947,12 +975,16 @@ void janet_line_get(const char *p, JanetBuffer *buffer) {
     }
     if (line()) {
         norawmode();
-        if (gbl_sigint_flag) {
-            raise(SIGINT);
-        } else {
+        if (gbl_cancel_current_repl_form) {
             fputc('\n', out);
+        } else {
+            if (gbl_sigint_flag) {
+                raise(SIGINT);
+            } else {
+                fputc('\n', out);
+            }
+            return;
         }
-        return;
     }
     fflush(stdin);
     norawmode();
@@ -991,6 +1023,7 @@ int main(int argc, char **argv) {
     /* Replace original getline with new line getter */
     JanetTable *replacements = janet_table(0);
     janet_table_put(replacements, janet_csymbolv("getline"), janet_wrap_cfunction(janet_line_getter));
+    janet_table_put(replacements, janet_csymbolv("set-repl-within-form"), janet_wrap_cfunction(janet_set_repl_within_form));
     janet_line_init();
 
     /* Get core env */

--- a/src/mainclient/shell.c
+++ b/src/mainclient/shell.c
@@ -63,7 +63,8 @@ Janet janet_line_getter(int32_t argc, Janet *argv) {
         gbl_cancel_current_repl_form = false;
 
         // Signal that the user bailed out of the current form
-        result = janet_wrap_nil();
+        const static char *const msg = "cancel";
+        result = janet_ckeywordv(msg);
     } else {
         result = janet_wrap_buffer(buf);
     }


### PR DESCRIPTION
A REPL tweak. Ctrl-C currently exits the REPL. This PR:

* Exits if on column 0 outside of an expression, like before.
* Cancels the current form if inside of an expression, but doesn't exit Janet.

This matches the behaviour of other language REPLs a bit more.

This PR is a bit hacky; it uses a thread-local boolean exposed to Janet and C and exposes a dummy version for bootstrapping. _If_ I know this new behaviour is desired, I'll clean up the PR in a follow-up commit to use a single function at the least and abstract away the check in `run-context`.

I just didn't want to spent too much time on this if users prefer the current Ctrl-C behaviour.