### PR TITLE
Add support for multi-arity functions

### DIFF
--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -872,7 +872,7 @@ static const JanetSpecial janetc_specials[] = {
     {"break", janetc_break},
     {"def", janetc_def},
     {"do", janetc_do},
-    {"fn", janetc_fn},
+    {"fn*", janetc_fn},
     {"if", janetc_if},
     {"quasiquote", janetc_quasiquote},
     {"quote", janetc_quote},

--- a/test/suite0000.janet
+++ b/test/suite0000.janet
@@ -295,6 +295,12 @@
     (++ i))
   (assert (= i 6) "when macro"))
 
+# Multi-arity functions
+(def mafn-1 (fn ([x] :foo) ([x y] :bar)))
+(assert (= :bar (mafn-1 1 2)) "multi-arity function literal")
+(defn mafn-2 ([x] :foo) ([x y] :bar) ([x y & z] :qux))
+(assert (= :qux (mafn-2 1 2 3 4)) "multi-arity defn macro")
+
 # Denormal tables and structs
 
 (assert (= (length {1 2 nil 3}) 1) "nil key struct literal")
@@ -313,7 +319,7 @@
 (assert (= (length @{1 2 3 nil}) 1) "nil value table literal")
 
 # Regression Test
-(assert (= 1 (((compile '(fn [] 1) @{})))) "regression test")
+(assert (= 1 (((compile '(fn* [] 1) @{})))) "regression test")
 
 # Regression Test #137
 (def [a b c] (range 10))


### PR DESCRIPTION
I have to admit I mostly made this to see if it was possible but in case it's of interest, here is a PR that adds multi-arity function support to Janet.

## Syntax

Support has been added to both function literals and the `defn` macro:

```janet
(fn ([x] :foo) ([x y] :bar) ([x y & z] :qux))

(defn f
  "A multi-arity function."
  ([x] :foo)
  ([x y] :bar)
  ([x y & z] :qux))
```

## Implementation

Rather than try to add it at the level of the compiler, this implementation renames the `fn` special form to `fn*` and adds a `fn` macro to `boot.janet`. The macro adds a variadic argument parameter and a number of if-statements that execute the correct function body depending on the number of arguments. Because the number of elements in the argument tuple is critical to deciding which function body to execute, `&key` and `&opt` are not supported in multi-arity functions (they work as usual in single-arity functions). A variadic arity is permitted but it must be the final form declared.

The `defn` macro largely gets support for 'free'. The changes to that macro are to cause all of the function signatures to be added to the docstring.

For functions that are not written to have multiple arities, the code should add limited overhead as it largely works as it does currently.

## Shortcomings

The implementation has the following shortcomings:

- The renaming of `fn` to `fn*` will break code that uses `compile` to compile a syntax tree that uses `fn` (this is the reason for the change to line 322 in `suite0000.janet`).

-  The `fn` macro determines whether an element in the declaration is an argument tuple or a function body based on whether it is of tuple type `:brackets` or not. This does not cause any problems for the way most Janet code is written but you can see in the diff how a macro like `juxt` had to be modified to work properly.

For the above reasons, if this was something that is worth pursuing, it is possibly best to leave it to a Janet 2.0.