### PR TITLE
Fix call to match in run-context

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2171,7 +2171,7 @@
   (while parser-not-done
     (if (env :exit) (break))
     (buffer/clear buf)
-    (match (= (chunks buf p))
+    (match (chunks buf p)
       :cancel
       (do
         # A :cancel chunk represents a cancelled form in the REPL, so reset.


### PR DESCRIPTION
The call to `match` added to `run-context` via #642 mistakenly used part of the predicate from the `if` statement it replaced. This PR fixes that error.