### PR TITLE
Add argument to some janet_panicf calls

### DIFF
--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -137,7 +137,7 @@ static const char *janet_dyncstring(const char *name, const char *dflt) {
     const uint8_t *jstr = janet_unwrap_string(x);
     const char *cstr = (const char *)jstr;
     if (strlen(cstr) != (size_t) janet_string_length(jstr)) {
-        janet_panicf("string %v contains embedded 0s");
+        janet_panicf("string %v contains embedded 0s", x);
     }
     return cstr;
 }

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -1493,7 +1493,9 @@ JanetSignal janet_pcall(
 
 Janet janet_mcall(const char *name, int32_t argc, Janet *argv) {
     /* At least 1 argument */
-    if (argc < 1) janet_panicf("method :%s expected at least 1 argument");
+    if (argc < 1) {
+        janet_panicf("method :%s expected at least 1 argument", name);
+    }
     /* Find method */
     Janet method = janet_method_lookup(argv[0], name);
     if (janet_checktype(method, JANET_NIL)) {


### PR DESCRIPTION
Some calls to `janet_panicf` had format strings with format specifiers in them but lacked an appropriate number of subsequent arguments.

Thanks @pyrmont and @andrewchambers 