### PR TITLE
Fix error for uname switch -o on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ ifeq ($(UNAME), Haiku)
 	LDFLAGS=-Wl,--export-dynamic
 endif
 # For Android (termux)
-ifeq ($(UNAME), Linux)
+ifeq ($(UNAME), Linux) # uname on Darwin doesn't recognise -o
 ifeq ($(shell uname -o), Android)
 	CLIBS:=$(CLIBS) -landroid-spawn
 endif


### PR DESCRIPTION
PR #840 added detection for Termux running on Android by calling `shell uname -o`. Unfortunately, the `-o` switch is not recognised on macOS (and possibly other BSD-derived systems?). As a result, when you run commands, an error will be output (the command does still work).

So running `make clean` on macOS, for example, outputs:

```
uname: illegal option -- o
usage: uname [-amnprsv]
rm -rf build vgcore.* callgrind.*
rm -rf test/install/build test/install/modpath
```

To address this, this PR adds a check to see if the OS is Linux before checking if it's Android.