### PR TITLE
Fix typos in ev/go ev/select

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3375,7 +3375,7 @@
     ~(,ev/thread (fiber/new (fn _thread [&] ,;body) :t)))
 
   (defmacro ev/spawn-thread
-    ``Run some code in a new thread. Like `ev/do-thread`, but returns immediately with a fiber.``
+    ``Run some code in a new thread. Like `ev/do-thread`, but returns nil immediately.``
     [& body]
     ~(,ev/thread (fiber/new (fn _thread [&] ,;body) :t) nil :n))
 

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -943,7 +943,7 @@ JANET_CORE_FN(cfun_channel_pop,
 JANET_CORE_FN(cfun_channel_choice,
               "(ev/select & clauses)",
               "Block until the first of several channel operations occur. Returns a tuple of the form [:give chan], [:take chan x], or [:close chan], where "
-              "a :give tuple is the result of a write and :take tuple is the result of a write. Each clause must be either a channel (for "
+              "a :give tuple is the result of a write and :take tuple is the result of a read. Each clause must be either a channel (for "
               "a channel take operation) or a tuple [channel x] for a channel give operation. Operations are tried in order, such that the first "
               "clauses will take precedence over later clauses. Both and give and take operations can return a [:close chan] tuple, which indicates that "
               "the specified channel was closed while waiting, or that the channel was already closed.") {
@@ -2438,7 +2438,7 @@ JANET_CORE_FN(cfun_ev_go,
               "(ev/go fiber &opt value supervisor)",
               "Put a fiber on the event loop to be resumed later. Optionally pass "
               "a value to resume with, otherwise resumes with nil. Returns the fiber. "
-              "An optional `core/channel` can be provided as well as a supervisor. When various "
+              "An optional `core/channel` can be provided as a supervisor. When various "
               "events occur in the newly scheduled fiber, an event will be pushed to the supervisor. "
               "If not provided, the new fiber will inherit the current supervisor.") {
     janet_arity(argc, 1, 3);


### PR DESCRIPTION
I also have found that for `ev/close`, you mention the `(:close stream)` method. It could be good to have it mentioned for some other functions, not only in the `ev` module. If you think so too, I volunteer for the addition.