### PR TITLE
Fix typos in string/find-all documentation

### DIFF
--- a/src/core/string.c
+++ b/src/core/string.c
@@ -599,7 +599,7 @@ static const JanetReg string_cfuns[] = {
         JDOC("(string/find-all patt str)\n\n"
              "Searches for all instances of pattern patt in string "
              "str. Returns an array of all indices of found patterns. Overlapping "
-             "instances of the pattern are counted individual, meaning a byte in string "
+             "instances of the pattern are counted individually, meaning a byte in str "
              "may contribute to multiple found patterns.")
     },
     {


### PR DESCRIPTION
There are some minor typos in the `string/find-all` documentation added in bcba0c027998319d48c6e4b4ee3715eddf8946e1. This fixes them.