### PR TITLE
Update doc for thread/new and remove ws in loop's

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -533,23 +533,16 @@
 
   * :iterate -- repeatedly evaluate and bind to the expression while it is
     truthy.
-
   * :range -- loop over a range. The object should be a two-element tuple with
     a start and end value, and an optional positive step. The range is half
     open, [start, end).
-
   * :range-to -- same as :range, but the range is inclusive [start, end].
-
   * :down -- loop over a range, stepping downwards. The object should be a
     two-element tuple with a start and (exclusive) end value, and an optional
     (positive!) step size.
-
   * :down-to -- same as :down, but the range is inclusive [start, end].
-
   * :keys -- iterate over the keys in a data structure.
-
   * :pairs -- iterate over the key-value pairs as tuples in a data structure.
-
   * :in -- iterate over the values in a data structure or fiber.
 
   `loop` also accepts conditionals to refine the looping further. Conditionals are of
@@ -560,13 +553,13 @@
   where `:modifier` is one of a set of keywords, and `argument` is keyword-dependent.
   `:modifier` can be one of:
 
-    * `:while expression` - breaks from the loop if `expression` is falsey.
-    * `:until expression` - breaks from the loop if `expression` is truthy.
-    * `:let bindings` - defines bindings inside the loop as passed to the `let` macro.
-    * `:before form` - evaluates a form for a side effect before the next inner loop.
-    * `:after form` - same as `:before`, but the side effect happens after the next inner loop.
-    * `:repeat n` - repeats the next inner loop `n` times.
-    * `:when condition` - only evaluates the loop body when condition is true.
+  * `:while expression` - breaks from the loop if `expression` is falsey.
+  * `:until expression` - breaks from the loop if `expression` is truthy.
+  * `:let bindings` - defines bindings inside the loop as passed to the `let` macro.
+  * `:before form` - evaluates a form for a side effect before the next inner loop.
+  * `:after form` - same as `:before`, but the side effect happens after the next inner loop.
+  * `:repeat n` - repeats the next inner loop `n` times.
+  * `:when condition` - only evaluates the loop body when condition is true.
 
   The `loop` macro always evaluates to nil.
   ```

--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -720,10 +720,10 @@ static const JanetReg threadlib_cfuns[] = {
              "Start a new thread that will start immediately. "
              "If capacity is provided, that is how many messages can be stored in the thread's mailbox before blocking senders. "
              "The capacity must be between 1 and 65535 inclusive, and defaults to 10. "
-             "Can optionally provide flags to the new thread - supported flags are:\n"
-             "\t:h - Start a heavyweight thread. This loads the core environment by default, so may use more memory initially. Messages may compress better, though.\n"
-             "\t:a - Allow sending over registered abstract types to the new thread\n"
-             "\t:c - Send over cfunction information to the new thread.\n"
+             "Can optionally provide flags to the new thread - supported flags are:\n\n"
+             "* :h - Start a heavyweight thread. This loads the core environment by default, so may use more memory initially. Messages may compress better, though.\n\n"
+             "* :a - Allow sending over registered abstract types to the new thread\n\n"
+             "* :c - Send over cfunction information to the new thread.\n\n"
              "Returns a handle to the new thread.")
     },
     {


### PR DESCRIPTION
I am not sure, why doubling the \n in .c is needed, but without it `(doc thread/new)` prints:

```
repl:1:> (doc thread/new)


    cfunction

    (thread/new func &opt capacity flags)

    Start a new thread that will start immediately. If capacity is
    provided, that is how many messages can be stored in the thread's
    mailbox before blocking senders. The capacity must be between 1 and
    65535 inclusive, and defaults to 10. Can optionally provide flags to
    the new thread - supported flags are: 	:h - Start a heavyweight
    thread. This loads the core environment by default, so may use more
    memory initially. Messages may compress better, though. 	:a - Allow
    sending over registered abstract types to the new thread 	:c - Send
    over cfunction information to the new thread. Returns a handle to the
    new thread.
```

I also changed '\t' to '*' as in `loop` doc. In `loop` doc I shaved some whitespace.