### PR TITLE
Tweak docstring for math/rng-uniform

### DIFF
--- a/src/core/math.c
+++ b/src/core/math.c
@@ -141,7 +141,7 @@ JANET_CORE_FN(cfun_rng_make,
 
 JANET_CORE_FN(cfun_rng_uniform,
               "(math/rng-uniform rng)",
-              "Extract a random integer in the range [0, 1) from the RNG."
+              "Extract a random number in the range [0, 1) from the RNG."
              ) {
     janet_fixarity(argc, 1);
     JanetRNG *rng = janet_getabstract(argv, 0, &janet_rng_type);

--- a/src/core/math.c
+++ b/src/core/math.c
@@ -141,8 +141,7 @@ JANET_CORE_FN(cfun_rng_make,
 
 JANET_CORE_FN(cfun_rng_uniform,
               "(math/rng-uniform rng)",
-              "Extract a random random integer in the range [0, max] from the RNG. If "
-              "no max is given, the default is 2^31 - 1."
+              "Extract a random integer in the range [0, 1) from the RNG."
              ) {
     janet_fixarity(argc, 1);
     JanetRNG *rng = janet_getabstract(argv, 0, &janet_rng_type);


### PR DESCRIPTION
The older docstring from https://github.com/janet-lang/janet/blob/617da2494228f9a587ae613d3fad522dca968f8c/src/core/math.c#L431 looks closer to the actual behavior:
```
Janet 1.17.0-dev-c94d7574 linux/x64 - '(doc)' for help
repl:1:> (math/rng-uniform (math/rng (os/cryptorand 3)))
0.43143
repl:2:> (math/rng-uniform (math/rng (os/cryptorand 3)))
0.106315
repl:3:> (math/rng-uniform (math/rng (os/cryptorand 3)))
0.0975404
```