### PR TITLE
Add search on PATH for async execute example

### DIFF
--- a/examples/async-execute.janet
+++ b/examples/async-execute.janet
@@ -1,6 +1,6 @@
 (defn dowork [name n]
   (print name " starting work...")
-  (os/execute [(dyn :executable) "-e" (string "(os/sleep " n ")")])
+  (os/execute [(dyn :executable) "-e" (string "(os/sleep " n ")")] :p)
   (print name " finished work!"))
 
 # Will be done in parallel


### PR DESCRIPTION
Without it, an example fails with `No such file or directory`.