### PR TITLE
Only set :current-file in run-context if source is a path

### DIFF
--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -958,9 +958,14 @@ JANET_CORE_FN(cfun,
     }
     const uint8_t *source = NULL;
     if (argc >= 3) {
-        source = janet_checktype(argv[2], JANET_STRING) ?
-            janet_unwrap_string(argv[2]) :
-            janet_unwrap_keyword(argv[2]);
+        Janet x = argv[2];
+        if (janet_checktype(x, JANET_STRING)) {
+            source = janet_unwrap_string(x);
+        } else if (janet_checktype(x, JANET_KEYWORD)) {
+            source = janet_unwrap_keyword(x);
+        } else {
+            janet_panic_type(x, 2, JANET_TFLAG_STRING | JANET_TFLAG_KEYWORD);
+        }
     }
     JanetArray *lints = (argc >= 4) ? janet_getarray(argv, 3) : NULL;
     JanetCompileResult res = janet_compile_lint(argv[0], env, source, lints);

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -958,7 +958,9 @@ JANET_CORE_FN(cfun,
     }
     const uint8_t *source = NULL;
     if (argc >= 3) {
-        source = janet_getstring(argv, 2);
+        source = janet_checktype(argv[2], JANET_STRING) ?
+            janet_unwrap_string(argv[2]) :
+            janet_unwrap_keyword(argv[2]);
     }
     JanetArray *lints = (argc >= 4) ? janet_getarray(argv, 3) : NULL;
     JanetCompileResult res = janet_compile_lint(argv[0], env, source, lints);


### PR DESCRIPTION
This PR introduces a convention for calling `run-context` to prevent the `:current-file` dynamic binding from being incorrectly set.

## Background

Revisions were made in 6bf9f894293e224cc99f61f92f22dc134e66f552 and e8c738002bebe7bacd1b1ede3376a98b896f8f6f to update the `:current-file` dynamic binding  if a `:source` argument representing a file path was passed to `run-context`. These changes assumed that `:source` would represent a path unless it was equal to `"<anonymous>"`. This assumption is wrong; indeed a number of functions in `boot.janet` set the value to a description (e.g. `"eval-string"`, `"repl"` etc). The bug was discovered because Janet 1.19.1 breaks the Temple module in the Spork library (which uses `eval-string`).

## Implementation

This PR fixes this problem by adopting a convention that paths are strings and descriptions are keywords. So when, for example, `eval-string` calls `run-context` it does not set the `:source` argument to `"eval-string"` but rather `:eval-string`. Because Janet's ordinary print statements print these values identically, this should not cause an issue with messages that expect `:source` to be a string.

In addition to changes to `boot.janet`, a change has been made to `compile.c` so that it can accept keywords as values to its `:source` argument.

## Considerations

An argument can be made that the changes to `run-context` should be reverted. If a user wishes to set the `:current-file` dynamic binding, this can be done as a separate operation.

I can see the strength in this argument but think that the previous behaviour led to non-intuitive errors. If a user calls `run-context` to evaluate a string of Janet code with a `:source` argument set to a file path, I think the user will expect that calls to `import` with a relative path in that string will cause the import to happen relative to `:source`. Without this change, that won't be the case unless they separately set `:current-file`.