### PR TITLE
Improve hash for arrays and KVs 

### DIFF
--- a/src/core/util.c
+++ b/src/core/util.c
@@ -227,19 +227,21 @@ int32_t janet_string_calchash(const uint8_t *str, int32_t len) {
 /* Computes hash of an array of values */
 int32_t janet_array_calchash(const Janet *array, int32_t len) {
     const Janet *end = array + len;
-    uint32_t hash = 5381;
-    while (array < end)
-        hash = (hash << 5) + hash + janet_hash(*array++);
+    uint32_t hash = 0;
+    while (array < end) {
+        uint32_t elem = janet_hash(*array++);
+        hash ^= elem + 0x9e3779b9 + (hash<<6) + (hash>>2);
+    }
     return (int32_t) hash;
 }
 
 /* Computes hash of an array of values */
 int32_t janet_kv_calchash(const JanetKV *kvs, int32_t len) {
     const JanetKV *end = kvs + len;
-    uint32_t hash = 5381;
+    uint32_t hash = 0;
     while (kvs < end) {
-        hash = (hash << 5) + hash + janet_hash(kvs->key);
-        hash = (hash << 5) + hash + janet_hash(kvs->value);
+        hash ^= janet_hash(kvs->key) + 0x9e3779b9 + (hash<<6) + (hash>>2);
+        hash ^= janet_hash(kvs->value) + 0x9e3779b9 + (hash<<6) + (hash>>2);
         kvs++;
     }
     return (int32_t) hash;

--- a/src/core/value.c
+++ b/src/core/value.c
@@ -261,6 +261,16 @@ int32_t janet_hash(Janet x) {
         case JANET_STRUCT:
             hash = janet_struct_hash(janet_unwrap_struct(x));
             break;
+        case JANET_NUMBER:
+            hash = (int32_t)janet_unwrap_number(x);
+            hash = ((hash >> 16) ^ hash) * 0x45d9f3b;
+            hash = ((hash >> 16) ^ hash) * 0x45d9f3b;
+            hash = (hash >> 16) ^ hash;
+
+            uint32_t lo = (uint32_t)(janet_u64(x) & 0xFFFFFFFF);
+            hash ^= lo + 0x9e3779b9 + (hash<<6) + (hash>>2);
+
+            break;
         case JANET_ABSTRACT: {
             JanetAbstract xx = janet_unwrap_abstract(x);
             const JanetAbstractType *at = janet_abstract_type(xx);


### PR DESCRIPTION
#538 

The current standard hash is [djb2](http://www.cse.yorku.ca/~oz/hash.html#djb2) (aka Bernstein hash). When used to combine the hash values of array or KV elements it performs poorly when the elements are numbers.

This can be easily demonstrated by created tables with tuples or structs as keys whose elements are numbers:

```sh
time janet -e '(def tbl @{}) (loop [x :in (range 1000) y :in (range 1000)] (put tbl (tuple 0 x 1 y) true))'
40.78s user 0.07s system 99% cpu 40.862 total
time janet -e '(def tbl @{}) (loop [x :in (range 1000) y :in (range 1000)] (put tbl {0 x 1 y} true))'
48.98s user 0.15s system 99% cpu 49.136 total
```

And with the changes of this PR:

```sh
time build/janet -e '(def tbl @{}) (loop [x :in (range 1000) y :in (range 1000)] (put tbl (tuple 0 x 1 y) true))'
5.89s user 0.07s system 99% cpu 5.965 total

time build/janet -e '(def tbl @{}) (loop [x :in (range 1000) y :in (range 1000)] (put tbl {0 x 1 y} true))'
3.80s user 0.09s system 99% cpu 3.885 total
```

See also:
https://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
