### PR TITLE
Improve numarray example

### DIFF
--- a/examples/numarray/numarray.c
+++ b/examples/numarray/numarray.c
@@ -109,6 +109,11 @@ static const JanetReg cfuns[] = {
         "(numarray/scale numarray factor)\n\n"
         "scale numarray by factor"
     },
+    {
+        "sum", num_array_sum,
+        "(numarray/sum numarray)\n\n"
+        "sums numarray"
+    },
     {NULL, NULL, NULL}
 };
 

--- a/examples/numarray/numarray.c
+++ b/examples/numarray/numarray.c
@@ -76,9 +76,16 @@ void num_array_put(void *p, Janet key, Janet value) {
     }
 }
 
+static Janet num_array_length(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 1);
+    num_array *array = (num_array *)janet_getabstract(argv, 0, &num_array_type);
+    return janet_wrap_number(array->size);
+}
+
 static const JanetMethod methods[] = {
     {"scale", num_array_scale},
     {"sum", num_array_sum},
+    {"length", num_array_length},
     {NULL, NULL}
 };
 

--- a/examples/numarray/test/numarray_tests.janet
+++ b/examples/numarray/test/numarray_tests.janet
@@ -1,4 +1,4 @@
-(import build/numarray)
+(import /build/numarray)
 
 (def a (numarray/new 30))
 (print (get a 20))


### PR DESCRIPTION
In my pursuit for the "number crunching" library for Janet, I started to think about some better presentation/implementation for data in both statistical sets and linear algebra spaces. I found the numarray example in the main repo, to my surprise. 

It used a system-wide import, which I have changed to the absolute one. 

As an exercise, I added the sum function already defined to the numarray object as a method and added length fn and method.