### PR TITLE
Add GitHub Workflow to test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+
+  test-posix:
+    name: Build and test on POSIX systems
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@master
+      - name: Compile the project
+        run: make clean && make
+      - name: Test the project
+        run: make test
+
+  test-windows:
+    name: Build and test on Windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@master
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Build the project
+        shell: cmd
+        run: build_win
+      - name: Test the project
+        shell: cmd
+        run: build_win test


### PR DESCRIPTION
This PR adds a GitHub workflow that will build and test Janet on Linux, macOS and Windows whenever any commits are pushed to this GitHub repository or whenever a pull request is opened.

You can see the result of a [test run](https://github.com/pyrmont/janet/actions/runs/1164837908) on my fork.

A few points to note:

1. The OSs run on x64 architecture. I haven't looked into this but my understanding is that if you want to run on other architectures, the workflow would need to create Docker instances for those other architectures.

2. GitHub only natively supports Linux, macOS and Windows. If you want to test on other operating systems (e.g. BSD), I think that also has to be done via Docker instance.

3. GitHub Workflows do [have limits](https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration#about-billing-for-github-actions). The limits are pretty generous in my experience but depending on how frequently the workflow is being run, it might be worth limiting it to pushes and pull request to the master branch. I'd probably run it like this for a while and adjust as necessary.