### PR TITLE
Update (parser/where) to support optional line and column

### DIFF
--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -985,8 +985,20 @@ static Janet cfun_parse_flush(int32_t argc, Janet *argv) {
 }
 
 static Janet cfun_parse_where(int32_t argc, Janet *argv) {
-    janet_fixarity(argc, 1);
+    janet_arity(argc, 1, 3);
     JanetParser *p = janet_getabstract(argv, 0, &janet_parser_type);
+    if (argc > 1) {
+        int32_t line = janet_getinteger(argv, 1);
+        if (line < 1)
+            janet_panicf("invalid line number %d", line);
+        p->line = (size_t) line;
+    }
+    if (argc > 2) {
+        int32_t column = janet_getinteger(argv, 2);
+        if (column < 0)
+            janet_panicf("invalid column number %d", column);
+        p->column = (size_t) column;
+    }
     Janet *tup = janet_tuple_begin(2);
     tup[0] = janet_wrap_integer(p->line);
     tup[1] = janet_wrap_integer(p->column);
@@ -1247,8 +1259,10 @@ static const JanetReg parse_cfuns[] = {
     },
     {
         "parser/where", cfun_parse_where,
-        JDOC("(parser/where parser)\n\n"
-             "Returns the current line number and column of the parser's internal state.")
+        JDOC("(parser/where parser &opt line col)\n\n"
+             "Returns the current line number and column of the parser's internal state. If line or "
+             "line and col are provided, the current line number and column of the parser are set to "
+             "those values.")
     },
     {
         "parser/eof", cfun_parse_eof,

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -1260,9 +1260,9 @@ static const JanetReg parse_cfuns[] = {
     {
         "parser/where", cfun_parse_where,
         JDOC("(parser/where parser &opt line col)\n\n"
-             "Returns the current line number and column of the parser's internal state. If line or "
-             "line and col are provided, the current line number and column of the parser are set to "
-             "those values.")
+             "Returns the current line number and column of the parser's internal state. If line is "
+             "provided, the current line number of the parser is first set to that value. If column is "
+             "also provided, the current column number of the parser is also first set to that value.")
     },
     {
         "parser/eof", cfun_parse_eof,

--- a/test/suite0006.janet
+++ b/test/suite0006.janet
@@ -128,6 +128,18 @@
 (assert (not= nil (parse-error @"\xc3\x28")) "reject invalid utf-8 symbol")
 (assert (not= nil (parse-error @":\xc3\x28")) "reject invalid utf-8 keyword")
 
+# Parser line and column numbers
+(defn parser-location [input &opt location]
+  (def p (parser/new))
+  (parser/consume p input)
+  (if location
+    (parser/where p ;location)
+    (parser/where p)))
+
+(assert (= [1 7] (parser-location @"(+ 1 2)")) "parser location 1")
+(assert (= [5 7] (parser-location @"(+ 1 2)" [5])) "parser location 2")
+(assert (= [10 10] (parser-location @"(+ 1 2)" [10 10])) "parser location 3")
+
 # String check-set
 (assert (string/check-set "abc" "a") "string/check-set 1")
 (assert (not (string/check-set "abc" "z")) "string/check-set 2")


### PR DESCRIPTION
Following discussion, this PR adds two optional arguments, `line` and `column`, to `(parser/where p)`. It is intended to be used primarily by REPLs.

If a user includes `line` or `line column`, then the parser's state is updated to the specified line (and, if given, column). A basic check is done to ensure that the user cannot set the line to be less than 1 or for column to be less than zero. This PR adds tests to the test suite to confirm the basic functionality works as expected.

This fixes #531. 