### PR TITLE
Support for systems missing O_CLOEXEC

### DIFF
--- a/src/conf/janetconf.h
+++ b/src/conf/janetconf.h
@@ -58,6 +58,7 @@
 /* #define JANET_NO_REALPATH */
 /* #define JANET_NO_SYMLINKS */
 /* #define JANET_NO_UMASK */
+/* #define JANET_NO_CLOEXEC */
 /* #define JANET_OUT_OF_MEMORY do { printf("janet out of memory\n"); exit(1); } while (0) */
 /* #define JANET_EXIT(msg) do { printf("C assert failed executing janet: %s\n", msg); exit(1); } while (0) */
 /* #define JANET_TOP_LEVEL_SIGNAL(msg) call_my_function((msg), stderr) */

--- a/src/conf/janetconf.h
+++ b/src/conf/janetconf.h
@@ -58,7 +58,6 @@
 /* #define JANET_NO_REALPATH */
 /* #define JANET_NO_SYMLINKS */
 /* #define JANET_NO_UMASK */
-/* #define JANET_NO_CLOEXEC */
 /* #define JANET_OUT_OF_MEMORY do { printf("janet out of memory\n"); exit(1); } while (0) */
 /* #define JANET_EXIT(msg) do { printf("C assert failed executing janet: %s\n", msg); exit(1); } while (0) */
 /* #define JANET_TOP_LEVEL_SIGNAL(msg) call_my_function((msg), stderr) */

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -112,7 +112,7 @@ typedef struct {
 #endif
 static JanetStream *make_stream(int fd, int flags) {
     JanetStream *stream = janet_abstract(&StreamAT, sizeof(JanetStream));
-#if !defined(SOCK_CLOEXEC) && !defined(JANET_NO_CLOEXEC)
+#if !defined(SOCK_CLOEXEC) && defined(O_CLOEXEC)
     int extra = O_CLOEXEC;
 #else
     int extra = 0;

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -112,7 +112,7 @@ typedef struct {
 #endif
 static JanetStream *make_stream(int fd, int flags) {
     JanetStream *stream = janet_abstract(&StreamAT, sizeof(JanetStream));
-#ifndef SOCK_CLOEXEC
+#if !defined(SOCK_CLOEXEC) && !defined(JANET_NO_CLOEXEC)
     int extra = O_CLOEXEC;
 #else
     int extra = 0;


### PR DESCRIPTION
This PR adds a `JANET_NO_CLOEXEC` define to janetconf.h for systems which don't have `O_CLOEXEC`.

This PR is part of an effort to support janet on OS X Tiger / PowerPC.