### PR TITLE
Add struct special-forms to root environment

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2891,6 +2891,14 @@
          (if d (doc-format d) "    no documentation found.")
          "\n\n"))
 
+(defn- print-special-entry
+  [sf]
+  (def d (in sf :doc))
+  (print "\n\n"
+         "    special form\n\n"
+         (if d (doc-format d) "    no documentation found.")
+         "\n\n"))
+
 (defn doc*
   "Get the documentation for a symbol in a given environment. Function form of doc."
   [&opt sym]
@@ -2900,18 +2908,20 @@
     (print-index (fn [x] (string/find sym x)))
 
     sym
-    (do
+    (cond
       (def x (dyn sym))
-      (if (not x)
-        (do
-          (def [fullpath mod-kind] (module/find (string sym)))
-          (if-let [mod-env (in module/cache fullpath)]
-            (print-module-entry {:module     true
-                                 :kind       mod-kind
-                                 :source-map [fullpath nil nil]
-                                 :doc        (in mod-env :doc)})
-            (print "symbol " sym " not found.")))
-        (print-module-entry x)))
+      (print-module-entry x)
+
+      (def sf (get special-forms sym))
+      (print-special-entry sf)
+
+      (if-let [[fullpath mod-kind] (module/find (string sym))
+               mod-env             (in module/cache fullpath)]
+        (print-module-entry {:module     true
+                             :kind       mod-kind
+                             :source-map [fullpath nil nil]
+                             :doc        (in mod-env :doc)})
+        (print "symbol " sym " not found.")))
 
     # else
     (print-index identity)))

--- a/src/core/compile.h
+++ b/src/core/compile.h
@@ -190,12 +190,16 @@ struct JanetFunOptimizer {
 struct JanetSpecial {
     const char *name;
     JanetSlot(*compile)(JanetFopts opts, int32_t argn, const Janet *argv);
+    const char *doc;
 };
 
 /****************************************************/
 
 /* Get an optimizer if it exists, otherwise NULL */
 const JanetFunOptimizer *janetc_funopt(uint32_t flags);
+
+/* Get the list of specials */
+extern const JanetSpecial janetc_specials[13];
 
 /* Get a special. Return NULL if none exists */
 const JanetSpecial *janetc_special(const uint8_t *name);

--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -1206,6 +1206,20 @@ JanetTable *janet_core_env(JanetTable *replacements) {
     janet_def(env, "root-env", janet_wrap_table(env),
               JDOC("The root environment used to create environments with (make-env)."));
 
+
+    // Create struct of special forms
+    int num_specials = (int) (sizeof(janetc_specials) / sizeof(JanetSpecial));
+    JanetKV *sfs = janet_struct_begin(num_specials);
+    for (int i = 0; i < num_specials; i++) {
+        JanetKV *sf = janet_struct_begin(1);
+        janet_struct_put(sf, janet_ckeywordv("doc"), janet_cstringv(janetc_specials[i].doc));
+        janet_struct_end(sf);
+        janet_struct_put(sfs, janet_csymbolv(janetc_specials[i].name), janet_wrap_struct(sf));
+    }
+    janet_struct_end(sfs);
+    janet_def(env, "special-forms", janet_wrap_struct(sfs),
+              JDOC("The special forms in Janet."));
+
     janet_load_libs(env);
     janet_gcroot(janet_wrap_table(env));
     return env;

--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -866,20 +866,104 @@ error2:
 }
 
 /* Keep in lexicographic order */
-static const JanetSpecial janetc_specials[] = {
-    {"break", janetc_break},
-    {"def", janetc_def},
-    {"do", janetc_do},
-    {"fn", janetc_fn},
-    {"if", janetc_if},
-    {"quasiquote", janetc_quasiquote},
-    {"quote", janetc_quote},
-    {"set", janetc_varset},
-    {"splice", janetc_splice},
-    {"unquote", janetc_unquote},
-    {"upscope", janetc_upscope},
-    {"var", janetc_var},
-    {"while", janetc_while}
+const JanetSpecial janetc_specials[] = {
+    {"break", janetc_break,
+     JDOC("(break value?)\n\n"
+          "Breaks from a while loop or return early from a function. The break "
+          "special form can only break from the inner-most loop. Since a while "
+          "loop always returns nil, the optional `value` parameter has no "
+          "effect when used in a while loop, but when returning from a "
+          "function, the value parameter is the function's return value.")},
+    {"def", janetc_def,
+     JDOC("(def name meta... value)\n\n"
+          "Binds a value to a symbol. The symbol can be substituted for the "
+          "value in subsequent expressions for the same result. A binding made "
+          "by def is a constant and cannot be updated. A symbol can be "
+          "redefined to a new value, but previous uses of the binding will "
+          "refer to the previous value of the binding.\n\n"
+          "def can also take a tuple, array, table or struct to perform "
+          "destructuring on the value, allowing multiple assignments in one "
+          "def. Metadata and a docstring can be appended to the symbol when in "
+          "the global scope. If not in the global scope, the extra metadata "
+          "will be ignored.")},
+    {"do", janetc_do,
+     JDOC("(do body...)\n\n"
+          "Executes a series of forms for side effects and evaluates to the "
+          "final form. Also introduces a new lexical scope without creating or "
+          "calling a function.")},
+    {"fn", janetc_fn,
+     JDOC("(fn name? args body...)\n\n"
+          "Compiles a function literal (closure). A function literal consists "
+          "of an optional name, an argument list, and a function body. The "
+          "optional name is allowed so that functions can more easily be "
+          "recursive. The argument list is a tuple of named parameters, and "
+          "the body is 0 or more forms. The function will evaluate to the last "
+          "form in the body. The other forms will only be evaluated for side "
+          "effects. Introduces a new lexical scope, meaning the defs and vars "
+          "inside a function body will not escape outside the body.")},
+    {"if", janetc_if,
+     JDOC("(if condition when-true when-false?)\n\n"
+          "Evaluates one of two branches depending on the value of the "
+          "condition. The first form is the condition, the second form is the "
+          "branch to evaluate when the condition is true, and the optional "
+          "third form is the form to evaluate when the condition is false. If "
+          "no third form is provided, the result of the false branch is nil.\n\n"
+          "The if special form will not evaluate the when-true or when-false "
+          "forms unless it needs to - it is a lazy form, which is why it cannot "
+          "be a function or macro.\n\n"
+          "The condition is considered false only if it evaluates to nil or "
+          "false - all other values are considered true.")},
+    {"quasiquote", janetc_quasiquote,
+     JDOC("(quasiquote x)\n\n"
+          "Aallows for unquoting within x unlike (quote x). This makes "
+          "quasiquote useful for writing macros, as a macro definition often "
+          "generates a lot of templated code with a few custom values. The "
+          "shorthand for quasiquote is ~x. Within the quasiquoted form, "
+          "(unquote x) will evaluate and insert x into the unquoted form. The "
+          "shorthand for (unquote x) is ,x.")},
+    {"quote", janetc_quote,
+     JDOC("(quote x)\n\n"
+          "Evaluates to the literal value of the first argument. The argument "
+          "is not compiled and is simply used as a constant value in the "
+          "compiled code. The shorthand for (quote x) is 'x.")},
+    {"set", janetc_varset,
+     JDOC("(set l-value r-value)\n\n"
+          "Updates the value of the var l-value with the new r-value. The set "
+          "special form will then evaluate to r-value. The r-value can be any "
+          "expression, and the l-value should be a bound var or a pair of a "
+          "data structure and key. This allows set to behave like setf or setq "
+          "in Common Lisp.")},
+    {"splice", janetc_splice,
+     JDOC("(splice x)\n\n"
+          "Allows an array or tuple to be put into another form inline. splice "
+          "only has an effect in two places: as an argument in a function call "
+          "or literal constructor, or as the argument to the unquote form. "
+          "Outside of these two settings, the splice special form simply "
+          "evaluates directly to its argument x. The shorthand for (splice x) "
+          "is ;x. splice has no effect on the behavior of other special forms, "
+          "except as an argument to unquote.")},
+    {"unquote", janetc_unquote,
+     JDOC("(unquote x)\n\n"
+          "Unquotes a form within a quasiquoted form. Outside of a quasiquoted "
+          "form, unquote is invalid.")},
+    {"upscope", janetc_upscope,
+     JDOC("(upscope & body)\n\n"
+          "Evaluates body and evaluates to the result of the last form. This "
+          "is similar to do. However, unlike do, upscope does not create a new "
+          "lexical scope, which means that bindings created inside it are "
+          "visible in the scope where upscope is declared. This is useful for "
+          "writing macros that make several def and var declarations at once.")},
+    {"var", janetc_var,
+     JDOC("(var name meta... value)\n\n"
+          "Binds a value similarly to def but the binding can be updated using "
+          "set. In all other respects it is the same as def.")},
+    {"while", janetc_while,
+     JDOC("(while condition body...)\n\n"
+          "Compiles to a C-like while loop. The body of the form will be "
+          "continuously evaluated until the condition is false or nil. "
+          "Therefore, it is expected that the body will contain some side "
+          "effects or the loop will continue forever. A while loop always "
+          "evaluates to nil.")}
 };
 
 /* Find a special */

--- a/src/mainclient/shell.c
+++ b/src/mainclient/shell.c
@@ -25,6 +25,7 @@
 #endif
 
 #include <janet.h>
+#include "../core/compile.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -513,18 +514,10 @@ static JanetByteView longest_common_prefix(void) {
 }
 
 static void check_specials(JanetByteView src) {
-    check_cmatch(src, "break");
-    check_cmatch(src, "def");
-    check_cmatch(src, "do");
-    check_cmatch(src, "fn");
-    check_cmatch(src, "if");
-    check_cmatch(src, "quasiquote");
-    check_cmatch(src, "quote");
-    check_cmatch(src, "set");
-    check_cmatch(src, "splice");
-    check_cmatch(src, "unquote");
-    check_cmatch(src, "var");
-    check_cmatch(src, "while");
+    int num_specials = (int) (sizeof(janetc_specials) / sizeof(JanetSpecial));
+    for(int i = 0; i < num_specials; i++) {
+        check_cmatch(src, janetc_specials[i].name);
+    }
 }
 
 static void resolve_format(JanetTable *entry) {

--- a/tools/tm_lang_gen.janet
+++ b/tools/tm_lang_gen.janet
@@ -2,23 +2,11 @@
 # Used to help build the tmLanguage grammar. Emits
 # the entire .tmLanguage file for janet.
 
-# Use dynamic binding and make this the first 
+# Use dynamic binding and make this the first
 # expression in the file to not pollute (all-bindings)
-(setdyn :allsyms  
-  (array/concat
-    @["break"
-      "def"
-      "do"
-      "var"
-      "set"
-      "fn"
-      "while"
-      "if"
-      "quote"
-      "quasiquote"
-      "unquote"
-      "splice"]
-    (all-bindings)))
+(setdyn :allsyms
+  (-> (map string (keys special-forms))
+      (array/concat (all-bindings))))
 (def allsyms (dyn :allsyms))
 
 (def grammar-template


### PR DESCRIPTION
This PR adds a `special-forms` struct to the root environment containing documentation for each form. The documentation is based on the wording used on the section of the Janet website explaining the special forms.

## Implementation

This commit generates a `special-forms` struct as part of the larger generation of the root environment in `src/core/corelib.c`. Each key in the struct is a symbol matching a special form. The value for each key is itself a struct containing a docstring under the `:doc` keyword.

To generate the `special-forms` value, the following changes were made:

1. update the `JanetSpecial` struct to include a `doc` member;
2. add docstrings to the `janetc_specials` array of `JanetSpecial` structs defined in `src/core/compile.c`;
3. expose the `janetc_specials` array via `src/core/compile.h`. 

The `doc` macro is updated to use the `special-forms` struct to display documentation for the special forms.

## Background

This PR was prompted by the work in #690.

Janet contains a number of special forms which are defined in the compiler. Currently, these forms are not accessible from 'within' Janet. Where references to the special forms are required, they must be hard-coded. This creates two problems:

* First, it is error-prone and can result in references becoming stale. An example of this is the `upscope` special form. It was added 1.13.1 but has not been added to the list of special forms in `tools/tm_lang_gen.janet`, nor has it been added to the list of special forms in `src/mainclient/shell.c`.

* Second, it means that certain introspective elements of Janet are 'blind' to the special forms. An example of this is in the `doc` macro which cannot return any documentation for the special forms since they are not part of the environment at all.

## Alternatives

1. **Use a checklist.** The number of special forms is unlikely to change frequently and it may be preferable to merely keep a checklist of references that should be manually updated when changes are made. This could be added to as a comment in `src/core/compile.c`. This will still require diligence to ensure that changes are kept up to date.

2. **Add individual bindings to the root environment.** Rather than encapsulating information on the special forms within a single value, separate bindings could be put into the root environment. However, it was not clear what value to assign in the `:value` key for these bindings and there was concern that this could give the impression that the bindings could be dynamically replaced (which would have no effect on the way Janet is compiled).