### PR TITLE
Add kqueue support to Janet

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -73,6 +73,7 @@ conf.set('JANET_NO_REALPATH', not get_option('realpath'))
 conf.set('JANET_NO_PROCESSES', not get_option('processes'))
 conf.set('JANET_SIMPLE_GETLINE', get_option('simple_getline'))
 conf.set('JANET_EV_NO_EPOLL', not get_option('epoll'))
+conf.set('JANET_EV_NO_KQUEUE', not get_option('kqueue'))
 conf.set('JANET_NO_THREADS', get_option('threads'))
 conf.set('JANET_NO_INTERPRETER_INTERRUPT', not get_option('interpreter_interrupt'))
 if get_option('os_name') != ''

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,6 +18,7 @@ option('umask', type : 'boolean', value : true)
 option('realpath', type : 'boolean', value : true)
 option('simple_getline', type : 'boolean', value : false)
 option('epoll', type : 'boolean', value : false)
+option('kqueue', type : 'boolen', value : false)
 option('interpreter_interrupt', type : 'boolean', value : false)
 
 option('recursion_guard', type : 'integer', min : 10, max : 8000, value : 1024)

--- a/src/conf/janetconf.h
+++ b/src/conf/janetconf.h
@@ -48,6 +48,7 @@
 /* #define JANET_OS_NAME my-custom-os */
 /* #define JANET_ARCH_NAME pdp-8 */
 /* #define JANET_EV_NO_EPOLL */
+/* #define JANET_EV_NO_KQUEUE */
 /* #define JANET_NO_INTERPRETER_INTERRUPT */
 
 /* Custom vm allocator support */

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1679,7 +1679,11 @@ void janet_loop1_impl(int has_timeout, JanetTimestamp timeout) {
 
     struct kevent timer;
     if (janet_vm.timer_enabled || has_timeout) {
-        EV_SET(&timer, JANET_KQUEUE_TIMER_IDENT, EVFILT_TIMER, EV_ADD | EV_ENABLE | EV_CLEAR, NOTE_MSECONDS, timeout, &janet_vm.timer);
+        EV_SET(&timer,
+               JANET_KQUEUE_TIMER_IDENT,
+               EVFILT_TIMER,
+               EV_ADD | EV_ENABLE | EV_CLEAR,
+               NOTE_MSECONDS | NOTE_ABSTIME, timeout, &janet_vm.timer);
         add_kqueue_events(&timer, 1);
     }
     janet_vm.timer_enabled = has_timeout;

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1615,10 +1615,25 @@ JanetListenerState *janet_listen(JanetStream *stream, JanetListener behavior, in
     struct kevent kev[2];
     /* NOTE: NetBSD uses a different type for udata, might not work there or
      * may warn! */
+    /* Disabled, may be incorrect
     EV_SET(&kev[0], stream->handle, EVFILT_READ, EV_ADD | (state->stream->_mask & JANET_ASYNC_LISTEN_READ ? EV_ENABLE : EV_DISABLE), 0, 0, stream);
     EV_SET(&kev[1], stream->handle, EVFILT_WRITE, EV_ADD | (state->stream->_mask & JANET_ASYNC_LISTEN_WRITE ? EV_ENABLE : EV_DISABLE), 0, 0, stream);
+    */
 
-    add_kqueue_events(kev, 2);
+    int length = 0;
+    if (state->stream->_mask & JANET_ASYNC_LISTEN_READ) {
+        EV_SET(&kev[length], stream->handle, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, stream);
+        length++;
+    }
+    if (state->stream->_mask & JANET_ASYNC_LISTEN_WRITE) {
+        EV_SET(&kev[length], stream->handle, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, stream);
+        length++;
+    }
+
+    if (length > 0) {
+        add_kqueue_events(kev, length);
+    }
+
     return state;
 }
 

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1597,7 +1597,7 @@ void add_kqueue_events(const struct kevent *events, int length) {
      * note that kqueue actually does this. We do not do this at this time.  */
     int status;
     status = kevent(janet_vm.kq, events, length, NULL, 0, NULL);
-    if(status == -1 && errno != EINTR)
+    if (status == -1 && errno != EINTR)
         janet_panicv(janet_ev_lasterr());
 }
 
@@ -1626,9 +1626,9 @@ JanetListenerState *janet_listen(JanetStream *stream, JanetListener behavior, in
 
 static void janet_unlisten(JanetListenerState *state, int is_gc) {
     JanetStream *stream = state->stream;
-    if(!(stream->flags & JANET_STREAM_CLOSED)) {
+    if (!(stream->flags & JANET_STREAM_CLOSED)) {
         /* Use flag to indicate state is not registered in kqueue */
-        if(!(state->_mask & (1 << JANET_ASYNC_EVENT_COMPLETE))) {
+        if (!(state->_mask & (1 << JANET_ASYNC_EVENT_COMPLETE))) {
             int is_last = (state->_next == NULL && stream->state == state);
             int op = is_last ? EV_DELETE : EV_DISABLE | EV_ADD;
             struct kevent kev[2];
@@ -1673,13 +1673,13 @@ void janet_loop1_impl(int has_timeout, JanetTimestamp timeout) {
     do {
         status = kevent(janet_vm.kq, NULL, 0, events, JANET_KQUEUE_MAX_EVENTS, NULL);
     } while (status == -1 && errno == EINTR);
-    if(status == -1)
+    if (status == -1)
         JANET_EXIT("failed to poll events");
 
     /* Step state machines */
-    for(int i = 0; i < status; i++) {
+    for (int i = 0; i < status; i++) {
         void *p = events[i].udata;
-        if(&janet_vm.timer == p) {
+        if (&janet_vm.timer == p) {
             /* Timer expired, ignore */;
         } else if (janet_vm.selfpipe == p) {
             /* Self-pipe handling */
@@ -1703,7 +1703,7 @@ void janet_loop1_impl(int has_timeout, JanetTimestamp timeout) {
                 } else {
                     statuses[2] = state->machine(state, JANET_ASYNC_EVENT_ERR);
                 }
-                if(statuses[0] == JANET_ASYNC_STATUS_DONE ||
+                if (statuses[0] == JANET_ASYNC_STATUS_DONE ||
                    statuses[1] == JANET_ASYNC_STATUS_DONE ||
                    statuses[2] == JANET_ASYNC_STATUS_DONE ||
                    statuses[3] == JANET_ASYNC_STATUS_DONE)

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1661,7 +1661,7 @@ static void janet_unlisten(JanetListenerState *state, int is_gc) {
                 length++;
             }
 
-            add_kqueue_events(kev, 2);
+            add_kqueue_events(kev, length);
         }
     }
     janet_unlisten_impl(state, is_gc);

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1679,17 +1679,17 @@ void janet_loop1_impl(int has_timeout, JanetTimestamp timeout) {
                 statuses[i] = JANET_ASYNC_STATUS_NOT_DONE;
 
             if (events[i].filter == EVFILT_WRITE)
-                status[0] = state->machine(state, JANET_ASYNC_EVENT_WRITE);
+                statuses[0] = state->machine(state, JANET_ASYNC_EVENT_WRITE);
             if (events[i].filter == EVFILT_READ)
-                status[1] = state->machine(state, JANET_ASYNC_EVENT_READ);
+                statuses[1] = state->machine(state, JANET_ASYNC_EVENT_READ);
             if (events[i].flags & EV_ERROR)
-                status[2] = state->machine(state, JANET_ASYNC_EVENT_ERR);
+                statuses[2] = state->machine(state, JANET_ASYNC_EVENT_ERR);
             if ((events[i].flags & EV_EOF) && !(events[i].data > 0))
-                status[3] = state->maine(state, JANET_ASYNC_EVENT_HUP);
-            if(status[0] == JANET_ASYNC_STATUS_DONE ||
-                   status[1] == JANET_ASYNC_STATUS_DONE ||
-                   status[2] == JANET_ASYNC_STATUS_DONE ||
-                   status[3] == JANET_ASYNC_STATUSDONE)
+                statuses[3] = state->maine(state, JANET_ASYNC_EVENT_HUP);
+            if(statuses[0] == JANET_ASYNC_STATUS_DONE ||
+                   statuses[1] == JANET_ASYNC_STATUS_DONE ||
+                   statuses[2] == JANET_ASYNC_STATUS_DONE ||
+                   statuses[3] == JANET_ASYNC_STATUS_DONE)
                 janet_unlisten(state, 0);
         }
     }

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1609,8 +1609,6 @@ JanetListenerState *janet_listen(JanetStream *stream, JanetListener behavior, in
     JanetListenerState *state = janet_listen_impl(stream, behavior, mask, size, user);
     struct kevent kev[2];
 
-    /* NOTE: NetBSD uses a different type for udata, might not work there or
-     * may warn/fail to compile (see wahern/cqueues)! */
     int length = 0;
     if (state->stream->_mask & JANET_ASYNC_LISTEN_READ) {
         EV_SETx(&kev[length], stream->handle, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, stream);

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1602,11 +1602,12 @@ void add_kqueue_events(const struct kevent *events, int length) {
     status = kevent(janet_vm.kq, events, length, NULL, 0, NULL);
     if(status == -1 && errno != EINTR)
         janet_panicv(janet_ev_lasterr());
+    /* Disabling this for now, probably is wrong, haven't seen it done elsewhere
     for(int i = 0; i < length; i++) {
         if((events[i].flags & EV_ERROR) && events[i].data != EINTR) {
             janet_panicv(janet_ev_lasterr());
         }
-    }
+    }*/
 }
 
 JanetListenerState *janet_listen(JanetStream *stream, JanetListener behavior, int mask, size_t size, void *user) {

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1704,9 +1704,9 @@ void janet_loop1_impl(int has_timeout, JanetTimestamp timeout) {
                     statuses[2] = state->machine(state, JANET_ASYNC_EVENT_ERR);
                 }
                 if (statuses[0] == JANET_ASYNC_STATUS_DONE ||
-                   statuses[1] == JANET_ASYNC_STATUS_DONE ||
-                   statuses[2] == JANET_ASYNC_STATUS_DONE ||
-                   statuses[3] == JANET_ASYNC_STATUS_DONE)
+                        statuses[1] == JANET_ASYNC_STATUS_DONE ||
+                        statuses[2] == JANET_ASYNC_STATUS_DONE ||
+                        statuses[3] == JANET_ASYNC_STATUS_DONE)
                     janet_unlisten(state, 0);
             }
         }

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1694,7 +1694,7 @@ void janet_loop1_impl(int has_timeout, JanetTimestamp timeout) {
 
     /* Step state machines */
     for (int i = 0; i < status; i++) {
-        void *p = events[i].udata;
+        void *p = (void*) events[i].udata;
         if (&janet_vm.timer == p) {
             /* Timer expired, ignore */;
         } else if (janet_vm.selfpipe == p) {
@@ -1736,7 +1736,9 @@ void janet_ev_init(void) {
     janet_vm.timer_enabled = 0;
     if (janet_vm.kq == -1) goto error;
     struct kevent events[2];
-    EV_SETx(&events[0], JANET_KQUEUE_TIMER_IDENT, EVFILT_TIMER, JANET_KQUEUE_TF, NOTE_MSECONDS, JANET_KQUEUE_TS(0), &janet_vm.timer);
+    /* Don't use JANET_KQUEUE_TS here, as even under FreeBSD we use intervals
+     * here. */
+    EV_SETx(&events[0], JANET_KQUEUE_TIMER_IDENT, EVFILT_TIMER, JANET_KQUEUE_TF, NOTE_MSECONDS, 0, &janet_vm.timer);
     EV_SETx(&events[1], janet_vm.selfpipe[0], EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, janet_vm.selfpipe);
     add_kqueue_events(events, 2);
     return;

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1601,10 +1601,10 @@ void add_kqueue_events(const struct kevent *events, int length) {
     int status;
     status = kevent(janet_vm.kq, events, length, NULL, 0, NULL);
     if(status == -1 && errno != EINTR)
-        exit(-1); /* do a better exit */
+        janet_panicv(janet_ev_lasterr());
     for(int i = 0; i < length; i++) {
         if((events[i].flags & EV_ERROR) && events[i].data != EINTR) {
-            exit(-1); /* do a better exit */
+            janet_panicv(janet_ev_lasterr());
         }
     }
 }

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -171,6 +171,11 @@ struct JanetVM {
     int epoll;
     int timerfd;
     int timer_enabled;
+#elif defined(JANET_EV_KQUEUE)
+    JanetHandle selfpipe[2];
+    int kq;
+    int timer;
+    int timer_enabled
 #else
     JanetHandle selfpipe[2];
     struct pollfd *fds;

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -175,7 +175,7 @@ struct JanetVM {
     JanetHandle selfpipe[2];
     int kq;
     int timer;
-    int timer_enabled
+    int timer_enabled;
 #else
     JanetHandle selfpipe[2];
     struct pollfd *fds;

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -198,7 +198,13 @@ extern "C" {
 #define JANET_EV_EPOLL
 #endif
 
+/* Enable or disable kqueue on BSD */
 #if defined(JANET_BSD) && !defined(JANET_EV_NO_KQUEUE)
+#define JANET_EV_KQUEUE
+#endif
+
+/* Enable or disable kqueue on Apple */
+#if defined(JANET_APPLE) && !defined(JANET_EV_NO_KQUEUE)
 #define JANET_EV_KQUEUE
 #endif
 

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -198,7 +198,6 @@ extern "C" {
 #define JANET_EV_EPOLL
 #endif
 
-/* TODO: Probably breaks NetBSD, might need help here. */
 #if defined(JANET_BSD) && !defined(JANET_EV_NO_KQUEUE)
 #define JANET_EV_KQUEUE
 #endif

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -198,6 +198,11 @@ extern "C" {
 #define JANET_EV_EPOLL
 #endif
 
+/* TODO: Probably breaks NetBSD, might need help here. */
+#if defined(JANET_BSD) && !defined(JANET_EV_NO_KQUEUE)
+#define JANET_EV_KQUEUE
+#endif
+
 /* How to export symbols */
 #ifndef JANET_API
 #ifdef JANET_WINDOWS


### PR DESCRIPTION
~~Note that this is in no way ready for merge. I'm sort of seeking guidance/comments as to this whilst I make it ready for merging.~~

~~This seeks to add kqueue support to Janet for *BSD.~~ ~~I already know there are probably logic errors and at least one case of probably should not compile (latter with regards to NetBSD).~~

~~I'm hoping I can have a little help getting this ready for merging especially as there are parts of the Janet code base where I'm pretty sure I've come to wrong assumptions or simply don't know how it works.~~

~~Welcoming all comments, suggestions, and aid.~~

**EDIT**:
Ready for merge (passes all tests).

This adds kqueue support to Janet for *BSD (see notes below). Would fix #784.

*NOTE*:
~~Might need this tested on other BSD's, otherwise if no one can I may want to change things so it only gets compiled in under FreeBSD.~~ ~~In passing I saw a note about NetBSD using a different pointer type for the `udata` field in `struct kevent` but I actually referred to NetBSD's man page here and there and did not note that as documented!~~ ~~This should work under NetBSD which is the only system with a differently defined kevent struct.~~ We borrowed a macro from [wahern/cqueues](https://github.com/wahern/cqueues/blob/master/src/lib/kpoll.c) that casts to the underlying type for the `.udata` field in kevent structs for this purpose. ~~Should work under OpenBSD since the kevent struct is the same as FreeBSD.~~ ~~There may be subtle issues for Mac OS X and I don't believe this code should be active for it unless someone works on it to make sure it works. I've read in passing that Mac OS X has a buggy kqueue implementation.~~ No known issues on MacOS.

*NOTE*:
~~Broke on OpenBSD - NOTE_MSECONDS, NOTE_ABSTIME undefined!~~

Now works on FreeBSD, NetBSD, OpenBSD, and MacOS. Is DragonFly a supported BSD target?