### PR TITLE
`sort` doc

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -787,7 +787,7 @@
 
 (defn sort-by
   ``Returns `ind` sorted by calling
-  a function `f` on each element and comparing the result with <.``
+  a function `f` on each element and comparing the result with `<`.``
   [f ind]
   (sort ind (fn [x y] (< (f x) (f y)))))
 
@@ -801,7 +801,7 @@
 
 (defn sorted-by
   ``Returns a new sorted array that compares elements by invoking
-  a function `f` on each element and comparing the result with <.``
+  a function `f` on each element and comparing the result with `<`.``
   [f ind]
   (sorted ind (fn [x y] (< (f x) (f y)))))
 

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -778,9 +778,12 @@
   a)
 
 (defn sort
-  "Sort an array in-place. Uses quick-sort and is not a stable sort."
-  [a &opt before?]
-  (sort-help a 0 (- (length a) 1) (or before? <)))
+  ``Sort `ind` in-place, and return it. Uses quick-sort and is not a stable sort.
+  
+  If a `before?` comparator function is provided, sorts elements using that;
+  otherwise uses `<`.``
+  [ind &opt before?]
+  (sort-help ind 0 (- (length ind) 1) (or before? <)))
 
 (defn sort-by
   ``Returns `ind` sorted by calling
@@ -789,7 +792,10 @@
   (sort ind (fn [x y] (< (f x) (f y)))))
 
 (defn sorted
-  "Returns a new sorted array without modifying the old one."
+  ``Returns a new sorted array without modifying the old one.
+  
+  If a `before?` comparator function is provided, sorts elements using that;
+  otherwise uses `<`.``
   [ind &opt before?]
   (sort (array/slice ind) before?))
 

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -780,7 +780,7 @@
 (defn sort
   ``Sort `ind` in-place, and return it. Uses quick-sort and is not a stable sort.
   
-  If a `before?` comparator function is provided, sorts elements using that;
+  If a `before?` comparator function is provided, sorts elements using that,
   otherwise uses `<`.``
   [ind &opt before?]
   (sort-help ind 0 (- (length ind) 1) (or before? <)))
@@ -794,7 +794,7 @@
 (defn sorted
   ``Returns a new sorted array without modifying the old one.
   
-  If a `before?` comparator function is provided, sorts elements using that;
+  If a `before?` comparator function is provided, sorts elements using that,
   otherwise uses `<`.``
   [ind &opt before?]
   (sort (array/slice ind) before?))


### PR DESCRIPTION
Clarify doc for `sort` and `sorted`. Also in `sort`, changed arg name.