### PR TITLE
Add parser switching

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2034,8 +2034,12 @@
 
 (defn- load-parser
   [name]
-  (require-1 (string name "-parser") [] {})
-  ((symbol (string name "/parser"))))
+  (require-1 (string name "-syntax") [] {})
+  (def form (tuple (symbol (string name "-syntax/parser"))))
+  (def res (compile form))
+  (if (= (type res) :function)
+    (res)
+    (error (res :error))))
 
 (defn parser/new
   "Creates and returns a new parser object. Parsers are state machines that can

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2034,8 +2034,8 @@
 
 (defn- load-parser
   [name]
-  (require-1 (string "parser-" name) [] {})
-  ((symbol (string name "/new"))))
+  (require-1 (string name "-parser") [] {})
+  ((symbol (string name "/parser"))))
 
 (defn parser/new
   "Creates and returns a new parser object. Parsers are state machines that can

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2038,71 +2038,70 @@
   ((symbol (string name "/new"))))
 
 (defn parser/new
-  [&opt syntax]
   "Creates and returns a new parser object. Parsers are state machines that can
   receive bytes, and generate a stream of values."
+  [&opt syntax]
   (default syntax :default)
   (if (= syntax :default)
     (parser/default)
     (load-parser syntax)))
 
 (defn parser/clone
-  [p]
   "Creates a deep clone of a parser that is identical to the input parser. This
   cloned parser can be used to continue parsing from a good checkpoint if
   parsing later fails. Returns a new parser."
+  [p]
   (:clone p))
 
 (defn parser/has-more
-  [parser]
   "Check if the parser has more values in the value queue."
+  [parser]
   (:has-more parser))
 
 (defn parser/produce
-  [parser]
   "Dequeue the next value in the parse queue. Will return nil if no parsed
   values are in the queue, otherwise will dequeue the next value."
+  [parser]
   (:produce parser))
 
 (defn parser/consume
-  [parser bytes &opt index]
   "Input bytes into the parser and parse them. Will not throw errors if there is
   a parse error. Starts at the byte index given by index. Returns the number of
   bytes read."
+  [parser bytes &opt index]
   (if (nil? index)
     (:consume parser bytes)
     (:consume parser bytes index)))
 
 (defn parser/byte
-  [parser b]
   "Input a single byte into the parser byte stream. Returns the parser."
+  [parser b]
   (:byte parser b))
 
 (defn parser/error
-  [parser]
   "If the parser is in the error state, returns the message associated with that
   error. Otherwise, returns nil. Also flushes the parser state and parser queue,
   so be sure to handle everything in the queue before calling parser/error."
+  [parser]
   (:error parser))
 
 (defn parser/status
-  [parser]
   "Gets the current status of the parser state machine. The status will
   be one of:\n\n
   \t:pending - a value is being parsed.\n
   \t:error - a parsing error was encountered.\n
   \t:root - the parser can either read more values or safely terminate."
+  [parser]
   (:status parser))
 
 (defn parser/flush
-  [parser]
   "Clears the parser state and parse queue. Can be used to reset the parser if
   an error was encountered. Does not reset the line and column counter, so to
   begin parsing in a new context, create a new parser."
+  [parser]
   (:flush parser))
 
 (defn parser/state
-  [parser &opt key]
   "Returns a representation of the internal state of the parser. If a key is
   passed, only that information about the state is returned. Allowed keys are:
   \n\n
@@ -2113,26 +2112,27 @@
   \t:frames - Each table in the array represents a 'frame' in the parser state.
   Frames contain information about the start of the expression being parsed as
   well as the type of that expression and some type-specific information."
+  [parser &opt key]
   (if (nil? key)
     (:state parser)
     (:state parser key)))
 
 (defn parser/where
-  [parser]
   "Returns the current line number and column of the parser's internal state."
+  [parser]
   (:where parser))
 
 (defn parser/eof
-  [parser]
   "Indicate that the end of file was reached to the parser. This puts the
   parser in the :dead state."
+  [parser]
   (:eof parser))
 
 (defn parser/insert
-  [parser value]
   "Insert a value into the parser. This means that the parser state can be
   manipulated in between chunks of bytes. This would allow a user to add extra
   elements to arrays and tuples, for example. Returns the parser."
+  [parser value]
   (:insert parser value))
 
 ###

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2051,6 +2051,8 @@
     (res)
     (error (res :error))))
 
+(undef parsers)
+
 (defn parser/new
   "Creates and returns a new parser object. Parsers are state machines that can
   receive bytes, and generate a stream of values."

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2514,11 +2514,10 @@
   (defn chunks [buf _] (file/read f 2048 buf))
   (def syntax
     (let [line (file/read f :line)]
+      (file/seek f :set 0)
       (if (string/has-prefix? "#syntax " line)
         (string/slice line 8 -2)
-        (do
-          (file/seek f :set 0)
-          :default))))
+        :default)))
   (defn bp [&opt x y]
     (def ret (bad-parse x y))
     (if exit (os/exit 1))

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -1136,94 +1136,10 @@ static int parserget(void *p, Janet key, Janet *out) {
 
 static const JanetReg parse_cfuns[] = {
     {
-        "parser/new", cfun_parse_parser,
-        JDOC("(parser/new)\n\n"
-             "Creates and returns a new parser object. Parsers are state machines "
-             "that can receive bytes, and generate a stream of values.")
-    },
-    {
-        "parser/clone", cfun_parse_clone,
-        JDOC("(parser/clone p)\n\n"
-             "Creates a deep clone of a parser that is identical to the input parser. "
-             "This cloned parser can be used to continue parsing from a good checkpoint "
-             "if parsing later fails. Returns a new parser.")
-    },
-    {
-        "parser/has-more", cfun_parse_has_more,
-        JDOC("(parser/has-more parser)\n\n"
-             "Check if the parser has more values in the value queue.")
-    },
-    {
-        "parser/produce", cfun_parse_produce,
-        JDOC("(parser/produce parser)\n\n"
-             "Dequeue the next value in the parse queue. Will return nil if "
-             "no parsed values are in the queue, otherwise will dequeue the "
-             "next value.")
-    },
-    {
-        "parser/consume", cfun_parse_consume,
-        JDOC("(parser/consume parser bytes &opt index)\n\n"
-             "Input bytes into the parser and parse them. Will not throw errors "
-             "if there is a parse error. Starts at the byte index given by index. Returns "
-             "the number of bytes read.")
-    },
-    {
-        "parser/byte", cfun_parse_byte,
-        JDOC("(parser/byte parser b)\n\n"
-             "Input a single byte into the parser byte stream. Returns the parser.")
-    },
-    {
-        "parser/error", cfun_parse_error,
-        JDOC("(parser/error parser)\n\n"
-             "If the parser is in the error state, returns the message associated with "
-             "that error. Otherwise, returns nil. Also flushes the parser state and parser "
-             "queue, so be sure to handle everything in the queue before calling "
-             "parser/error.")
-    },
-    {
-        "parser/status", cfun_parse_status,
-        JDOC("(parser/status parser)\n\n"
-             "Gets the current status of the parser state machine. The status will "
-             "be one of:\n\n"
-             "\t:pending - a value is being parsed.\n"
-             "\t:error - a parsing error was encountered.\n"
-             "\t:root - the parser can either read more values or safely terminate.")
-    },
-    {
-        "parser/flush", cfun_parse_flush,
-        JDOC("(parser/flush parser)\n\n"
-             "Clears the parser state and parse queue. Can be used to reset the parser "
-             "if an error was encountered. Does not reset the line and column counter, so "
-             "to begin parsing in a new context, create a new parser.")
-    },
-    {
-        "parser/state", cfun_parse_state,
-        JDOC("(parser/state parser &opt key)\n\n"
-             "Returns a representation of the internal state of the parser. If a key is passed, "
-             "only that information about the state is returned. Allowed keys are:\n\n"
-             "\t:delimiters - Each byte in the string represents a nested data structure. For example, "
-             "if the parser state is '([\"', then the parser is in the middle of parsing a "
-             "string inside of square brackets inside parentheses. Can be used to augment a REPL prompt."
-             "\t:frames - Each table in the array represents a 'frame' in the parser state. Frames "
-             "contain information about the start of the expression being parsed as well as the "
-             "type of that expression and some type-specific information.")
-    },
-    {
-        "parser/where", cfun_parse_where,
-        JDOC("(parser/where parser)\n\n"
-             "Returns the current line number and column of the parser's internal state.")
-    },
-    {
-        "parser/eof", cfun_parse_eof,
-        JDOC("(parser/eof parser)\n\n"
-             "Indicate that the end of file was reached to the parser. This puts the parser in the :dead state.")
-    },
-    {
-        "parser/insert", cfun_parse_insert,
-        JDOC("(parser/insert parser value)\n\n"
-             "Insert a value into the parser. This means that the parser state can be manipulated "
-             "in between chunks of bytes. This would allow a user to add extra elements to arrays "
-             "and tuples, for example. Returns the parser.")
+        "parser/default", cfun_parse_parser,
+        JDOC("(parser/default)\n\n"
+             "Creates and returns a new default parser object. Parsers are state "
+             "machines that can receive bytes, and generate a stream of values.")
     },
     {NULL, NULL, NULL}
 };


### PR DESCRIPTION
This PR adds support for switching the parser used by Janet to parse input. It is inspired by Racket’s `#lang` shorthand.

The primary use case is to allow a user to write files in another syntax. A file indicates its syntax with a **syntax directive**. This is a statement at the beginning of the file of the form `#syntax <parser-name>`. Janet reads this directive and then passes the name of the syntax to use to `run-context`. The appropriate parser is then created (and loaded if necessary). If a syntax directive is not found at the beginning of a file, the file is parsed as normal.

Parsers are loaded using the same machinery as modules. Because of this a user can use any parser that they already have installed or can specify the parser in the `:deps` of a `project.janet` file. Parsers _must_ compile to a module with the name `<parser-name>-syntax`. The `-syntax` suffix is intended as a way to avoid namespace conflicts with parsers that share the name of other projects.

Here’s an example using the [Claret parser](https://github.com/pyrmont/claret). This parser uses a syntax that is heavily inspired by Clojure.

```clojure
#syntax claret

;; This is a comment

(print “””This is a long string”””)

(map #(print %) [1, 2, 3])
```

The syntax above uses `;` for comments, `”””` to delimit long strings, `#()` for function literals and treats `,` as whitespace.

The parser switching is implemented by:

- moving the `parser/` functions from `parse.c` into `boot.janet` so that the `parser/` functions work consistently with any parser;
- adding the `parser/default` function; and
- adding support for a `:syntax` option to be passed to `run-context`.

I've filed this as a draft so that it can inspire further discussion. 