### PR TITLE
Add bind option to net/connect

### DIFF
--- a/src/core/net.c
+++ b/src/core/net.c
@@ -376,10 +376,12 @@ JANET_CORE_FN(cfun_net_sockaddr,
 }
 
 JANET_CORE_FN(cfun_net_connect,
-              "(net/connect host port &opt type)",
+              "(net/connect host port &opt type bindhost)",
               "Open a connection to communicate with a server. Returns a duplex stream "
               "that can be used to communicate with the server. Type is an optional keyword "
-              "to specify a connection type, either :stream or :datagram. The default is :stream. ") {
+              "to specify a connection type, either :stream or :datagram. The default is :stream. "
+              "Bindhost is an optional string to select from what address to make the outgoing "
+              "connection, with the default being the same as using the OS's preferred address. ") {
     janet_arity(argc, 2, 4);
 
     int socktype = janet_get_sockettype(argv, argc, 2);

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -302,8 +302,7 @@ static struct addrinfo *janet_get_addrinfo(Janet *argv, int32_t offset, int sock
          * specify from where we connect, and in general don't care about a
          * port */
         int32_t current_offset = 3;
-        if (janet_keyeq(argv[current_offset], "stream") ||
-            janet_keyeq(argv[current_offset], "datagram")) {
+        if (janet_checktype(argv[3], JANET_KEYWORD)) {
            current_offset = 4;
         }
         host = (char *)janet_getcstring(argv, current_offset);
@@ -419,12 +418,9 @@ JANET_CORE_FN(cfun_net_connect,
         }
     }
 
-    /* TODO: check if need bind and bind! */
     ai = NULL;
     if (argc >= 3 && is_unix == 0) {
-        if (argc == 4 ||
-            (!janet_keyeq(argv[3], "stream") &&
-             !janet_keyeq(argv[3], "datagram"))) {
+        if (argc == 4 || !janet_checktype(argv[3], JANET_KEYWORD)) {
             ai = janet_get_addrinfo(argv, 0, socktype, 0, &is_unix, 1);
         }
     }

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -304,7 +304,7 @@ static struct addrinfo *janet_get_addrinfo(Janet *argv, int32_t offset, int sock
          * specify from where we connect, and in general don't care about a
          * port */
         int32_t current_offset = 3;
-        if (janet_checktype(argv[3], JANET_KEYWORD)) {
+        if (janet_checktype(argv[2], JANET_KEYWORD)) {
            current_offset = 4;
         }
         host = (char *)janet_getcstring(argv, current_offset);
@@ -422,7 +422,7 @@ JANET_CORE_FN(cfun_net_connect,
 
     ai = NULL;
     if (argc >= 3 && is_unix == 0) {
-        if (argc == 4 || !janet_checktype(argv[3], JANET_KEYWORD)) {
+        if (argc == 4 || !janet_checktype(argv[2], JANET_KEYWORD)) {
             ai = janet_get_addrinfo(argv, 0, socktype, 0, &is_unix, 1);
         }
     }

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -429,23 +429,25 @@ JANET_CORE_FN(cfun_net_connect,
         }
     }
 
-    /* Check all addrinfos in a loop for the first that we can bind to. */
-    struct addrinfo *rp = NULL;
-    for (rp = ai; rp != NULL; rp = rp->ai_next) {
+    if (ai != NULL) {
+        /* Check all addrinfos in a loop for the first that we can bind to. */
+        struct addrinfo *rp = NULL;
+        for (rp = ai; rp != NULL; rp = rp->ai_next) {
 #ifdef JANET_WINDOWS
-        sock = WSASocketW(rp->ai_family, rp->ai_socktype | JSOCKFLAGS, rp->ai_protocol, NULL, 0, WSA_FLAG_OVERLAPPED);
+            sock = WSASocketW(rp->ai_family, rp->ai_socktype | JSOCKFLAGS, rp->ai_protocol, NULL, 0, WSA_FLAG_OVERLAPPED);
 #else
-        sock = socket(rp->ai_family, rp->ai_socktype | JSOCKFLAGS, rp->ai_protocol);
+            sock = socket(rp->ai_family, rp->ai_socktype | JSOCKFLAGS, rp->ai_protocol);
 #endif
-        if (!JSOCKVALID(sock)) continue;
+            if (!JSOCKVALID(sock)) continue;
 
-        /* Bind */
-        if (bind(sock, rp->ai_addr, (int) rp->ai_addrlen) == 0) break;
-        JSOCKCLOSE(sock);
-    }
-    freeaddrinfo(ai);
-    if (NULL == rp) {
-        janet_panic("could not bind outgoing address");
+            /* Bind */
+            if (bind(sock, rp->ai_addr, (int) rp->ai_addrlen) == 0) break;
+            JSOCKCLOSE(sock);
+        }
+        freeaddrinfo(ai);
+        if (NULL == rp) {
+            janet_panic("could not bind outgoing address");
+        }
     }
 
     /* Connect to socket */

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -445,7 +445,7 @@ JANET_CORE_FN(cfun_net_connect,
     }
     freeaddrinfo(ai);
     if (NULL == rp) {
-        janet_panic("could not bind to any sockets");
+        janet_panic("could not bind outgoing address");
     }
 
     /* Connect to socket */

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -420,17 +420,18 @@ JANET_CORE_FN(cfun_net_connect,
         }
     }
 
-    ai = NULL;
+    /* Check if we're binding address */
+    struct addrinfo *binding = NULL;
     if (argc >= 3 && is_unix == 0) {
         if (argc == 4 || !janet_checktype(argv[2], JANET_KEYWORD)) {
-            ai = janet_get_addrinfo(argv, 0, socktype, 0, &is_unix, 1);
+            binding = janet_get_addrinfo(argv, 0, socktype, 0, &is_unix, 1);
         }
     }
 
-    if (ai != NULL) {
+    if (binding != NULL) {
         /* Check all addrinfos in a loop for the first that we can bind to. */
         struct addrinfo *rp = NULL;
-        for (rp = ai; rp != NULL; rp = rp->ai_next) {
+        for (rp = binding; rp != NULL; rp = rp->ai_next) {
 #ifdef JANET_WINDOWS
             sock = WSASocketW(rp->ai_family, rp->ai_socktype | JSOCKFLAGS, rp->ai_protocol, NULL, 0, WSA_FLAG_OVERLAPPED);
 #else
@@ -442,7 +443,7 @@ JANET_CORE_FN(cfun_net_connect,
             if (bind(sock, rp->ai_addr, (int) rp->ai_addrlen) == 0) break;
             JSOCKCLOSE(sock);
         }
-        freeaddrinfo(ai);
+        freeaddrinfo(binding);
         if (NULL == rp) {
             janet_panic("could not bind outgoing address");
         }

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -248,7 +248,9 @@ JANET_NO_RETURN static void janet_sched_accept(JanetStream *stream, JanetFunctio
 /* Adress info */
 
 static int janet_get_sockettype(Janet *argv, int32_t argc, int32_t n) {
-    JanetKeyword stype = janet_optkeyword(argv, argc, n, NULL);
+    JanetKeyword stype = NULL;
+    if(janet_checktype(argv[n], JANET_KEYWORD))
+        stype = janet_optkeyword(argv, argc, n, NULL);
     int socktype = SOCK_DGRAM;
     if ((NULL == stype) || !janet_cstrcmp(stype, "stream")) {
         socktype = SOCK_STREAM;

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -301,12 +301,7 @@ static struct addrinfo *janet_get_addrinfo(Janet *argv, int32_t offset, int sock
         /* when is_bind is set, we're performing a connect, but wanting to
          * specify from where we connect, and in general don't care about a
          * port */
-        /* TODO: remove check, argv[3] is where our bindhost is at! */
-        int32_t current_offset = 2;
-        if (janet_checktype(argv[current_offset], JANET_KEYWORD)) {
-           current_offset++;
-        }
-        host = (char *)janet_getcstring(argv, current_offset);
+        host = (char *)janet_getcstring(argv, 3);
         port = NULL;
         err = "could not get address info for connect bind: %s";
     }

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -303,9 +303,9 @@ static struct addrinfo *janet_get_addrinfo(Janet *argv, int32_t offset, int sock
         /* when is_bind is set, we're performing a connect, but wanting to
          * specify from where we connect, and in general don't care about a
          * port */
-        int32_t current_offset = 3;
-        if (janet_checktype(argv[2], JANET_KEYWORD)) {
-           current_offset = 4;
+        int32_t current_offset = 2;
+        if (janet_checktype(argv[current_offset], JANET_KEYWORD)) {
+           current_offset++;
         }
         host = (char *)janet_getcstring(argv, current_offset);
         port = NULL;


### PR DESCRIPTION
This will allow us to set the address we use for outgoing connections.

**All current tests pass**, works as intended as well.

Fixes #787 