### PR TITLE
Add TerminateProcess to janet_proc_gc and os_proc_kill on Windows

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -434,6 +434,7 @@ static int janet_proc_gc(void *p, size_t s) {
     JanetProc *proc = (JanetProc *) p;
 #ifdef JANET_WINDOWS
     if (!(proc->flags & JANET_PROC_CLOSED)) {
+        TerminateProcess(proc->pHandle, 1);
         CloseHandle(proc->pHandle);
         CloseHandle(proc->tHandle);
     }
@@ -519,6 +520,7 @@ static Janet os_proc_kill(int32_t argc, Janet *argv) {
         janet_panicf("cannot close process handle that is already closed");
     }
     proc->flags |= JANET_PROC_CLOSED;
+    TerminateProcess(proc->pHandle, 1);
     CloseHandle(proc->pHandle);
     CloseHandle(proc->tHandle);
 #else

--- a/test/suite0009.janet
+++ b/test/suite0009.janet
@@ -47,6 +47,11 @@
   (assert-no-error "pipe stdin to process 2" (os/proc-wait p))
   (assert (= "hello!" (string/trim x)) "round trip pipeline in process"))
 
+(let [p (os/spawn [janet "-e" `(do (ev/sleep 30) (os/exit 24)`] :p)]
+  (os/proc-kill p)
+  (def retval (os/proc-wait p))
+  (assert (not= retval 24) "Process was *not* terminated by parent"))
+
 # Parallel subprocesses
 
 (defn calc-1


### PR DESCRIPTION
On windows, nothing was called that would actually terminate a process. I diagnosed this by writing a file-watcher on windows that ran osprey servers.

This should also fix a long-running issue with Janitor