### PR TITLE
Change default string representation of nil to empty string

### DIFF
--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -188,7 +188,7 @@ static void janet_escape_buffer_b(JanetBuffer *buffer, JanetBuffer *bx) {
 void janet_to_string_b(JanetBuffer *buffer, Janet x) {
     switch (janet_type(x)) {
         case JANET_NIL:
-            janet_buffer_push_cstring(buffer, "nil");
+            janet_buffer_push_cstring(buffer, "");
             break;
         case JANET_BOOLEAN:
             janet_buffer_push_cstring(buffer,
@@ -277,6 +277,9 @@ void janet_description_b(JanetBuffer *buffer, Janet x) {
     switch (janet_type(x)) {
         default:
             break;
+        case JANET_NIL:
+            janet_buffer_push_cstring(buffer, "nil");
+            return;
         case JANET_KEYWORD:
             janet_buffer_push_u8(buffer, ':');
             break;


### PR DESCRIPTION
When `nil` is passed to functions that need to represent the value as a string, Janet uses the value `"nil"` as opposed to the empty string `""`. I am not sure if this was an intentional design decision; I have found it frustrating because it prevents idioms that construct strings using forms like `when`. Clojure, a language similar in many respects to Janet, represents `nil` as the empty string `""` and inspired this patch.

This PR changes the value returned by `janet_to_string_b` for `JANET_NIL` to `""`. It also updates `janet_description_b` to return the value `"nil`" for situations where it makes sense to output a textual representation (e.g. `(pp nil)`).

The existing test suite passes without any modification but I think it would be a good idea to add some tests. Is there a particular suite this should go in? I am also not sure if updating `janet_description_b` is sufficient for things like formatting options like `%j`.