### PR TITLE
Fix typo in janet_epoll_sync_callback, add test for "async" read from normal fd

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1434,7 +1434,7 @@ static void janet_epoll_sync_callback(JanetEVGenericMessage msg) {
     JanetAsyncStatus status2 = JANET_ASYNC_STATUS_NOT_DONE;
     if (state->stream->_mask & JANET_ASYNC_LISTEN_WRITE)
         status1 = state->machine(state, JANET_ASYNC_EVENT_WRITE);
-    if (state->stream->_mask & JANET_ASYNC_LISTEN_WRITE)
+    if (state->stream->_mask & JANET_ASYNC_LISTEN_READ)
         status2 = state->machine(state, JANET_ASYNC_EVENT_READ);
     if (status1 == JANET_ASYNC_STATUS_DONE ||
             status2 == JANET_ASYNC_STATUS_DONE) {

--- a/test/suite0009.janet
+++ b/test/suite0009.janet
@@ -115,6 +115,19 @@
    # Cast to string to enable comparison
    (assert (= "123\n456\n" (string (slurp "unique.txt"))) "File writing 4.2")
    (os/rm "unique.txt"))
+
+# Test that the stream created by os/open can be read from
+(assert-no-error "File reading 1.1"
+  (def outstream (os/open "unique.txt" :wct))
+  (defer (:close outstream)
+    (:write outstream "123\n")
+    (:write outstream "456\n"))
+    
+  (def outstream (os/open "unique.txt" :r))
+  (defer (:close outstream)
+    (assert (= "123\n456\n" (string (:read outstream :all))) "File reading 1.2"))
+  (os/rm "unique.txt"))
+     
      
 # ev/gather
 


### PR DESCRIPTION
Fixed a typo in janet_epoll_sync_callback  where `JANET_ASYNC_LISTEN_WRITE` was checked instead of `JANET_ASYNC_LISTEN_READ`.
It caused the runtime to hang when reading from a normal file descriptor, like one from `os/open`.

This PR also introduces a test for `ev/read`, its almost identical to the test for writing to a normal fd.
The only difference is it reads the content back with `:read` instead of `slurp`.