### PR TITLE
Make install-paths a function

### DIFF
--- a/jpm
+++ b/jpm
@@ -29,7 +29,7 @@
     (def i (last (string/find-all sep exe)))
     (slice exe 0 i)))
 
-(def- install-paths 
+(defn- install-paths []
   {:headerpath (os/realpath (string exe-dir "/../include/janet"))
    :libpath (os/realpath (string exe-dir "/../lib"))
    :binpath exe-dir})
@@ -38,16 +38,16 @@
 
 # Default based on janet binary location
 (def JANET_HEADERPATH (or (os/getenv "JANET_HEADERPATH")
-                          (get install-paths :headerpath)))
+                          (get (install-paths) :headerpath)))
 (def JANET_LIBPATH (or (os/getenv "JANET_LIBPATH")
-                       (get install-paths :libpath)))
+                       (get (install-paths) :libpath)))
 # We want setting JANET_PATH to contain installed binaries. However, it is convenient
 # to have globally installed binaries got to the same place as jpm itself, which is on
 # the $PATH.
 (def JANET_BINPATH (or (os/getenv "JANET_BINPATH")
                        (if-let [mp (os/getenv "JANET_MODPATH")] (string mp "/bin"))
                        (if-let [mp (os/getenv "JANET_PATH")] (string mp "/bin"))
-                       (get install-paths :binpath)))
+                       (get (install-paths) :binpath)))
 
 # modpath should only be derived from the syspath being used or an environment variable.
 (def JANET_MODPATH (or (os/getenv "JANET_MODPATH") (dyn :syspath)))

--- a/tools/patch-jpm.janet
+++ b/tools/patch-jpm.janet
@@ -20,7 +20,7 @@
 (def- replace-peg
   (peg/compile
     ~(% (* '(to "###START###")
-           (constant ,(string/format "# Inserted by tools/patch-jpm.janet\n(def install-paths %j)" install-paths))
+           (constant ,(string/format "# Inserted by tools/patch-jpm.janet\n(defn- install-paths [] %j)" install-paths))
            (thru "###END###")
            '(any 1)))))
 


### PR DESCRIPTION
As noted in [a comment](https://github.com/janet-lang/janet/issues/419#issuecomment-644536795) after #419 was closed, using `def-` for `install-paths` rather than `defn-` in the `jpm` script means that the values in the struct are evaluated regardless of whether `install-paths` is ever used. This can cause the script to break if executed within certain directory structures (such as the directory that the release tarball is extracted to). This is not a theoretical problem. It breaks [the GitHub Action workflow](https://github.com/pyrmont/markable/blob/master/.github/workflows/build.yml) I use as part of continuous integration in my Janet projects.

This PR uses `defn-` rather than `def-` to avoid this problem. It updates the calls to `install-paths` to be calls to `(install-paths)`. This avoids evaluation of the struct unless the value is actually required. A minor change is also made to `tools/patch-jpm.janet` as a result of the change in the nature of the binding.