### PR TITLE
Add .gitattributes: syntax highlight .janet files as Clojure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.janet linguist-language=Clojure


### PR DESCRIPTION
Much more readable, IMO!.

This is a short-term solution; a better one will be to make Janet an officially-recognized language by sending a PR to https://github.com/github/linguist .

Fixes #433