### PR TITLE
Fix janet_table_remove returning the key instead of the value

### DIFF
--- a/src/boot/table_test.c
+++ b/src/boot/table_test.c
@@ -61,5 +61,11 @@ int table_test() {
     assert(janet_equals(janet_table_get(t2, janet_csymbolv("t2key1")), janet_wrap_integer(10)));
     assert(janet_equals(janet_table_get(t2, janet_csymbolv("t2key2")), janet_wrap_integer(100)));
 
+    assert(t2->count == 4);
+    assert(janet_equals(janet_table_remove(t2, janet_csymbolv("t2key1")), janet_wrap_integer(10)));
+    assert(t2->count == 3);
+    assert(janet_equals(janet_table_remove(t2, janet_csymbolv("t2key2")), janet_wrap_integer(100)));
+    assert(t2->count == 2);
+
     return 0;
 }

--- a/src/core/table.c
+++ b/src/core/table.c
@@ -173,7 +173,7 @@ Janet janet_table_rawget(JanetTable *t, Janet key) {
 Janet janet_table_remove(JanetTable *t, Janet key) {
     JanetKV *bucket = janet_table_find(t, key);
     if (NULL != bucket && !janet_checktype(bucket->key, JANET_NIL)) {
-        Janet ret = bucket->key;
+        Janet ret = bucket->value;
         t->count--;
         t->deleted++;
         bucket->key = janet_wrap_nil();


### PR DESCRIPTION
I noticed that `janet_table_remove` was returning the key instead of the removed value.

It would be good to have a test for it to avoid regressions, but I have no idea where I should put such a test in the test suit or create a new test suit, so where do I put tests for it?