### PR TITLE
Add comment in 'not' doc about 'falsey?'

### DIFF
--- a/src/core/math.c
+++ b/src/core/math.c
@@ -281,7 +281,8 @@ static Janet janet_not(int32_t argc, Janet *argv) {
 static const JanetReg math_cfuns[] = {
     {
         "not", janet_not,
-        JDOC("(not x)\n\nReturns the boolean inverse of x.")
+        JDOC("(not x)\n\nReturns the boolean inverse of x.\n"
+             "falsey? can be implemented as (def falsey? not).")
     },
     {
         "math/random", janet_rand,


### PR DESCRIPTION
This might be obvious to seasoned lispers, but I thought if we add a note about `falsey?` in the docstring of `not`, then if a newbie hits https://janet-lang.org/api/index.html and searches for "falsey", they will at least see the docstring.

tested locally:

```
cell@flouride-e(falsey)$ ./build/janet
Janet 1.10.2-dev-7e1e307  Copyright (C) 2017-2020 Calvin Rose
janet:1:> (doc not)


    cfunction

    (not x)
    
    Returns the boolean inverse of x.
    falsey? can be implemented as (def falsey? not).


nil
```
