### PR TITLE
Use _NSGetEnviron() on Apple

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -56,7 +56,12 @@
 #include <dirent.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#ifdef JANET_APPLE
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+#else
 extern char **environ;
+#endif
 #ifdef JANET_THREADS
 #include <pthread.h>
 #endif


### PR DESCRIPTION
On Apple systems `NSGetEnviron` should be used instead of `extern char **environ`, for better compatibility (e.g. on older systems). See e.g. 

https://epics.anl.gov/tech-talk/2009/msg00536.php

for a discussion of the issue.

This PR makes the change. 