### PR TITLE
Add support for a profile.janet

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3378,8 +3378,10 @@
           (file/read stdin :line buf))
         (def env (make-env))
         (when-let [profile.janet (dyn :profilepath)] 
-            (def new-env (dofile profile.janet :exit true :env env))
-            (merge-module env new-env "" false))
+            (def src (env :source))
+            (def new-env (dofile profile.janet :exit true :source "profile.janet"))
+            (merge-module env new-env "" false)
+            (put env :source src))
         (if *debug* (put env :debug true))
         (def getter (if *raw-stdin* getstdin getline))
         (defn getchunk [buf p]

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3283,9 +3283,9 @@
   (var *debug* false)
   (var *compile-only* false)
 
-  (when-let [jp (getenv-alias "JANET_PATH")] (setdyn :syspath jp))
-  (when-let [jp (getenv-alias "JANET_HEADERPATH")] (setdyn :headerpath jp))
-  (when-let [jprofile (getenv-alias "JANET_PROFILE")] (setdyn :profilepath jprofile))
+  (if-let [jp (getenv-alias "JANET_PATH")] (setdyn :syspath jp))
+  (if-let [jp (getenv-alias "JANET_HEADERPATH")] (setdyn :headerpath jp))
+  (if-let [jprofile (getenv-alias "JANET_PROFILE")] (setdyn :profilepath jprofile))
   
   # Flag handlers
   (def handlers
@@ -3378,7 +3378,7 @@
           (file/read stdin :line buf))
         (def env (make-env))
         (when-let [profile.janet (dyn :profilepath)] 
-            (def new-env (dofile profile.janet :exit *exit-on-error* :env env))
+            (def new-env (dofile profile.janet :exit true :env env))
             (merge-module env new-env "" false))
         (if *debug* (put env :debug true))
         (def getter (if *raw-stdin* getstdin getline))

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3378,10 +3378,8 @@
           (file/read stdin :line buf))
         (def env (make-env))
         (when-let [profile.janet (dyn :profilepath)] 
-            (def src (env :source))
-            (def new-env (dofile profile.janet :exit true :source "profile.janet"))
-            (merge-module env new-env "" false)
-            (put env :source src))
+            (def new-env (dofile profile.janet :exit true))
+            (merge-module env new-env "" false))
         (if *debug* (put env :debug true))
         (def getter (if *raw-stdin* getstdin getline))
         (defn getchunk [buf p]


### PR DESCRIPTION
Add support for a profile.janet, along with a flag for disabling it's use in the presence of a JANET_PROFILE env var.