### PR TITLE
Add missing argument to errorf in jpm

### DIFF
--- a/jpm
+++ b/jpm
@@ -980,7 +980,7 @@ int main(int argc, const char **argv) {
         (let [op (out-path src ".c" objext)]
           (compile-c opts src op)
           op)
-        (errorf "unknown source file type: %s, expected .c or .cpp"))))
+        (errorf "unknown source file type: %s, expected .c or .cpp" src))))
 
   (when-let [embedded (opts :embedded)]
     (loop [src :in embedded]


### PR DESCRIPTION
Hey, this fixes a minor bug I found while using jpm. This errorf call was missing an argument, so if you use a file with an extension other than .c or .cpp when declaring a native module, you see this error message:

```
$ jpm build
not enough values for format
  in string/format
  in errorf [boot.janet] on line 152, column 10
  in declare-native [/Users/alligator/.local/bin/jpm] on line 952, column 9
  in _thunk [./project.janet] (tailcall) on line 5, column 1
```

instead of this one:

```
$ jpm build
unknown source file type: badfile.txt, expected .c or .cpp
  in errorf [boot.janet] on line 152, column 3
  in declare-native [../janet/jpm] on line 983, column 9
  in _thunk [./project.janet] (tailcall) on line 5, column 1
```