### PR TITLE
Fix redefinable macros

### DIFF
--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -657,7 +657,7 @@ static int macroexpand1(
     }
     Janet macroval;
     JanetBindingType btype = janet_resolve(c->env, name, &macroval);
-    if (btype != JANET_BINDING_MACRO ||
+    if (!(btype == JANET_BINDING_MACRO || btype == JANET_BINDING_DYNAMIC_MACRO) ||
             !janet_checktype(macroval, JANET_FUNCTION))
         return 0;
 


### PR DESCRIPTION
I did have this code in an earlier version of PR #898 but it wasn't in the final version (which is my fault). This fixes the problem described by @sogaiu in [this comment](https://github.com/janet-lang/janet/pull/898#issuecomment-1012833139).