### PR TITLE
Use GitHub Workflow to create release (including building for Linux and macOS)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set the version
         run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - name: Set the platform
-        run: echo "platform=${RUNNER_OS,,}" >> $GITHUB_ENV
+        run: echo "platform=$(tr '[A-Z]' '[a-z]' <<< $RUNNER_OS)" >> $GITHUB_ENV
       - name: Compile the project
         run: make clean && make
       - name: Build the artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Compile the project
         run: make clean && make
       - name: Build the artifact
-        run: make build/janet-${{ env.version }}-${{ env.platform }}-x64.tar.gz
+        run: JANET_DIST_DIR=janet-${{ env.version }}-${{ env.platform }} make build/janet-${{ env.version }}-${{ env.platform }}-x64.tar.gz
       - name: Draft the release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+
+  release:
+    name: Build release binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@master
+      - name: Set the version
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      - name: Set the platform
+        run: echo "platform=${RUNNER_OS,,}" >> $GITHUB_ENV
+      - name: Compile the project
+        run: make clean && make
+      - name: Build the artifact
+        run: make build/janet-${{ env.version }}-${{ env.platform }}-x64.tar.gz
+      - name: Draft the release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: |
+            build/*.gz
+            build/janet.h
+            build/c/janet.c
+            build/c/shell.c


### PR DESCRIPTION
This PR includes a GitHub workflow that will create a draft release when a tag of the form `v*.*.*` is pushed to the GitHub repository. Importantly, it creates builds for Linux and macOS (both on x64 architecture).

You can see the result of a published release on [my fork](https://github.com/pyrmont/janet/releases/tag/v1.17.1). I'll delete that tag in time so for future reference, this is what it looked at the time of this PR:
<img width="1235" alt="Screenshot" src="https://user-images.githubusercontent.com/41152/130402084-e6bd9ba5-8a66-46cb-8e3c-88219bbeeef9.png">

A few points to note:

1. The tarballs are generated using the command `make build/janet-<tagname>-<platform>-x64.tar.gz` and so archive to a file that includes the platform architecture `x64`. This is different from previous tarballs that were only in the form `janet-<tagname>-<platform>.tar.gz`.

2. Currently, the release is created in draft and needs to be manually published. It is possible to completely automate a release. The workflow relies on the [GH Release](https://github.com/marketplace/actions/gh-release) action and supports automatic publishing (with custom release notes).

3. GitHub Workflows can be run on Windows (see the [list of supported OSs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners)). In theory this means that Windows builds could be created via this Workflow. I didn't look into the practicality of that.

4. Currently, GitHub records the release as being published by @github-actions. It is possible to publish as a user (e.g. @bakpakin) but that requires creating a GitHub token. More information is available in [this issue](https://github.com/softprops/action-gh-release/issues/148).

If accepted, this fixes #769.