### PR TITLE
Support adding arbitrary metadata to bindings

### DIFF
--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -251,6 +251,9 @@ static JanetTable *handleattr(JanetCompiler *c, int32_t argn, const Janet *argv)
             case JANET_STRING:
                 janet_table_put(tab, janet_ckeywordv("doc"), attr);
                 break;
+            case JANET_STRUCT:
+                janet_table_merge_struct(tab, janet_unwrap_struct(attr));
+                break;
         }
     }
     return tab;

--- a/test/suite0004.janet
+++ b/test/suite0004.janet
@@ -70,5 +70,17 @@
 (assert (= ~(,defn 1 2 3) [defn 1 2 3]) "bracket tuples are never macros")
 (assert (= ~(,+ 1 2 3) [+ 1 2 3]) "bracket tuples are never function calls")
 
+# Metadata
+
+(def foo-with-tags :a-tag :bar)
+(assert (get (dyn 'foo-with-tags) :a-tag) "extra keywords in def are metadata tags")
+
+(def foo-with-meta {:baz :quux} :bar)
+(assert (= :quux (get (dyn 'foo-with-meta) :baz)) "extra struct in def is metadata")
+
+(defn foo-fn-with-meta {:baz :quux} "This is a function" [x] (identity x))
+(assert (= :quux (get (dyn 'foo-fn-with-meta) :baz)) "extra struct in defn is metadata")
+(assert (= "(foo-fn-with-meta x)\n\nThis is a function" (get (dyn 'foo-fn-with-meta) :doc)) "extra string in defn is docstring")
+
 (end-suite)
 


### PR DESCRIPTION
This PR adds support for registering arbitrary metadata to a top-level binding using a struct.

## Implementation

The `handleattr()` function in the `src/core/specials.c` file supports two types of attributes: keywords and strings. Keywords are treated as 'tags' while a string is treated as a docstring. Trying to pass any other Janet type as an attribute results in an error.

This PR updates `handleattr()` to permit a struct to be provided as an attribute. The keys and values of the struct are merged with the binding's environment table. 

## Background

Janet supports adding 'attributes' to a top-level binding's environment table as in the following example:

```janet
(defn double :foo "Double the input" [x] (* 2 x))
(dyn 'double) # => @{:doc "(double x)\n\nDouble the input" :foo true :source-map ("repl" 1 1) :value <function double>}
```

Currently, Janet only supports attributes that are keywords or strings. A keyword attribute results in that keyword being added as a key to the binding's table with the value being `true`. A string attribute results in the `:doc` key being added to the binding's table with the value being the docstring.

While this covers many situations in which metadata is desired, there are situations where arbitrary metadata would be useful. For example, the deprecation status of a function could be made part of the binding:

```janet
(defn double {:deprecated :warn} "Double the input" [x] (* 2 x))
(dyn 'double) # => @{:deprecated :warn :doc "(double x)\n\nDouble the input" :source-map ("repl" 3 1) :value <function double>}
```
This could then be used to output a warning when Janet code used the deprecated function (a system for deprecation is being discussed in #644).

## Alternatives

1. **Retain the status quo.** A user can add arbitrary metadata to a top-level binding by manipulating the binding's environment table after it has been created:

   ```janet
   (defn double "Double the input" [x] (* 2 x))
   (put (dyn 'double) :deprecated :warn)
   (dyn 'double) # => @{:deprecated :warn :doc "(double x)\n\nDouble the input" :source-map ("repl" 3 1) :value <function double>}
   ```

   This has the disadvantage of being more cumbersome. In addition, if the name of the binding changes, the call to `put` that adds the additional metadata needs to be updated.

2. **Use a special syntax.** Clojure supports metadata being added to bindings using the `^` sigil. Janet's existing metadata support does not use such a sigil and the use of an environment table (rather than something more akin to Clojure's vars) is a barrier to a completely equivalent implementation.