### PR TITLE
Display module-level docstrings with (doc)

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2848,16 +2848,16 @@
             (cond
               (x :ref) (string :var " (" (type (in (x :ref) 0)) ")")
               (x :macro) :macro
-              (x :module) (string :module " (" (x :kind) ": " (x :path) ")")
+              (x :module) (string :module " (" (x :kind) ")")
               (type (x :value)))
             "\n"))
   (def sm (x :source-map))
   (def d (x :doc))
   (print "\n\n"
-         (if d bind-type "")
-         (if-let [[path line col] sm]
-           (string "    " path " on line " line ", column " col "\n") "")
-         (if (or d sm) "\n" "")
+         (when d bind-type)
+         (when-let [[path line col] sm]
+           (string "    " path (when (and line col) (string " on line " line ", column " col)) "\n"))
+         (when (or d sm) "\n")
          (if d (doc-format d) "    no documentation found.")
          "\n\n"))
 
@@ -2876,10 +2876,10 @@
         (do
           (def [fullpath mod-kind] (module/find (string sym)))
           (if-let [mod-env (in module/cache fullpath)]
-            (print-module-entry {:module true
-                                 :path   fullpath
-                                 :kind   mod-kind
-                                 :doc    (in mod-env :doc)})
+            (print-module-entry {:module     true
+                                 :kind       mod-kind
+                                 :source-map [fullpath nil nil]
+                                 :doc        (in mod-env :doc)})
             (print "symbol " sym " not found.")))
         (print-module-entry x)))
 

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2848,6 +2848,7 @@
             (cond
               (x :ref) (string :var " (" (type (in (x :ref) 0)) ")")
               (x :macro) :macro
+              (x :module) (string :module " (" (x :kind) ": " (x :path) ")")
               (type (x :value)))
             "\n"))
   (def sm (x :source-map))
@@ -2873,9 +2874,12 @@
       (def x (dyn sym))
       (if (not x)
         (do
-          (def [fullpath _] (module/find (string sym)))
+          (def [fullpath mod-kind] (module/find (string sym)))
           (if-let [mod-env (in module/cache fullpath)]
-            (in mod-env :doc)
+            (print-module-entry {:module true
+                                 :path   fullpath
+                                 :kind   mod-kind
+                                 :doc    (in mod-env :doc)})
             (print "symbol " sym " not found.")))
         (print-module-entry x)))
 


### PR DESCRIPTION
This adds support for looking up 'module-level' docstrings (discussed in #598) with `(doc)`.

### Algorithm

The PR updates `(doc*)` to perform the following:

1. if the subject of `doc` is not a symbol in the environment, search `module/cache`;
2. if no entry exists in the cache for the subject, display the ordinary error message;
3. if an entry does exist in the cache, call `(print-module-entry)` to display the module documentation;
4. if the module does not have a `:doc` dynamic binding at the top-level, display the message `no documentation found` (as would be the case for another binding without documentation).

Because `(doc*)` uses `(module/find)` to get the full path, the documentation functions have been reordered to come after the module loading functions. Unfortunately this shows up as there being a large number of changes but the only functions that were edited were `(doc*)` and `(print-module-entry)`. `module/cache` was moved from the documentation section to the evaluation and compilation section (just above `module/paths`).

### Example

If you have the following module:

```
# my_module.janet

(setdyn :doc "This is the docstring for my_module")

(defn plus-two [x] (+ x 2))
```

Then at the REPL, you'd do this:

```
repl:1:> (import ./my_module)
@{my_module/plus-two @{:private true} _ @{:value <cycle 0>}}
repl:2:> (doc ./my_module)


    module (source)
    my_module.janet

    This is the docstring for my_module.


nil
```

### Possible Bug?

At present `(print-module-entry)` will print a source mapping but not the `bind-type` if no docstring exists. I wasn't sure if this was intended so left it as-is for the moment but it looks to me like a bug. If we are printing the source mapping for a binding regardless of whether a docstring exists, then it seems we should also print the `bind-type`.

I can submit an additional commit to fix this if it is a bug.