### PR TITLE
Implement os/realpath with _fullpath

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1224,17 +1224,16 @@ static Janet os_rename(int32_t argc, Janet *argv) {
 
 static Janet os_realpath(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 1);
-#ifdef JANET_NO_REALPATH
-    (void) argv;
-    janet_panic("os/realpath not supported on this platform");
-#else
     const char *src = janet_getcstring(argv, 0);
+#ifdef JANET_WINDOWS
+    char *dest = _fullpath(NULL, src, _MAX_PATH);
+#else
     char *dest = realpath(src, NULL);
+#endif
     if (NULL == dest) janet_panicf("%s: %s", strerror(errno), src);
     Janet ret = janet_cstringv(dest);
     free(dest);
     return ret;
-#endif
 }
 
 static Janet os_permission_string(int32_t argc, Janet *argv) {

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -138,11 +138,6 @@ extern "C" {
 #define JANET_NO_UTC_MKTIME
 #endif
 
-/* Add some windows flags */
-#ifdef JANET_WINDOWS
-#define JANET_NO_REALPATH
-#endif
-
 /* Define how global janet state is declared */
 #ifdef JANET_SINGLE_THREADED
 #define JANET_THREAD_LOCAL


### PR DESCRIPTION
Maybe you had a good reason to not do this. I can see that `_fullpath` is not quite the same as `realpath`, because `realpath` only accepts paths that exist but it still seems like it could be useful.