### PR TITLE
Support for `& rest` pattern in destructure and match

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1678,6 +1678,7 @@
 
   * array or bracket tuple -- an array or bracket tuple will match only if
     all of its elements match the corresponding elements in `x`.
+    Use `& rest` at the end of an array or bracketed tuple to bind all remaining values to `rest`.
 
   * table or struct -- a table or struct will match if all values match with
     the corresponding values in `x`.

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1760,7 +1760,15 @@
         (get-length-sym s)
         (eachp [i sub-pattern] pattern
           (when (= sub-pattern '&)
-            # TODO: check that & is followed by something
+            (when (<= (length pattern) (inc i))
+              (errorf "expected symbol following & in pattern"))
+
+            (when (< (+ i 2) (length pattern))
+              (errorf "expected a single symbol follow '& in pattern, found %q" (slice pattern (inc i))))
+
+            (when (not= (type (pattern (inc i))) :symbol)
+              (errorf "expected symbol following & in pattern, found %q" (pattern (inc i))))
+
             (put b2g (pattern (inc i)) @[[slice s i]])
             (break))
           (visit-pattern-1 b2g s i sub-pattern)))

--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -155,7 +155,17 @@ static int destructure(JanetCompiler *c,
                 JanetSlot nextright = janetc_farslot(c);
                 Janet subval = values[i];
 
-                if (!janet_cstrcmp(janet_unwrap_symbol(subval), "&")) {
+                if (janet_type(subval) == JANET_SYMBOL && !janet_cstrcmp(janet_unwrap_symbol(subval), "&")) {
+                    if (i + 1 >= len) {
+                        janetc_cerror(c, "expected symbol following '& in destructuring pattern");
+                        return 1;
+                    }
+
+                    if (janet_type(values[i + 1]) != JANET_SYMBOL) {
+                        janetc_error(c, janet_formatc("expected symbol following '& in destructuring pattern, found %q", values[i + 1]));
+                        return 1;
+                    }
+
                     JanetSlot argi = janetc_farslot(c);
                     JanetSlot arg  = janetc_farslot(c);
                     JanetSlot len  = janetc_farslot(c);

--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -161,6 +161,20 @@ static int destructure(JanetCompiler *c,
                         return 1;
                     }
 
+                    if (i + 2 < len) {
+                        int32_t num_extra = len - i - 1;
+                        Janet* extra = janet_tuple_begin(num_extra);
+                        janet_tuple_flag(extra) |= JANET_TUPLE_FLAG_BRACKETCTOR;
+
+                        for (int32_t j = 0; j < num_extra; ++j) {
+                            extra[j] = values[j + i + 1];
+                        }
+
+                        janetc_error(c, janet_formatc("expected a single symbol follow '& in destructuring pattern, found %q", janet_wrap_tuple(janet_tuple_end(extra))));
+                        return 1;
+                    }
+
+
                     if (!janet_checktype(values[i + 1], JANET_SYMBOL)) {
                         janetc_error(c, janet_formatc("expected symbol following '& in destructuring pattern, found %q", values[i + 1]));
                         return 1;

--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -155,13 +155,13 @@ static int destructure(JanetCompiler *c,
                 JanetSlot nextright = janetc_farslot(c);
                 Janet subval = values[i];
 
-                if (janet_type(subval) == JANET_SYMBOL && !janet_cstrcmp(janet_unwrap_symbol(subval), "&")) {
+                if (janet_checktype(subval, JANET_SYMBOL) && !janet_cstrcmp(janet_unwrap_symbol(subval), "&")) {
                     if (i + 1 >= len) {
                         janetc_cerror(c, "expected symbol following '& in destructuring pattern");
                         return 1;
                     }
 
-                    if (janet_type(values[i + 1]) != JANET_SYMBOL) {
+                    if (!janet_checktype(values[i + 1], JANET_SYMBOL)) {
                         janetc_error(c, janet_formatc("expected symbol following '& in destructuring pattern, found %q", values[i + 1]));
                         return 1;
                     }

--- a/test/suite0001.janet
+++ b/test/suite0001.janet
@@ -157,6 +157,19 @@
   (assert (= b 2) "tuple destructuring 10 - rest")
   (assert (= x :a) "tuple destructuring 11 - rest")
   (assert (= rest [:c :b :a]) "tuple destructuring 12 - rest"))
+(do
+  (def [a b & rest] [:a :b])
+  (assert (= a :a) "tuple destructuring 13 - rest")
+  (assert (= b :b) "tuple destructuring 14 - rest")
+  (assert (= rest []) "tuple destructuring 15 - rest"))
+
+(do
+  (def [[a b & r1] c & r2] [[:a :b 1 2] :c 3 4])
+  (assert (= a :a) "tuple destructuring 16 - rest")
+  (assert (= b :b) "tuple destructuring 17 - rest")
+  (assert (= c :c) "tuple destructuring 18 - rest")
+  (assert (= r1 [1 2]) "tuple destructuring 19 - rest")
+  (assert (= r2 [3 4]) "tuple destructuring 20 - rest"))
 
 # Marshal
 

--- a/test/suite0001.janet
+++ b/test/suite0001.janet
@@ -151,6 +151,12 @@
   (assert (= a :a) "tuple destructuring 6 - rest")
   (assert (= b :b) "tuple destructuring 7 - rest")
   (assert (= rest [nil :d]) "tuple destructuring 8 - rest"))
+(do
+  (def [[a b] x & rest] [[1 2] :a :c :b :a])
+  (assert (= a 1) "tuple destructuring 9 - rest")
+  (assert (= b 2) "tuple destructuring 10 - rest")
+  (assert (= x :a) "tuple destructuring 11 - rest")
+  (assert (= rest [:c :b :a]) "tuple destructuring 12 - rest"))
 
 # Marshal
 

--- a/test/suite0001.janet
+++ b/test/suite0001.janet
@@ -137,6 +137,21 @@
   (assert (= a 1) "dictionary destructuring 3")
   (assert (= b 2) "dictionary destructuring 4")
   (assert (= c 4) "dictionary destructuring 5 - expression as key"))
+(let [test-tuple [:a :b 1 2]]
+  (def [a b one two] test-tuple)
+  (assert (= a :a) "tuple destructuring 1")
+  (assert (= b :b) "tuple destructuring 2")
+  (assert (= two 2) "tuple destructuring 3"))
+(let [test-tuple [:a :b 1 2]]
+  (def [a & rest] test-tuple)
+  (assert (= a :a) "tuple destructuring 4 - rest")
+  (assert (= rest [:b 1 2]) "tuple destructuring 5 - rest"))
+(do
+  (def [a b & rest] [:a :b nil :d])
+  (assert (= a :a) "tuple destructuring 6 - rest")
+  (assert (= b :b) "tuple destructuring 7 - rest")
+  (pp rest)
+  (assert (= rest [nil :d]) "tuple destructuring 8 - rest"))
 
 # Marshal
 

--- a/test/suite0001.janet
+++ b/test/suite0001.janet
@@ -150,7 +150,6 @@
   (def [a b & rest] [:a :b nil :d])
   (assert (= a :a) "tuple destructuring 6 - rest")
   (assert (= b :b) "tuple destructuring 7 - rest")
-  (pp rest)
   (assert (= rest [nil :d]) "tuple destructuring 8 - rest"))
 
 # Marshal

--- a/test/suite0008.janet
+++ b/test/suite0008.janet
@@ -106,6 +106,10 @@
 (assert (= nil (match {:a :hi} {:a a :b b} a)) "match 3")
 (assert (= nil (match [1 2] [a b c] a)) "match 4")
 (assert (= 2 (match [1 2] [a b] b)) "match 5")
+(assert (= [2 :a :b] (match [1 2 :a :b] [o & rest] rest)) "match 6")
+(assert (= [] (match @[:a] @[x & r] r :fallback)) "match 7")
+(assert (= :fallback (match @[1] @[x y & r] r :fallback)) "match 8")
+(assert (= [1 2 3 4] (match @[1 2 3 4] @[x y z & r] [x y z ;r] :fallback)) "match 9")
 
 # And/or checks
 


### PR DESCRIPTION
This PR adds support for the `& rest` pattern in destructure and the `match` macro. The pattern can be used inside an array or tuple. It binds any remaining input to `rest`, if everything preceding it matched.

Examples:
```
(match [:a :b :c]
  [:a & rest] rest)
# => (:b :c)
```

```
(def [x y & r] [1 2])
# x = 1, y = 2, r = ()
```

#912