### PR TITLE
Fix argument passing to os/realpath in jpm

### DIFF
--- a/jpm
+++ b/jpm
@@ -44,7 +44,7 @@
 
 (defn- try-real [path]
   "If os/realpath fails just use normal path."
-  (try (os/realpath) ([_] path)))
+  (try (os/realpath path) ([_] path)))
 
 (defn- install-paths []
   {:headerpath (try-real (string exe-dir "/../include/janet"))


### PR DESCRIPTION
The `try-real` function in `jpm` didn't pass the path to `os/realpath`. This PR fixes that.