### PR TITLE
Use named union in JanetGCObject

### DIFF
--- a/src/core/abstract.c
+++ b/src/core/abstract.c
@@ -63,8 +63,8 @@ void *janet_abstract_begin_threaded(const JanetAbstractType *atype, size_t size)
     }
     janet_vm.next_collection += size + sizeof(JanetAbstractHead);
     header->gc.flags = JANET_MEMORY_THREADED_ABSTRACT;
-    header->gc.next = NULL; /* Clear memory for address sanitizers */
-    header->gc.refcount = 1;
+    header->gc.data.next = NULL; /* Clear memory for address sanitizers */
+    header->gc.data.refcount = 1;
     header->size = size;
     header->type = atype;
     void *abstract = (void *) & (header->data);
@@ -86,11 +86,11 @@ void *janet_abstract_threaded(const JanetAbstractType *atype, size_t size) {
 #ifdef JANET_WINDOWS
 
 static int32_t janet_incref(JanetAbstractHead *ab) {
-    return InterlockedIncrement(&ab->gc.refcount);
+    return InterlockedIncrement(&ab->gc.data.refcount);
 }
 
 static int32_t janet_decref(JanetAbstractHead *ab) {
-    return InterlockedDecrement(&ab->gc.refcount);
+    return InterlockedDecrement(&ab->gc.data.refcount);
 }
 
 void janet_os_mutex_init(JanetOSMutex *mutex) {
@@ -112,11 +112,11 @@ void janet_os_mutex_unlock(JanetOSMutex *mutex) {
 #else
 
 static int32_t janet_incref(JanetAbstractHead *ab) {
-    return __atomic_add_fetch(&ab->gc.refcount, 1, __ATOMIC_RELAXED);
+    return __atomic_add_fetch(&ab->gc.data.refcount, 1, __ATOMIC_RELAXED);
 }
 
 static int32_t janet_decref(JanetAbstractHead *ab) {
-    return __atomic_add_fetch(&ab->gc.refcount, -1, __ATOMIC_RELAXED);
+    return __atomic_add_fetch(&ab->gc.data.refcount, -1, __ATOMIC_RELAXED);
 }
 
 void janet_os_mutex_init(JanetOSMutex *mutex) {

--- a/src/core/debug.c
+++ b/src/core/debug.c
@@ -86,7 +86,7 @@ void janet_debug_find(
                 }
             }
         }
-        current = current->next;
+        current = current->data.next;
     }
     if (best_def) {
         *def_out = best_def;

--- a/src/core/gc.c
+++ b/src/core/gc.c
@@ -323,7 +323,7 @@ void janet_sweep() {
     JanetGCObject *current = janet_vm.blocks;
     JanetGCObject *next;
     while (NULL != current) {
-        next = current->next;
+        next = current->data.next;
         if (current->flags & (JANET_MEM_REACHABLE | JANET_MEM_DISABLED)) {
             previous = current;
             current->flags &= ~JANET_MEM_REACHABLE;
@@ -331,7 +331,7 @@ void janet_sweep() {
             janet_vm.block_count--;
             janet_deinit_block(current);
             if (NULL != previous) {
-                previous->next = next;
+                previous->data.next = next;
             } else {
                 janet_vm.blocks = next;
             }
@@ -395,7 +395,7 @@ void *janet_gcalloc(enum JanetMemoryType type, size_t size) {
 
     /* Prepend block to heap list */
     janet_vm.next_collection += size;
-    mem->next = janet_vm.blocks;
+    mem->data.next = janet_vm.blocks;
     janet_vm.blocks = mem;
     janet_vm.block_count++;
 
@@ -532,7 +532,7 @@ void janet_clear_memory(void) {
     JanetGCObject *current = janet_vm.blocks;
     while (NULL != current) {
         janet_deinit_block(current);
-        JanetGCObject *next = current->next;
+        JanetGCObject *next = current->data.next;
         janet_free(current);
         current = next;
     }

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -866,7 +866,7 @@ struct JanetGCObject {
     union {
         JanetGCObject *next;
         int32_t refcount; /* For threaded abstract types */
-    };
+    } data;
 };
 
 /* A lightweight green thread in janet. Does not correspond to


### PR DESCRIPTION
As discussed in #849, the definition of JanetGCObject uses an anonymous union which is (strictly speaking) not valid C99. I'm not sure how important we consider this to be but, in case it helps, this PR names the union `data` and updates the references to use this name.

This fixes #849 .