### PR TITLE
Work in progress - more socket functions

### DIFF
--- a/src/core/net.c
+++ b/src/core/net.c
@@ -744,7 +744,6 @@ static Janet janet_so_getname(const struct sockaddr_storage *ss, socklen_t slen)
             if (slen > offsetof(struct sockaddr_un, sun_path)) {
                 struct sockaddr_un *sun = (struct sockaddr_un *)ss;
                 char *pe = (char *)sun + SO_MIN(sizeof * sun, slen);
-                size_t plen;
 
                 while (pe > sun->sun_path && pe[-1] == '\0')
                     --pe;

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -788,7 +788,7 @@ JANET_CORE_FN(cfun_net_getsockname,
     memset(&ss, 0, slen);
 
     int error;
-    if (0 != (error = getsockname(js->handle, (struct sockaddr *) &ss, &slen)))
+    if (0 != (error = getsockname((JSock)js->handle, (struct sockaddr *) &ss, &slen)))
         janet_panicf("Failed to get peername on fd %d, error: %s", js->handle, janet_ev_lasterr());
 
     return janet_so_getname(&ss, slen);
@@ -805,7 +805,7 @@ JANET_CORE_FN(cfun_net_getpeername,
     memset(&ss, 0, slen);
 
     int error;
-    if (0 != (error = getpeername(js->handle, (struct sockaddr *)&ss, &slen))) {
+    if (0 != (error = getpeername((JSock)js->handle, (struct sockaddr *)&ss, &slen))) {
         janet_panicf("Failed to get peername on fd %d, error: %s", js->handle, janet_ev_lasterr());
     }
 

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -720,7 +720,7 @@ static inline void *sa_aton_(void *dst, size_t lim, const char *src) {
 }
 */
 
-static JanetString janet_so_getname(const struct sockaddr_storage *ss, socklen_t slen) {
+static Janet janet_so_getname(const struct sockaddr_storage *ss, socklen_t slen) {
     uint8_t *hn = NULL;
     uint16_t hp = 0;
     size_t plen = SA_ADDRSTRLEN;
@@ -760,7 +760,15 @@ static JanetString janet_so_getname(const struct sockaddr_storage *ss, socklen_t
             break;
     }
 
-    return janet_string(hn, plen + 1);
+    Janet name[2];
+    int32_t len = 1;
+    name[0] = janet_wrap_string(janet_cstring((const char *)hn));
+    if (hp > 0) {
+        len++;
+        name[1] = janet_wrap_integer(hp);
+    }
+
+    return janet_wrap_tuple(janet_tuple_n(name, len));
 }
 
 JANET_CORE_FN(cfun_net_getsockname,
@@ -776,7 +784,7 @@ JANET_CORE_FN(cfun_net_getsockname,
     if(0 != (error = getsockname(js->handle, (struct sockaddr *) &ss, &slen)))
         janet_panicf("Failed to get peername on fd %d, error: %s", js->handle, janet_ev_lasterr());
 
-    return janet_wrap_string(janet_so_getname(&ss, slen));
+    return janet_so_getname(&ss, slen);
 }
 
 
@@ -794,7 +802,7 @@ JANET_CORE_FN(cfun_net_getpeername,
         janet_panicf("Failed to get peername on fd %d, error: %s", js->handle, janet_ev_lasterr());
     }
 
-    return janet_wrap_string(janet_so_getname(&ss, slen));
+    return janet_so_getname(&ss, slen);
 }
 
 JANET_CORE_FN(cfun_stream_accept_loop,

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -576,158 +576,149 @@ JANET_CORE_FN(cfun_net_listen,
 #define SO_MIN(a, b) (((a) < (b))? (a) : (b))
 #define SA_ADDRSTRLEN SO_MAX(INET6_ADDRSTRLEN, (sizeof ((struct sockaddr_un *)0)->sun_path) + 1)
 #define sa_ntoa(sa)  sa_ntoa_((char [SA_ADDRSTRLEN]){ 0 }, SA_ADDRSTRLEN, (sa))
-#define sa_aton(str) sa_aton_(&(struct sockaddr_storage){ 0 }, sizeof (struct sockaddr_storage), (str))
 #define sa_family(...) sa_family(__VA_ARGS__)
 #define sa_port(...) sa_port(__VA_ARGS__)
 
 union sockaddr_arg {
-	struct sockaddr *sa;
-	const struct sockaddr *c_sa;
+    struct sockaddr *sa;
+    const struct sockaddr *c_sa;
+    struct sockaddr_storage *ss;
+    struct sockaddr_storage *c_ss;
+    struct sockaddr_in *sin;
+    struct sockaddr_in *c_sin;
+    struct sockaddr_in6 *sin6;
+    struct sockaddr_in6 *c_sin6;
+    struct sockaddr_un *sun;
+    struct sockaddr_un *c_sun;
+    union sockaddr_any *any;
+    union sockaddr_any *c_any;
 
-	struct sockaddr_storage *ss;
-	struct sockaddr_storage *c_ss;
-
-	struct sockaddr_in *sin;
-	struct sockaddr_in *c_sin;
-
-	struct sockaddr_in6 *sin6;
-	struct sockaddr_in6 *c_sin6;
-
-	struct sockaddr_un *sun;
-	struct sockaddr_un *c_sun;
-	union sockaddr_any *any;
-	union sockaddr_any *c_any;
-
-	void *ptr;
-	void *c_ptr;
+    void *ptr;
+    void *c_ptr;
 };
 
 union sockaddr_any {
-	struct sockaddr sa;
-	struct sockaddr_storage ss;
-	struct sockaddr_in sin;
-	struct sockaddr_in6 sin6;
-	struct sockaddr_un sun;
+    struct sockaddr sa;
+    struct sockaddr_storage ss;
+    struct sockaddr_in sin;
+    struct sockaddr_in6 sin6;
+    struct sockaddr_un sun;
 };
 
-static inline union sockaddr_arg sockaddr_ref(void* arg) {
-	return (union sockaddr_arg){ arg };
+static inline union sockaddr_arg sockaddr_ref(void *arg) {
+    return (union sockaddr_arg) {
+        arg
+    };
 }
 
-static inline sa_family_t *(sa_family)(void* arg) {
-	return &sockaddr_ref(arg).sa->sa_family;
+static inline sa_family_t *(sa_family)(void *arg) {
+    return &sockaddr_ref(arg).sa->sa_family;
 }
 
-static inline in_port_t *(sa_port)(void* arg, const in_port_t *def, int *error) {
-	switch (*sa_family(arg)) {
-	case AF_INET:
-		return &sockaddr_ref(arg).sin->sin_port;
-	case AF_INET6:
-		return &sockaddr_ref(arg).sin6->sin6_port;
-	default:
-		if (error)
-			*error = EAFNOSUPPORT;
+static inline in_port_t *(sa_port)(void *arg, const in_port_t *def, int *error) {
+    switch (*sa_family(arg)) {
+        case AF_INET:
+            return &sockaddr_ref(arg).sin->sin_port;
+        case AF_INET6:
+            return &sockaddr_ref(arg).sin6->sin6_port;
+        default:
+            if (error)
+                *error = EAFNOSUPPORT;
 
-		return (in_port_t *)def;
-	}
+            return (in_port_t *)def;
+    }
 }
 
 size_t janet_socket_strlcpy(char *dst, const char *src, size_t lim) {
-	char *d		= dst;
-	char *e		= &dst[lim];
-	const char *s	= src;
+    char *d     = dst;
+    char *e     = &dst[lim];
+    const char *s   = src;
 
-	if (d < e) {
-		do {
-			if ('\0' == (*d++ = *s++))
-				return s - src - 1;
-		} while (d < e);
+    if (d < e) {
+        do {
+            if ('\0' == (*d++ = *s++))
+                return s - src - 1;
+        } while (d < e);
 
-		d[-1]	= '\0';
-	}
+        d[-1]   = '\0';
+    }
 
-	while (*s++ != '\0')
-		;;
+    while (*s++ != '\0')
+        ;;
 
-	return s - src - 1;
+    return s - src - 1;
 }
 
 char *sa_ntop(char *dst, size_t lim, const void *src, const char *def, int *_error) {
-	union sockaddr_any *any = (void *)src;
-	const char *unspec = "0.0.0.0";
-	char text[SA_ADDRSTRLEN];
-	int error;
+    union sockaddr_any *any = (void *)src;
+    const char *unspec = "0.0.0.0";
+    char text[SA_ADDRSTRLEN];
+    int error;
 
-	switch (*sa_family(&any->sa)) {
-	case AF_INET:
-		unspec = "0.0.0.0";
+    switch (*sa_family(&any->sa)) {
+        case AF_INET:
+            unspec = "0.0.0.0";
 
-		if (!inet_ntop(AF_INET, &any->sin.sin_addr, text, sizeof text))
-			goto syerr;
+            if (!inet_ntop(AF_INET, &any->sin.sin_addr, text, sizeof text))
+                goto syerr;
 
-		break;
-	case AF_INET6:
-		unspec = "::";
+            break;
+        case AF_INET6:
+            unspec = "::";
 
-		if (!inet_ntop(AF_INET6, &any->sin6.sin6_addr, text, sizeof text))
-			goto syerr;
+            if (!inet_ntop(AF_INET6, &any->sin6.sin6_addr, text, sizeof text))
+                goto syerr;
 
-		break;
-	case AF_UNIX:
-		unspec = "/nonexistent";
+            break;
+        case AF_UNIX:
+            unspec = "/nonexistent";
 
-		memset(text, 0, sizeof text);
-		memcpy(text, any->sun.sun_path, SO_MIN(sizeof text - 1, sizeof any->sun.sun_path));
+            memset(text, 0, sizeof text);
+            memcpy(text, any->sun.sun_path, SO_MIN(sizeof text - 1, sizeof any->sun.sun_path));
 
-		break;
-	default:
-		error = EAFNOSUPPORT;
+            break;
+        default:
+            error = EAFNOSUPPORT;
 
-		goto error;
-	}
+            goto error;
+    }
 
-	if (janet_socket_strlcpy(dst, text, lim) >= lim) {
-		error = ENOSPC;
+    if (janet_socket_strlcpy(dst, text, lim) >= lim) {
+        error = ENOSPC;
 
-		goto error;
-	}
+        goto error;
+    }
 
-	return dst;
+    return dst;
 syerr:
-	error = errno;
+    error = errno;
 error:
-	if (_error)
-		*_error = error;
+    if (_error)
+        *_error = error;
 
-	/*
-	 * NOTE: Always write something in case caller ignores errors, such
-	 * as when caller is using the sa_ntoa() macro.
-	 */
-	safe_memcpy(dst, (def)? def : unspec, lim);
+    /*
+     * NOTE: Always write something in case caller ignores errors, such
+     * as when caller is using the sa_ntoa() macro.
+     */
+    safe_memcpy(dst, (def) ? def : unspec, lim);
 
-	return (char *)def;
+    return (char *)def;
 }
-
-void *sa_pton(void *, size_t, const char *, const void *, int *);
 
 static inline char *sa_ntoa_(char *dst, size_t lim, const void *src) {
-	return sa_ntop(dst, lim, src, NULL, &(int){ 0 }), dst;
+    return sa_ntop(dst, lim, src, NULL, &(int) {
+        0
+    }), dst;
 }
-
-/*
-static inline void *sa_aton_(void *dst, size_t lim, const char *src) {
-	return sa_pton(dst, lim, src, NULL, &(int){ 0 }), dst;
-}
-*/
 
 static Janet janet_so_getname(const struct sockaddr_storage *ss, socklen_t slen) {
     uint8_t *hn = NULL;
     uint16_t hp = 0;
     size_t plen = SA_ADDRSTRLEN;
 
-    switch(ss->ss_family) {
+    switch (ss->ss_family) {
         case AF_INET:
-            /* fall through */
+        /* fall through */
         case AF_INET6:
             /* hn = hostname, hp = hostport */
             hn = (uint8_t *)sa_ntoa(ss);
@@ -737,7 +728,7 @@ static Janet janet_so_getname(const struct sockaddr_storage *ss, socklen_t slen)
             /* support nameless sockets, linux-ism */
             if (slen > offsetof(struct sockaddr_un, sun_path)) {
                 struct sockaddr_un *sun = (struct sockaddr_un *)ss;
-                char *pe = (char *)sun + SO_MIN(sizeof *sun, slen);
+                char *pe = (char *)sun + SO_MIN(sizeof * sun, slen);
                 size_t plen;
 
                 while (pe > sun->sun_path && pe[-1] == '\0')
@@ -773,7 +764,7 @@ static Janet janet_so_getname(const struct sockaddr_storage *ss, socklen_t slen)
 
 JANET_CORE_FN(cfun_net_getsockname,
               "(net/localname stream)",
-              "Document me!") {
+              "Gets the local address and port in a tuple in that order.") {
     janet_arity(argc, 1, 1);
     JanetStream *js = janet_getabstract(argv, 0, &janet_stream_type);
     struct sockaddr_storage ss;
@@ -781,7 +772,7 @@ JANET_CORE_FN(cfun_net_getsockname,
     memset(&ss, 0, slen);
 
     int error;
-    if(0 != (error = getsockname(js->handle, (struct sockaddr *) &ss, &slen)))
+    if (0 != (error = getsockname(js->handle, (struct sockaddr *) &ss, &slen)))
         janet_panicf("Failed to get peername on fd %d, error: %s", js->handle, janet_ev_lasterr());
 
     return janet_so_getname(&ss, slen);
@@ -790,12 +781,12 @@ JANET_CORE_FN(cfun_net_getsockname,
 
 JANET_CORE_FN(cfun_net_getpeername,
               "(net/peername stream)",
-              "Document me!") {
+              "Gets the remote peer's address and port in a tuple in that order.") {
     janet_arity(argc, 1, 1);
     JanetStream *js = janet_getabstract(argv, 0, &janet_stream_type);
     struct sockaddr_storage ss;
     socklen_t slen = sizeof ss;
-	memset(&ss, 0, slen);
+    memset(&ss, 0, slen);
 
     int error;
     if (0 != (error = getpeername(js->handle, (struct sockaddr *)&ss, &slen))) {

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -29,7 +29,6 @@
 #ifdef JANET_NET
 
 #include <math.h>
-#include <arpa/inet.h>
 #ifdef JANET_WINDOWS
 #include <winsock2.h>
 #include <windows.h>
@@ -39,6 +38,7 @@
 #pragma comment (lib, "Mswsock.lib")
 #pragma comment (lib, "Advapi32.lib")
 #else
+#include <arpa/inet.h>
 #include <unistd.h>
 #include <signal.h>
 #include <sys/ioctl.h>

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -571,6 +571,10 @@ JANET_CORE_FN(cfun_net_listen,
     }
 }
 
+/* Definitions from:
+ *   https://github.com/wahern/cqueues/blog/master/src/lib/socket.h
+ *     SO_MAX, SA_PORT_NONE, SO_MIN, SA_ADDRSTRLEN, sa_ntoa, sa_family,
+ *     sa_port */
 #define SO_MAX(a, b) (((a) > (b))? (a) : (b))
 #define SA_PORT_NONE (&(in_port_t){ 0 })
 #define SO_MIN(a, b) (((a) < (b))? (a) : (b))
@@ -583,10 +587,12 @@ JANET_CORE_FN(cfun_net_listen,
 #define sa_family(...) sa_family(__VA_ARGS__)
 #define sa_port(...) sa_port(__VA_ARGS__)
 #ifdef JANET_WINDOWS
-typedef short sa_family_t;
-typedef unsigned short in_port_t;
+typedef short sa_family_t; /* added to silence warnings */
+typedef unsigned short in_port_t; /* added to silence warnings */
 #endif
 
+/* Definition from:
+ *   https://github.com/wahern/cqueues/blog/master/src/lib/socket.h */
 union sockaddr_arg {
     struct sockaddr *sa;
     const struct sockaddr *c_sa;
@@ -607,6 +613,8 @@ union sockaddr_arg {
     void *c_ptr;
 };
 
+/* Definition from:
+ *   https://github.com/wahern/cqueues/blog/master/src/lib/socket.h */
 union sockaddr_any {
     struct sockaddr sa;
     struct sockaddr_storage ss;
@@ -617,16 +625,22 @@ union sockaddr_any {
 #endif
 };
 
+/* Definition from:
+ *   https://github.com/wahern/cqueues/blog/master/src/lib/socket.h */
 static inline union sockaddr_arg sockaddr_ref(void *arg) {
     return (union sockaddr_arg) {
         arg
     };
 }
 
+/* Definition from:
+ *   https://github.com/wahern/cqueues/blog/master/src/lib/socket.h */
 static inline sa_family_t *(sa_family)(void *arg) {
     return &sockaddr_ref(arg).sa->sa_family;
 }
 
+/* Definition from:
+ *   https://github.com/wahern/cqueues/blog/master/src/lib/socket.h */
 static inline in_port_t *(sa_port)(void *arg, const in_port_t *def, int *error) {
     switch (*sa_family(arg)) {
         case AF_INET:
@@ -641,6 +655,9 @@ static inline in_port_t *(sa_port)(void *arg, const in_port_t *def, int *error) 
     }
 }
 
+/* Definition from:
+ *   https://github.com/wahern/cqueues/blog/master/src/lib/socket.c
+ * Original was dns_strlcpy */
 size_t janet_socket_strlcpy(char *dst, const char *src, size_t lim) {
     char *d     = dst;
     char *e     = &dst[lim];
@@ -661,6 +678,8 @@ size_t janet_socket_strlcpy(char *dst, const char *src, size_t lim) {
     return s - src - 1;
 }
 
+/* Definition from:
+ *   https://github.com/wahern/cqueues/blog/master/src/lib/socket.c */
 char *sa_ntop(char *dst, size_t lim, const void *src, const char *def, int *_error) {
     union sockaddr_any *any = (void *)src;
     const char *unspec = "0.0.0.0";
@@ -719,12 +738,17 @@ error:
     return (char *)def;
 }
 
+/* Definition from:
+ *   https://github.com/wahern/cqueues/blog/master/src/lib/socket.h */
 static inline char *sa_ntoa_(char *dst, size_t lim, const void *src) {
     return sa_ntop(dst, lim, src, NULL, &(int) {
         0
     }), dst;
 }
 
+/* Definition from:
+ *   https://github.com/wahern/cqueues/blog/master/src/lib/socket.c
+ * Originaly was lso_pushname */
 static Janet janet_so_getname(const struct sockaddr_storage *ss, socklen_t slen) {
     uint8_t *hn = NULL;
     uint16_t hp = 0;

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -588,7 +588,9 @@ union sockaddr_arg {
     struct sockaddr_in *c_sin;
     struct sockaddr_in6 *sin6;
     struct sockaddr_in6 *c_sin6;
+#ifndef JANET_WINDOWS
     struct sockaddr_un *sun;
+#endif
     struct sockaddr_un *c_sun;
     union sockaddr_any *any;
     union sockaddr_any *c_any;
@@ -602,7 +604,9 @@ union sockaddr_any {
     struct sockaddr_storage ss;
     struct sockaddr_in sin;
     struct sockaddr_in6 sin6;
+#ifndef JANET_WINDOWS
     struct sockaddr_un sun;
+#endif
 };
 
 static inline union sockaddr_arg sockaddr_ref(void *arg) {
@@ -670,6 +674,7 @@ char *sa_ntop(char *dst, size_t lim, const void *src, const char *def, int *_err
                 goto syerr;
 
             break;
+#ifndef JANET_WINDOWS
         case AF_UNIX:
             unspec = "/nonexistent";
 
@@ -677,6 +682,7 @@ char *sa_ntop(char *dst, size_t lim, const void *src, const char *def, int *_err
             memcpy(text, any->sun.sun_path, SO_MIN(sizeof text - 1, sizeof any->sun.sun_path));
 
             break;
+#endif
         default:
             error = EAFNOSUPPORT;
 

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -582,6 +582,10 @@ JANET_CORE_FN(cfun_net_listen,
 #define sa_ntoa(sa)  sa_ntoa_((char [SA_ADDRSTRLEN]){ 0 }, SA_ADDRSTRLEN, (sa))
 #define sa_family(...) sa_family(__VA_ARGS__)
 #define sa_port(...) sa_port(__VA_ARGS__)
+#ifdef JANET_WINDOWS
+typedef short sa_family_t;
+typedef unsigned short in_port_t;
+#endif
 
 union sockaddr_arg {
     struct sockaddr *sa;

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -574,7 +574,11 @@ JANET_CORE_FN(cfun_net_listen,
 #define SO_MAX(a, b) (((a) > (b))? (a) : (b))
 #define SA_PORT_NONE (&(in_port_t){ 0 })
 #define SO_MIN(a, b) (((a) < (b))? (a) : (b))
+#ifndef JANET_WINDOWS
 #define SA_ADDRSTRLEN SO_MAX(INET6_ADDRSTRLEN, (sizeof ((struct sockaddr_un *)0)->sun_path) + 1)
+#else
+#define SA_ADDRSTRLEN (INET6_ADDRSTRLEN + 1)
+#endif
 #define sa_ntoa(sa)  sa_ntoa_((char [SA_ADDRSTRLEN]){ 0 }, SA_ADDRSTRLEN, (sa))
 #define sa_family(...) sa_family(__VA_ARGS__)
 #define sa_port(...) sa_port(__VA_ARGS__)
@@ -730,6 +734,7 @@ static Janet janet_so_getname(const struct sockaddr_storage *ss, socklen_t slen)
             hn = (uint8_t *)sa_ntoa(ss);
             hp = ntohs(*sa_port((void *)ss, SA_PORT_NONE, NULL));
             break;
+#ifndef JANET_WINDOWS
         case AF_UNIX:
             /* support nameless sockets, linux-ism */
             if (slen > offsetof(struct sockaddr_un, sun_path)) {
@@ -751,6 +756,7 @@ static Janet janet_so_getname(const struct sockaddr_storage *ss, socklen_t slen)
                 plen = 1;
             }
             break;
+#endif
         default:
             hn = (uint8_t *)"";
             plen = 0;

--- a/test/suite0009.janet
+++ b/test/suite0009.janet
@@ -166,12 +166,6 @@
         (do (net/write stream to-write) (net/read stream 1024 buffer))
         (do (net/read stream 1024 buffer) (net/write stream to-write)))
       (def comparison (string/split " " buffer))
-      (printf "%s\n\t%s%q\n\t%s%q"
-              (if (= direction :write) "-->" "<--")
-              "remote view: "
-              comparison
-              "local view: "
-              [my-ip my-port remote-ip remote-port])
       (assert (and (= my-ip (get comparison 2))
                    (= (string my-port) (get comparison 3))
                    (= remote-ip (get comparison 0))

--- a/test/suite0009.janet
+++ b/test/suite0009.janet
@@ -151,6 +151,48 @@
 
   (:close s))
 
+# Test localname and peername
+(repeat 10
+  (defn check-matching-names [stream &opt direction]
+    "Checks that the remote agrees with the local about ip/port"
+    (let [[my-ip my-port]         (net/localname stream)
+          [remote-ip remote-port] (net/peername stream)
+          to-write                (string/join
+                                    @[my-ip (string my-port)
+                                      remote-ip (string remote-port)]
+                                    " ")
+          buffer                  @""]
+      (if (= direction :write)
+        (do (net/write stream to-write) (net/read stream 1024 buffer))
+        (do (net/read stream 1024 buffer) (net/write stream to-write)))
+      (def comparison (string/split " " buffer))
+      (printf "%s\n\t%s%q\n\t%s%q"
+              (if (= direction :write) "-->" "<--")
+              "remote view: "
+              comparison
+              "local view: "
+              [my-ip my-port remote-ip remote-port])
+      (assert (and (= my-ip (get comparison 2))
+                   (= (string my-port) (get comparison 3))
+                   (= remote-ip (get comparison 0))
+                   (= (string remote-port) (get comparison 1))))))
+  (defn names-handler
+    "Simple handler for connections."
+    [stream]
+    (defer (:close stream)
+      (check-matching-names stream)))
+
+  (def s (net/server "127.0.0.1" "8000" names-handler))
+  (assert s "made server 1")
+
+  (defn test-names []
+    (with [conn (net/connect "127.0.0.1" "8000")]
+          (check-matching-names conn :write)))
+
+  (test-names)
+  (test-names)
+  (:close s))
+
 # Create pipe
 
 (var pipe-counter 0)


### PR DESCRIPTION
When this is complete we'll have getpeername, getsockname ~~and possibly
getpeerid, getpeerpid,~~ in the net/* API.

~~Definitely will need running through astyle before merge.~~ **DONE**

Borrowed a lot from [wahern/cqueues](https://github.com/wahern/cqueues).

Please comment/suggest others that might be wanted in the net/* API as well as let me know if the code is awful and hint on ways to make it cleaner.

**Note**:
*nix function names are mapped to "nicer" names in this code. I'm not averse to changing the names of stuff if either *nix function names or  something otherwise sensible is preferred.

All functions return a tuple of `(host port)` where port is optional.

Tested as working with AF_INET*, haven't tested with AF_UNIX (should work). All testing done under FreeBSD (will test under *BSD and Linux later). **Need help with Win32!**

Current mappings:
`getpeername` -> `(net/peername stream)`
`getsockname` -> `(net/localname stream)`

*EDIT*:
Going to drop out getpeerid and getpeerpid - some systems don't provide pid, and I can't find the header that'll get me to where I'll stop being warned about `getpeereid` being undefined (checked man pages, we've included the necessary, just apparently that's not where it is). Going to clean up, commit, and mark as ready in a moment, but it will need some help for Windows sadly.