### PR TITLE
Fix net server fiber

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2739,7 +2739,7 @@
     [host port &opt handler type]
     (def s (net/listen host port type))
     (if handler
-      (ev/go (fn [] (net/accept-loop s handler))))
+      (ev/go (coro (net/accept-loop s handler))))
     s))
 
 (undef guarddef)

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2739,7 +2739,7 @@
     [host port &opt handler type]
     (def s (net/listen host port type))
     (if handler
-      (ev/go (coro (net/accept-loop s handler))))
+      (ev/call (fn [] (net/accept-loop s handler))))
     s))
 
 (undef guarddef)


### PR DESCRIPTION
Without this change, net/server -> ev/go errors with:

```
error: bad slot #0, expected fiber, got <function 0x7FF41E2B7190>
  in ev/go
  in net/server [boot.janet] (tailcall) on line 2742, column 7
  in _thunk [./neiloffice] on line -1, column -1
  in cli-main [boot.janet] on line 2891, column 37
```
I tried both `ev/go` with `coro` and this solution, which seems to be better. Please let me know which solution you would prefer.