### PR TITLE
Use kill instead of raise for SIGINT.

### DIFF
--- a/src/mainclient/shell.c
+++ b/src/mainclient/shell.c
@@ -757,7 +757,7 @@ static int line() {
                 kleft();
                 break;
             case 3:     /* ctrl-c */
-                raise(SIGINT);
+                kill(getpid(), SIGINT);
                 /* fallthrough */
             case 17:    /* ctrl-q */
                 gbl_cancel_current_repl_form = 1;


### PR DESCRIPTION
Raise signals can only be handled by the current thread while
kill signals can be handled by background threads.