### PR TITLE
Fix polling on libmusl

### DIFF
--- a/src/core/net.c
+++ b/src/core/net.c
@@ -207,9 +207,6 @@ JanetAsyncStatus net_machine_read(JanetListenerState *s, JanetAsyncEvent event) 
                     nread = recv(s->pollable->handle, buffer->data + buffer->count, bytes_left, 0);
                 }
             } while (nread == -1 && JLASTERR == JEINTR);
-            if (JLASTERR == JEAGAIN || JLASTERR == JEWOULDBLOCK) {
-                break;
-            }
 
             /* Increment buffer counts */
             if (nread > 0) {

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -207,6 +207,9 @@ JanetAsyncStatus net_machine_read(JanetListenerState *s, JanetAsyncEvent event) 
                     nread = recv(s->pollable->handle, buffer->data + buffer->count, bytes_left, 0);
                 }
             } while (nread == -1 && JLASTERR == JEINTR);
+            if ((nread == 0) && (JLASTERR == JEAGAIN || JLASTERR == JEWOULDBLOCK)) {
+                break;
+            }
 
             /* Increment buffer counts */
             if (nread > 0) {


### PR DESCRIPTION
This is definitely wrong fix, but it makes my code work. Without it, it hangs as can be seen in this (stripped) strace log:

```bind(3, {sa_family=AF_INET, sin_port=htons(0), sin_addr=inet_addr("0.0.0.0")}, 16) = 0
sendto(3, "P>\1\0\0\1\0\0\0\0\0\0\4neil\10laststar\4work\0"..., 36, MSG_NOSIGNAL, {sa_family=AF_INET, sin_port=htons(53), sin_addr=inet_addr("8.8.8.8")}, 16) = 36
sendto(3, "P>\1\0\0\1\0\0\0\0\0\0\4neil\10laststar\4work\0"..., 36, MSG_NOSIGNAL, {sa_family=AF_INET, sin_port=htons(53), sin_addr=inet_addr("4.4.4.4")}, 16) = 36
sendto(3, "QB\1\0\0\1\0\0\0\0\0\0\4neil\10laststar\4work\0"..., 36, MSG_NOSIGNAL, {sa_family=AF_INET, sin_port=htons(53), sin_addr=inet_addr("8.8.8.8")}, 16) = 36
sendto(3, "QB\1\0\0\1\0\0\0\0\0\0\4neil\10laststar\4work\0"..., 36, MSG_NOSIGNAL, {sa_family=AF_INET, sin_port=htons(53), sin_addr=inet_addr("4.4.4.4")}, 16) = 36
poll([{fd=3, events=POLLIN}], 1, 2500)  = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "P>\201\200\0\1\0\1\0\0\0\0\4neil\10laststar\4work\0"..., 512, 0, {sa_family=AF_INET, sin_port=htons(53), sin_addr=inet_addr("8.8.8.8")}, [16]) = 52
recvfrom(3, 0x7ffdda5fa320, 512, 0, 0x7ffdda5f9dd0, [16]) = -1 EAGAIN (Resource temporarily unavailable)
poll([{fd=3, events=POLLIN}], 1, 2457)  = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "QB\201\200\0\1\0\0\0\1\0\0\4neil\10laststar\4work\0"..., 512, 0, {sa_family=AF_INET, sin_port=htons(53), sin_addr=inet_addr("8.8.8.8")}, [16]) = 95
close(3)                                = 0
socket(AF_INET, SOCK_STREAM|SOCK_CLOEXEC, IPPROTO_TCP) = 3
connect(3, {sa_family=AF_INET, sin_port=htons(6660), sin_addr=inet_addr("116.203.207.90")}, 16) = 0
fcntl(3, F_GETFL)                       = 0x2 (flags O_RDWR)
fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK)    = 0
open("/dev/random", O_RDONLY)           = 4
poll([{fd=4, events=POLLIN}], 1, -1)    = 1 ([{fd=4, revents=POLLIN}])
close(4)                                = 0
open("/dev/urandom", O_RDONLY)          = 4
read(4, "V\30\376\332\f\204\256\210\20j\363k\4\272 !\236\32\235\235h\337\315\300\363\352\344;;\224\315\226"..., 56) = 56
close(4)                                = 0
poll([{fd=3, events=POLLOUT}], 1, -1)   = 1 ([{fd=3, revents=POLLOUT}])
sendto(3, "0\0\0\0\247\313h;|\311'\240\347\337\345p3\312\231\26064\347\24\26\335#\330\376\353.A"..., 52, MSG_NOSIGNAL, NULL, 0) = 52
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "`\0\0\0", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\"\276\f\250", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\353\215\366\274", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\26\242\247\222", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, ",\3400\374", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\221\317\340b", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "&\362\357c", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\6\267\363\254", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\324\26'\10", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "N\0042\316", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "qx\265\372", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\227J\216Q", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\326\376\2608", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\373\241f\345", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\n&\243\313", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\344x\304\202", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\260\265\274~", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "r\206\224\341", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\221\311\342\234", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\373\3\346\340", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\311\202\357\0", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "Oj\33Q", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\346ipS", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\215O\316\310", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "\203s\344\26", 4, 0, NULL, NULL) = 4
poll([{fd=3, events=POLLIN}], 1, -1
```

The last line is cut by the strace, not by me.