### PR TITLE
add NULL check in gc.c to avoid UB

### DIFF
--- a/src/core/gc.c
+++ b/src/core/gc.c
@@ -123,6 +123,8 @@ static void janet_mark_abstract(void *adata) {
 
 /* Mark a bunch of items in memory */
 static void janet_mark_many(const Janet *values, int32_t n) {
+    if (values == NULL)
+        return;
     const Janet *end = values + n;
     while (values < end) {
         janet_mark(*values);


### PR DESCRIPTION
After the UB was fixed in value.c, I tried running the build again and encoutered another instance of UB in gc.c.  With this fixed I'm now able to build janet with ubsan enabled, meaning there's no more UB encountered in janet_boot during the build.