### PR TITLE
Tweak comment for janet_fiber_popframe

### DIFF
--- a/src/core/fiber.c
+++ b/src/core/fiber.c
@@ -420,8 +420,7 @@ void janet_fiber_cframe(JanetFiber *fiber, JanetCFunction cfun) {
     newframe->flags = 0;
 }
 
-/* Pop a stack frame from the fiber. Returns the new stack frame, or
- * NULL if there are no more frames */
+/* Pop a stack frame from the fiber. */
 void janet_fiber_popframe(JanetFiber *fiber) {
     JanetStackFrame *frame = janet_fiber_frame(fiber);
     if (fiber->frame == 0) return;


### PR DESCRIPTION
The return type of `janet_fiber_popframe` is void, but the associated comment for the function mentions returning some value.

This PR assumes the current behavior of the function is fine and thus modifies the comment to remove mention of returning something.
