### PR TITLE
Add ppc to os/arch

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -159,6 +159,8 @@ static Janet os_arch(int32_t argc, Janet *argv) {
     return janet_ckeywordv("arm");
 #elif (defined(__sparc__))
     return janet_ckeywordv("sparc");
+#elif (defined(__ppc__))
+    return janet_ckeywordv("ppc");
 #else
     return janet_ckeywordv("unknown");
 #endif


### PR DESCRIPTION
I noticed that my PowerPC build of janet returned "unknown" as the os/arch.

This PR detects PowerPC via `defined(__ppc__)`, which I verified via the following C program:

```c
int main() {
#if defined(__ppc__)
return 1;
#else
return 2;
#endif
}
```

(compiled with the stock gcc 4.0.1 which ships with OS X Tiger / Xcode 2.5)