### PR TITLE
Allow source location in run-context to be updated

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2173,7 +2173,9 @@
         (buffer/clear buf))
 
       [:source new-where]
-      (set where new-where)
+      (if (string? new-where)
+        (set where new-where)
+        (set where default-where))
 
       (do
         (var pindex 0)

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2098,7 +2098,7 @@
         :on-parse-error on-parse-error
         :fiber-flags guard
         :evaluator evaluator
-        :source where
+        :source default-where
         :parser parser
         :read read
         :expander expand} opts)
@@ -2108,8 +2108,10 @@
   (default on-compile-error bad-compile)
   (default on-parse-error bad-parse)
   (default evaluator (fn evaluate [x &] (x)))
-  (default where "<anonymous>")
+  (default default-where "<anonymous>")
   (default guard :ydt)
+
+  (var where default-where)
 
   # Evaluate 1 source form in a protected manner
   (defn eval1 [source &opt l c]
@@ -2163,11 +2165,16 @@
   (while parser-not-done
     (if (env :exit) (break))
     (buffer/clear buf)
-    (if (= (chunks buf p) :cancel)
+    (match (= (chunks buf p))
+      :cancel
       (do
         # A :cancel chunk represents a cancelled form in the REPL, so reset.
         (:flush p)
         (buffer/clear buf))
+
+      [:source new-where]
+      (set where new-where)
+
       (do
         (var pindex 0)
         (var pstatus nil)


### PR DESCRIPTION
This PR adds a mechanism to update the source location being used in `run-context`.

## Implementation

The caller of the `run-context` function can provide a function under the `:chunks` parameter. The return value of this function can be used to send a signal to `run-context`. At present, the only return value that can be sent is the keyword `:cancel`.

This PR updates `run-context` to recognise an additional return value, a 2-value tuple `[:source <new-where>]`. The value of `<new-where>` is used to update the source location. If `<new-where>` is not a string, the value originally provided to `run-context` is used instead (or the default `"anonymous"` if no such value was provided).

## Background

The `run-context` function evaluates Janet source code:

https://github.com/janet-lang/janet/blob/a5f237993d48b6d4185f17f396cc8df44f728896/src/boot/boot.janet#L2073-L2091

The caller of the `run-context` function can provide a `:source` parameter to `run-context`. The value of this parameter is treated as the location from which the Janet code originated (e.g. the path to the file containing the source string). The source location is used in error messages to help a user understand the location where a problem occurred.

The `run-context` function is used by spork's netrepl to evaluate messages that are sent to the netrepl server by a netrepl client ([source](https://github.com/janet-lang/spork/blob/59aba861fb60c3384f341f78835153dbb9bcce25/spork/netrepl.janet#L134-L142)). When netrepl calls the `run-context` function it sets the value of the `:source` parameter to `"repl"`. The result of this is that if a message sent to the netrepl server contains an error, the location will be given as `repl`.

When a user types source code into the REPL by hand, this source location is helpful. However, for situations in which the netrepl is being used by an editor plugin, it would be preferable if the location could be updated to reflect the file being edited. This PR provides such a mechanism.

## Alternatives

1. **Store in parser.** The source location could be kept in the parser object. This would keep the source location together with the line and column number. A problem with this approach is managing memory for the source location. The line and column numbers are kept in `size_t` fields that do not require memory management. A source location would be a UTF-8 encoded byte array and would be more complicated.

2. **Use a function.** The source location could be returned from a function that is called in all the locations in `run-context` where the value is currently used. This could be made backwards-compatible by allowing the `:source` parameter to be either a string or a function. A problem with this approach is that I don't think it will work with the current implementation of spork's netrepl as there would be no way to update the value returned by the function.

## Notes

This PR by itself would not allow a netrepl client to update the source location. If this PR is accepted, the intention is to submit a separate PR to spork's netrepl that would allow a message prefixed with a new signalling byte (e.g. `0xFD`) to return the `[:source <new-where>]` value.