### PR TITLE
Add support for systems which are missing arc4random_buf

### DIFF
--- a/src/conf/janetconf.h
+++ b/src/conf/janetconf.h
@@ -58,6 +58,7 @@
 /* #define JANET_NO_REALPATH */
 /* #define JANET_NO_SYMLINKS */
 /* #define JANET_NO_UMASK */
+/* #define JANET_NO_ARC4RANDOM_BUF */
 /* #define JANET_OUT_OF_MEMORY do { printf("janet out of memory\n"); exit(1); } while (0) */
 /* #define JANET_EXIT(msg) do { printf("C assert failed executing janet: %s\n", msg); exit(1); } while (0) */
 /* #define JANET_TOP_LEVEL_SIGNAL(msg) call_my_function((msg), stderr) */

--- a/src/conf/janetconf.h
+++ b/src/conf/janetconf.h
@@ -58,7 +58,6 @@
 /* #define JANET_NO_REALPATH */
 /* #define JANET_NO_SYMLINKS */
 /* #define JANET_NO_UMASK */
-/* #define JANET_NO_ARC4RANDOM_BUF */
 /* #define JANET_OUT_OF_MEMORY do { printf("janet out of memory\n"); exit(1); } while (0) */
 /* #define JANET_EXIT(msg) do { printf("C assert failed executing janet: %s\n", msg); exit(1); } while (0) */
 /* #define JANET_TOP_LEVEL_SIGNAL(msg) call_my_function((msg), stderr) */

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -70,6 +70,20 @@ extern char **environ;
 void arc4random_buf(void *buf, size_t nbytes);
 #endif
 
+/* arc4random_buf wasn't available in OS X until 10.7. */
+#ifdef JANET_NO_ARC4RANDOM_BUF
+/* Based on https://stackoverflow.com/a/12956868/558735 */
+uint32_t arc4random(void);
+void arc4random_buf(void *buf, size_t nbytes) {
+    size_t entropy_len = (nbytes/4)+1;
+    uint32_t entropy[entropy_len];        
+    for (size_t i = 0; i < entropy_len; i++) {
+        entropy[i] = arc4random();
+    }
+    memcpy(buf, entropy, nbytes);
+}
+#endif
+
 /* Not POSIX, but all Unixes but Solaris have this function. */
 #if defined(JANET_POSIX) && !defined(__sun)
 time_t timegm(struct tm *tm);

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -72,15 +72,20 @@ void arc4random_buf(void *buf, size_t nbytes);
 
 /* arc4random_buf wasn't available in OS X until 10.7. */
 #ifdef JANET_NO_ARC4RANDOM_BUF
-/* Based on https://stackoverflow.com/a/12956868/558735 */
 uint32_t arc4random(void);
 void arc4random_buf(void *buf, size_t nbytes) {
-    size_t entropy_len = (nbytes/4)+1;
-    uint32_t entropy[entropy_len];        
-    for (size_t i = 0; i < entropy_len; i++) {
-        entropy[i] = arc4random();
+    uint32_t *buf_as_words = (uint32_t*)buf;
+    size_t nwords = nbytes / 4;
+    for (size_t i=0; i < nwords; i++) {
+        buf_as_words[i] = arc4random();
     }
-    memcpy(buf, entropy, nbytes);
+
+    size_t tail_len = nbytes % 4;
+    if (tail_len) {
+        uint8_t *tail = buf + nbytes - tail_len;
+        uint32_t rand = arc4random();
+        memcpy(tail, &rand, tail_len);
+    }
 }
 #endif
 


### PR DESCRIPTION
~~This PR adds a trivial implementation of `arc4random_buf()` (based on https://stackoverflow.com/a/12956868/558735) for systems which have `arc4random()` but not `arc4random_buf()`.  This includes PowerPC Macs which are stuck on OS X Tiger.~~

~~This is enabled by uncommenting the `JANET_NO_ARC4RANDOM_BUF` define in `janetconf.h`.~~

This PR modifies `os_cryptorand()` to use `/dev/urandom` on Macs prior to OS X 10.7.

context: https://github.com/janet-lang/janet/issues/430