### PR TITLE
Another improvement of quicksort

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -795,34 +795,45 @@
     a
     (if (not= (> b a) (> b c)) b c)))
 
-(defn sort-help [a lo hi by]
-  (when (< lo hi)
-    (def pivot
-      (median-of-three (in a hi) (in a lo)
-                       (in a (math/floor (/ (+ lo hi) 2)))))
-    (var left lo)
-    (var right hi)
-    (while true
-      (while (by (in a left) pivot) (++ left))
-      (while (by pivot (in a right)) (-- right))
-      (when (<= left right)
-        (def tmp (in a left))
-        (set (a left) (in a right))
-        (set (a right) tmp)
-        (++ left)
-        (-- right))
-      (if (>= left right) (break)))
-    (sort-help a lo right by)
-    (sort-help a left hi by))
+(defn- insertion-sort [a lo hi by]
+  (for i (+ lo 1) (+ hi 1)
+    (def temp (in a i))
+    (var j (- i 1))
+    (while (and (>= j lo) (by temp (in a j)))
+      (set (a (+ j 1)) (in a j))
+      (-- j))
+
+    (set (a (+ j 1)) temp))
   a)
 
 (defn sort
   "Sort an array in-place. Uses quick-sort and is not a stable sort."
   [a &opt by]
-  (sort-help a 0 (- (length a) 1) (or by <)))
+  (default by <)
+  (def stack @[[0 (- (length a) 1)]])
+  (while (not (empty? stack))
+    (def [lo hi] (array/pop stack))
+    (when (< lo hi)
+      (when (< (- hi lo) 32) (insertion-sort a lo hi by) (break))
+      (def pivot (median-of-three (in a hi) (in a lo) (in a (math/floor (/ (+ lo hi) 2)))))
+      (var left lo)
+      (var right hi)
+      (while true
+        (while (by (in a left) pivot) (++ left))
+        (while (by pivot (in a right)) (-- right))
+        (when (<= left right)
+          (def tmp (in a left))
+          (set (a left) (in a right))
+          (set (a right) tmp)
+          (++ left)
+          (-- right))
+        (if (>= left right) (break)))
+      (array/push stack [lo right])
+      (array/push stack [left hi])))
+  a)
 
 (undef median-of-three)
-(undef sort-help)
+(undef insertion-sort)
 
 (defn sort-by
   `Returns a new sorted array that compares elements by invoking


### PR DESCRIPTION
Ultimately it might be a good idea to implement Timsort to get a fast and stable sorting algorithm, but it turns out that is quite a bit of work... :-)

This change makes sort switch to insertion sort when an array is smaller than 32 and it also uses an array as stack instead of recursive function call. It looks like this gives us a ~8x speed-up:

**modified**
```
time build/janet -e '(math/seedrandom 42)(sort (map (fn [x] (math/random)) (range 1000000)) >)'
time build/janet -e '(sort (range 1000000) <)'
time build/janet -e '(sort (range 1000000) >)'
time build/janet -e '(sort (array ;(range 10000 100000) ;(map - (range 100000)) ;(range 100000)) >)'

0.49s user 0.01s system 99% cpu 0.503 total
0.26s user 0.00s system 99% cpu 0.265 total
0.28s user 0.00s system 99% cpu 0.284 total
0.08s user 0.00s system 99% cpu 0.084 total
```

**unmodified**
```
time janet -e '(math/seedrandom 42)(sort (map (fn [x] (math/random)) (range 1000000)) >)'
time janet -e '(sort (range 1000000) <)'
time janet -e '(sort (range 1000000) >)'
time janet -e '(sort (array ;(range 10000 100000) ;(map - (range 100000)) ;(range 100000)) >)'

3.63s user 0.01s system 99% cpu 3.644 total
2.59s user 0.00s system 99% cpu 2.598 total
2.46s user 0.00s system 99% cpu 2.467 total
8.34s user 0.01s system 99% cpu 8.363 total
```

Further speed ups could be achieved by detecting increasing/decreasing runs (like in Timsort) and maybe by using binary insertion sort.
