### PR TITLE
Support sending output to a function

### DIFF
--- a/src/core/io.c
+++ b/src/core/io.c
@@ -483,6 +483,19 @@ static Janet cfun_io_print_impl_x(int32_t argc, Janet *argv, int newline,
                 janet_buffer_push_u8(buf, '\n');
             return janet_wrap_nil();
         }
+        case JANET_FUNCTION: {
+            /* Special case function */
+            JanetFunction *fun = janet_unwrap_function(x);
+            JanetBuffer *buf = janet_buffer(0);
+            for (int32_t i = offset; i < argc; ++i) {
+                janet_to_string_b(buf, argv[i]);
+            }
+            if (newline)
+                janet_buffer_push_u8(buf, '\n');
+            Janet args[1] = { janet_wrap_buffer(buf) };
+            janet_call(fun, 1, args);
+            return janet_wrap_nil();
+        }
         case JANET_NIL:
             f = dflt_file;
             if (f == NULL) janet_panic("cannot print to nil");

--- a/test/suite0007.janet
+++ b/test/suite0007.janet
@@ -168,6 +168,16 @@
 (assert (= (string out-buf) "Hello\nhi") "print and prin to buffer 1")
 (assert (= (string err-buf) "Sup\nnot much.") "eprint and eprin to buffer 1")
 
+# Printing to functions
+(def out-buf @"")
+(defn prepend [x]
+  (with-dyns [:out out-buf]
+    (prin "> " x)))
+(with-dyns [:out prepend]
+  (print "Hello world"))
+
+(assert (= (string out-buf) "> Hello world\n") "print to buffer via function")
+
 (assert (= (string '()) (string [])) "empty bracket tuple literal")
 
 # with-vars


### PR DESCRIPTION
## Background

Presently, Janet allows a user to send output (via a dynamic binding) to a buffer:

```janet
(def buf @"")

(with-dyns [:out buf]
  (print "Hello world"))

(print buf)    #=> "Hello world"
```

## Change

This PR updates `cfun_io_print_impl_x` to support sending the output to a 1-argument function:

```janet
(defn prepend [x] (prin "Prepend> " x))

(with-dyns [:out prepend]
  (print "Hello world"))    #=> "Prepend> Hello world"
```

## Rationale

Supporting the sending of output to a function would allow a user to stream output over a socket. I am interested in exploring this as part of future improvements to the netrepl server. The idea is that Janet code evaluated in `run-context` could stream its output to a client.