### PR TITLE
Fix build on NetBSD.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ gmake test
 gmake repl
 ```
 
+### NetBSD
+
+NetBSD build instructions are the same as the FreeBSD build instuctions.
+Alternatively, install directly from packages, using `pkgin install janet`.
+
 ### Windows
 
 1. Install [Visual Studio](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=15#) or [Visual Studio Build Tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15#)

--- a/src/core/features.h
+++ b/src/core/features.h
@@ -38,4 +38,11 @@
 #define _XOPEN_SOURCE 500
 #endif
 
+/* Needed for timegm and other extensions when building with -std=c99.
+ * It also defines realpath, etc, which would normally require
+ * _XOPEN_SOURCE >= 500. */
+#if !defined(_NETBSD_SOURCE) && defined(__NetBSD__)
+#define _NETBSD_SOURCE
+#endif
+
 #endif


### PR DESCRIPTION
The NetBSD C library's headers do not expose extensions when compiling with `-std=c99` (as opposed to `-std=gnu99` or no 'std' option), so define `_NETBSD_SOURCE` to get `timegm`, and functions that would otherwise require an `_XOPEN_SOURCE` definition, e.g. `realpath`.

Note that, as with FreeBSD, you need `gmake` to compile janet on NetBSD, and can also install it from packages.

I was previously passing `_NETBSD_SOURCE` through NetBSD's packaging system for the janet package, but this stopped working without patches when `BOOT_CFLAGS` was added. Might as well get it compiling from a fresh git clone now...

[Some more random information about _XOPEN_SOURCE as it applies on Solaris-like systems](https://gist.github.com/jperkin/b08f9108daf8d0ac695067d71f882a9d)