### PR TITLE
Expose `janet_rng_double` to the C API

### DIFF
--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1454,6 +1454,7 @@ JANET_API JanetRNG *janet_default_rng(void);
 JANET_API void janet_rng_seed(JanetRNG *rng, uint32_t seed);
 JANET_API void janet_rng_longseed(JanetRNG *rng, const uint8_t *bytes, int32_t len);
 JANET_API uint32_t janet_rng_u32(JanetRNG *rng);
+JANET_API double janet_rng_double(JanetRNG *rng);
 
 /* Array functions */
 JANET_API JanetArray *janet_array(int32_t capacity);


### PR DESCRIPTION
I think `janet_rng_double` was meant to be exposed to the C API (since it's not static). Also after I discovered it I wanted to use it 😄 

> P.S. I'm participating in [Hacktoberfest 2021](https://hacktoberfest.digitalocean.com/). If this PR is up to standard and merged, I'd appreciate if the `hacktoberfest-accepted` label could be added. Thanks!