### PR TITLE
Fix link to Introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Emacs, and Atom will have syntax packages for the Janet language, though.
 
 ## Installation
 
-See [the Introduction](https://janet-lang.org/docs/introduction.html) for more details. If you just want
+See the [Introduction](https://janet-lang.org/docs/index.html) for more details. If you just want
 to try out the language, you don't need to install anything. You can also move the `janet` executable wherever you want on your system and run it.
 
 ## Usage


### PR DESCRIPTION
As reported in #678, the link is still broken. The problem is that the file in the `/docs` directory is `index.html` not `introduction.html`. This corrects the link.