### PR TITLE
Expose janet_init_random_hash_key instead of janet_cryptorand.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## 1.11.3 - 2020-08-03
 - Add `JANET_HASHSEED` environment variable when `JANET_PRF` is enabled.
-- Expose `janet_cryptorand` in C API.
+- Expose `janet_init_random_hash_key` in C API.
 - Properly initialize PRF in default janet program
 - Add `index-of` to core library.
 - Add `-fPIC` back to core CFLAGS (non-optional when compiling default client  with Makefile)

--- a/jpm
+++ b/jpm
@@ -537,19 +537,19 @@
 int main(int argc, const char **argv) {
 
 #if defined(JANET_PRF)
-    uint8_t hash_key[JANET_HASH_KEY_SIZE + 1];
 #ifdef JANET_REDUCED_OS
     char *envvar = NULL;
 #else
     char *envvar = getenv("JANET_HASHSEED");
 #endif
     if (NULL != envvar) {
+        uint8_t hash_key[JANET_HASH_KEY_SIZE + 1];
         strncpy((char *) hash_key, envvar, sizeof(hash_key) - 1);
-    } else if (janet_cryptorand(hash_key, JANET_HASH_KEY_SIZE) != 0) {
+        janet_init_hash_key(hash_key);
+    } else if (janet_init_random_hash_key() != 0) {
         fputs("unable to initialize janet PRF hash function.\n", stderr);
         return 1;
     }
-    janet_init_hash_key(hash_key);
 #endif
 
     janet_init();

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -214,6 +214,10 @@ void janet_init_hash_key(uint8_t new_key[JANET_HASH_KEY_SIZE]) {
     memcpy(hash_key, new_key, sizeof(hash_key));
 }
 
+int janet_init_random_hash_key() {
+    return janet_cryptorand(hash_key, JANET_HASH_KEY_SIZE);
+}
+
 /* Calculate hash for string */
 
 int32_t janet_string_calchash(const uint8_t *str, int32_t len) {

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -108,6 +108,8 @@ void janet_core_cfuns(JanetTable *env, const char *regprefix, const JanetReg *cf
 int janet_gettime(struct timespec *spec);
 #endif
 
+int janet_cryptorand(uint8_t *out, size_t n);
+
 #define RETRY_EINTR(RC, CALL) do { (RC) = CALL; } while((RC) < 0 && errno == EINTR)
 
 /* Initialize builtin libraries */

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1389,6 +1389,7 @@ JANET_API JanetBuffer *janet_pretty(JanetBuffer *buffer, int depth, int flags, J
 #ifdef JANET_PRF
 #define JANET_HASH_KEY_SIZE 16
 JANET_API void janet_init_hash_key(uint8_t key[JANET_HASH_KEY_SIZE]);
+JANET_API int janet_init_random_hash_key(void);
 #endif
 JANET_API int janet_equals(Janet x, Janet y);
 JANET_API int32_t janet_hash(Janet x);
@@ -1544,8 +1545,6 @@ JANET_API FILE *janet_getfile(const Janet *argv, int32_t n, int32_t *flags);
 JANET_API FILE *janet_dynfile(const char *name, FILE *def);
 JANET_API JanetAbstract janet_checkfile(Janet j);
 JANET_API FILE *janet_unwrapfile(Janet j, int32_t *flags);
-
-int janet_cryptorand(uint8_t *out, size_t n);
 
 /* Marshal API */
 JANET_API void janet_marshal_size(JanetMarshalContext *ctx, size_t value);

--- a/src/mainclient/shell.c
+++ b/src/mainclient/shell.c
@@ -1018,19 +1018,19 @@ int main(int argc, char **argv) {
 #endif
 
 #if defined(JANET_PRF)
-    uint8_t hash_key[JANET_HASH_KEY_SIZE + 1];
 #ifdef JANET_REDUCED_OS
     char *envvar = NULL;
 #else
     char *envvar = getenv("JANET_HASHSEED");
 #endif
     if (NULL != envvar) {
+        uint8_t hash_key[JANET_HASH_KEY_SIZE + 1];
         strncpy((char *) hash_key, envvar, sizeof(hash_key) - 1);
-    } else if (janet_cryptorand(hash_key, JANET_HASH_KEY_SIZE) != 0) {
+        janet_init_hash_key(hash_key);
+    } else if (janet_init_random_hash_key() != 0) {
         fputs("unable to initialize janet PRF hash function.\n", stderr);
         return 1;
     }
-    janet_init_hash_key(hash_key);
 #endif
 
 


### PR DESCRIPTION
This seems like a more sensible thing to expose to the public.
janet_cryptorand becomes an internal util function.