### PR TITLE
Change tracev to upscope instead of using let

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1113,7 +1113,8 @@
   (def fmt-2 (if (or (neg? l) (neg? c)) ":" (string/format " on line %d, column %d:" l c)))
   (def fmt (string fmt-1 fmt-2 " %j is "))
   (def s (gensym))
-  ~(let [,s ,x]
+  ~(upscope
+     (def ,s ,x)
      (,eprinf ,fmt ',x)
      (,eprintf (,dyn :pretty-format "%q") ,s)
      ,s))

--- a/test/suite0007.janet
+++ b/test/suite0007.janet
@@ -320,4 +320,8 @@
   (array/push a x))
 (assert (deep= (range 4) a) "eachk 1")
 
+
+(tracev (def my-unique-var-name true))
+(assert my-unique-var-name "tracev upscopes")
+
 (end-suite)


### PR DESCRIPTION
So, tracev can't be used to wrap defs right now, which feels off (but could have valid reasons).

This added the ability to do that, along with a test of it working as expected.