### PR TITLE
Tweak format strings

### DIFF
--- a/src/core/net.c
+++ b/src/core/net.c
@@ -699,7 +699,7 @@ JANET_CORE_FN(cfun_net_getsockname,
     socklen_t slen = sizeof(ss);
     memset(&ss, 0, slen);
     if (getsockname((JSock)js->handle, (struct sockaddr *) &ss, &slen)) {
-        janet_panicf("Failed to get localname on %v: %s", argv[0], janet_ev_lasterr());
+        janet_panicf("Failed to get localname on %v: %V", argv[0], janet_ev_lasterr());
     }
     janet_assert(slen <= sizeof(ss), "socket address truncated");
     return janet_so_getname(&ss);
@@ -714,7 +714,7 @@ JANET_CORE_FN(cfun_net_getpeername,
     socklen_t slen = sizeof(ss);
     memset(&ss, 0, slen);
     if (getpeername((JSock)js->handle, (struct sockaddr *)&ss, &slen)) {
-        janet_panicf("Failed to get peername on %v: %s", argv[0], janet_ev_lasterr());
+        janet_panicf("Failed to get peername on %v: %V", argv[0], janet_ev_lasterr());
     }
     janet_assert(slen <= sizeof(ss), "socket address truncated");
     return janet_so_getname(&ss);


### PR DESCRIPTION
A couple of format strings were using `%s` where may be `%V` would be better.

With fbe06782, I get:
```
$ janet
Janet 1.18.0-dev-fbe06782 linux/x64 - '(doc)' for help
repl:1:> (def s (net/server "127.0.0.1" "0"))
<core/stream 0x563B07CEB270>
repl:2:> (net/peername s)
Segmentation fault (core dumped)
```
