### PR TITLE
Fix #822 - kqueue hang in suite 9.

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1709,7 +1709,8 @@ void janet_loop1_impl(int has_timeout, JanetTimestamp timeout) {
         } else {
             JanetStream *stream = p;
             JanetListenerState *state = stream->state;
-            if (NULL != state) {
+            while (NULL != state) {
+                JanetListenerState *next_state = state->_next;
                 state->event = events + i;
                 JanetAsyncStatus statuses[4];
                 for (int i = 0; i < 4; i++)
@@ -1730,6 +1731,8 @@ void janet_loop1_impl(int has_timeout, JanetTimestamp timeout) {
                         statuses[2] == JANET_ASYNC_STATUS_DONE ||
                         statuses[3] == JANET_ASYNC_STATUS_DONE)
                     janet_unlisten(state, 0);
+
+                state = next_state;
             }
         }
     }


### PR DESCRIPTION
This fixes #822 

Priorly we only checked exactly one state when an event was received. This was incorrect. A state may have a next state, an action to take after the first in the list of states has been taken. This change acknowledges that and makes the code work with the state list vs just the head of the list.

Tested under FreeBSD, NetBSD, and OpenBSD with success. MacOS is tested by CI and if that flakes we'll need someone to try it on a Mac device.