### PR TITLE
Update location of current file in run-context

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2292,6 +2292,8 @@
 
   (var where default-where)
 
+  (unless (= where "<anonymous>") (put env :current-file where))
+
   # Evaluate 1 source form in a protected manner
   (def lints @[])
   (defn eval1 [source &opt l c]
@@ -2370,8 +2372,12 @@
 
       [:source new-where]
       (if (string? new-where)
-        (set where new-where)
-        (set where default-where))
+        (do
+          (set where new-where)
+          (put env :current-file new-where))
+        (do
+          (set where default-where)
+          (put env :current-file nil)))
 
       (do
         (var pindex 0)


### PR DESCRIPTION
The `:current-file` dynamic binding is used by, among other things, `module/expand-path` to resolve relative paths when importing modules using `import`. Currently this means that files which are evaluated via a netrepl server cannot reliably use relative paths because `:current-file` is not updated when the location changes.

This PR causes `:current-file` to be updated to the location of the file being evaluated.