### PR TITLE
Windows: Fix `ev/read` hanging when called on stream from `os/open`

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -2219,6 +2219,10 @@ JanetAsyncStatus ev_machine_read(JanetListenerState *s, JanetAsyncEvent event) {
             } else
 #endif
             {
+                // Some handles (not all) read from the offset in lopOverlapped
+                // if its not set before calling `ReadFile` these streams will always read from offset 0 
+                state->overlapped.Offset = (DWORD) state->bytes_read;
+
                 status = ReadFile(s->stream->handle, state->chunk_buf, chunk_size, NULL, &state->overlapped);
                 if (!status && (ERROR_IO_PENDING != WSAGetLastError())) {
                     if (WSAGetLastError() == ERROR_BROKEN_PIPE) {


### PR DESCRIPTION
Fixes #906 on Windows.

Handles returned by `CreateFileA` with `FILE_FLAG_OVERLAPPED` support reading from arbitrary offsets.
The offset is passed to `ReadFile` through the `OVERLAPPED` structure.
Since `state->overlapped` is zeroed in `ev_machine_read`, `ReadFile` would always read from the start of the file and never finish.

This PR changes `ev_machine_read` to update the offset to the number of bytes read before calling `ReadFile`.