### PR TITLE
Support looking up missing symbols during compilation

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2746,6 +2746,8 @@
                 (and as (string as "/"))
                 prefix
                 (string (last (string/split "/" path)) "/")))
+  (unless (zero? (length prefix))
+    (put-in env [:modules prefix] newenv))
   (merge-module env newenv prefix ep))
 
 (defmacro import

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2746,8 +2746,6 @@
                 (and as (string as "/"))
                 prefix
                 (string (last (string/split "/" path)) "/")))
-  (unless (zero? (length prefix))
-    (put-in env [:modules prefix] newenv))
   (merge-module env newenv prefix ep))
 
 (defmacro import

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -197,6 +197,39 @@ void janetc_popscope_keepslot(JanetCompiler *c, JanetSlot retslot) {
     }
 }
 
+static int lookup_missing(
+    JanetCompiler *c,
+    const uint8_t *sym,
+    JanetFunction *handler,
+    Janet *out) {
+    Janet args[2] = { janet_wrap_symbol(sym), janet_wrap_table(c->env) };
+    JanetFiber *fiberp = janet_fiber(handler, 64, 2, args);
+    if (NULL == fiberp) {
+        int32_t minar = handler->def->min_arity;
+        int32_t maxar = handler->def->max_arity;
+        const uint8_t *es = NULL;
+        if (minar > 2)
+            es = janet_formatc("lookup handler arity mismatch, minimum at most 2, got %d", minar);
+        if (maxar < 2)
+            es = janet_formatc("lookup handler arity mismatch, maximum at least 2, got %d", maxar);
+        janetc_error(c, es);
+        return 0;
+    }
+    fiberp->env = c->env;
+    int lock = janet_gclock();
+    Janet tempOut;
+    JanetSignal status = janet_continue(fiberp, janet_wrap_nil(), &tempOut);
+    janet_gcunlock(lock);
+    if (status != JANET_SIGNAL_OK) {
+        janetc_error(c, janet_formatc("(lookup) %V", tempOut));
+        return 0;
+    } else {
+        *out = tempOut;
+    }
+
+    return 1;
+}
+
 /* Allow searching for symbols. Return information about the symbol */
 JanetSlot janetc_resolve(
     JanetCompiler *c,
@@ -230,6 +263,23 @@ JanetSlot janetc_resolve(
     /* Symbol not found - check for global */
     {
         JanetBinding binding = janet_resolve_ext(c->env, sym);
+        if (binding.type == JANET_BINDING_NONE) {
+            Janet handler = janet_table_get(c->env, janet_ckeywordv("missing-symbol"));
+            switch (janet_type(handler)) {
+                case JANET_NIL:
+                    break;
+                case JANET_FUNCTION:
+                    Janet entry;
+                    if (!lookup_missing(c, sym, janet_unwrap_function(handler), &entry))
+                        return janetc_cslot(janet_wrap_nil());
+                    binding = janet_binding_from_entry(entry);
+                    break;
+                default:
+                    janetc_error(c, janet_formatc("invalid lookup handler %V", handler));
+                    return janetc_cslot(janet_wrap_nil());
+            }
+        }
+
         switch (binding.type) {
             default:
             case JANET_BINDING_NONE:

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -265,11 +265,11 @@ JanetSlot janetc_resolve(
         JanetBinding binding = janet_resolve_ext(c->env, sym);
         if (binding.type == JANET_BINDING_NONE) {
             Janet handler = janet_table_get(c->env, janet_ckeywordv("missing-symbol"));
+            Janet entry;
             switch (janet_type(handler)) {
                 case JANET_NIL:
                     break;
                 case JANET_FUNCTION:
-                    Janet entry;
                     if (!lookup_missing(c, sym, janet_unwrap_function(handler), &entry))
                         return janetc_cslot(janet_wrap_nil());
                     binding = janet_binding_from_entry(entry);

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -607,8 +607,14 @@ JanetBinding janet_resolve_ext(JanetTable *env, const uint8_t *sym) {
     };
 
     /* Check environment for entry */
-    if (!janet_checktype(entry, JANET_TABLE))
-        return binding;
+    if (!janet_checktype(entry, JANET_TABLE)) {
+        Janet fn_entry = janet_table_get(env, janet_ckeywordv("missing-symbol"));
+        if (janet_checktype(fn_entry, JANET_FUNCTION)) {
+            Janet args[2] = { janet_wrap_symbol(sym), janet_wrap_table(env) };
+            entry = janet_call(janet_unwrap_function(fn_entry), 2, args);
+        }
+        if (!janet_checktype(entry, JANET_TABLE)) return binding;
+    }
     entry_table = janet_unwrap_table(entry);
 
     /* deprecation check */

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -608,10 +608,17 @@ JanetBinding janet_resolve_ext(JanetTable *env, const uint8_t *sym) {
 
     /* Check environment for entry */
     if (!janet_checktype(entry, JANET_TABLE)) {
-        Janet fn_entry = janet_table_get(env, janet_ckeywordv("missing-symbol"));
-        if (janet_checktype(fn_entry, JANET_FUNCTION)) {
+        Janet lookup_entry = janet_table_get(env, janet_ckeywordv("missing-symbol"));
+        if (janet_checktype(lookup_entry, JANET_FUNCTION)) {
+            JanetFunction *lookup = janet_unwrap_function(lookup_entry);
             Janet args[2] = { janet_wrap_symbol(sym), janet_wrap_table(env) };
-            entry = janet_call(janet_unwrap_function(fn_entry), 2, args);
+            JanetFiber *fiberp = janet_fiber(lookup, 64, 2, args);
+            if (NULL == fiberp) return binding;
+            fiberp->env = env;
+            int lock = janet_gclock();
+            JanetSignal status = janet_continue(fiberp, janet_wrap_nil(), &entry);
+            janet_gcunlock(lock);
+            if (status != JANET_SIGNAL_OK) return binding;
         }
         if (!janet_checktype(entry, JANET_TABLE)) return binding;
     }

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -84,6 +84,7 @@ void janet_buffer_format(
     int32_t argc,
     Janet *argv);
 Janet janet_next_impl(Janet ds, Janet key, int is_interpreter);
+JanetBinding janet_binding_from_entry(Janet entry);
 
 /* Registry functions */
 void janet_registry_put(

--- a/test/suite0009.janet
+++ b/test/suite0009.janet
@@ -123,12 +123,12 @@
     (defer (:close outstream)
       (:write outstream "123\n")
       (:write outstream "456\n"))
-      
+
     (def outstream (os/open "unique.txt" :r))
     (defer (:close outstream)
       (assert (= "123\n456\n" (string (:read outstream :all))) "File reading 1.2"))
     (os/rm "unique.txt")))
-       
+
   # ev/gather
 
 (assert (deep= @[1 2 3] (ev/gather 1 2 3)) "ev/gather 1")
@@ -265,5 +265,14 @@
 (ev/chan-close c1)
 (ev/rselect c2)
 (assert (= (slice arr) (slice (range 100))) "ev/chan-close 3")
+
+# threaded channels
+
+(def ch (ev/thread-chan 2))
+(def att (ev/thread-chan 109))
+(assert att "`att` was nil after creation")
+(ev/give ch att)
+(ev/do-thread
+  (assert (ev/take ch) "channel packing bug for threaded abstracts on threaded channels."))
 
 (end-suite)

--- a/test/suite0011.janet
+++ b/test/suite0011.janet
@@ -21,18 +21,10 @@
 (import ./helper :prefix "" :exit true)
 (start-suite 11)
 
-(assert (< 11899423.08 (math/gamma 11.5) 11899423.085)
-        "math/gamma")
+# math gamma
 
-(assert (< 2605.1158 (math/log-gamma 500) 2605.1159)
-        "math/log-gamma")
-
-(def ch (ev/thread-chan 2))
-(def att (ev/thread-chan 109))
-(assert att "`att` was nil after creation")
-(ev/give ch att)
-(ev/do-thread
-  (assert (ev/take ch) "channel packing bug for threaded abstracts on threaded channels."))
+(assert (< 11899423.08 (math/gamma 11.5) 11899423.085) "math/gamma")
+(assert (< 2605.1158 (math/log-gamma 500) 2605.1159) "math/log-gamma")
 
 (end-suite)
 

--- a/test/suite0011.janet
+++ b/test/suite0011.janet
@@ -26,5 +26,18 @@
 (assert (< 11899423.08 (math/gamma 11.5) 11899423.085) "math/gamma")
 (assert (< 2605.1158 (math/log-gamma 500) 2605.1159) "math/log-gamma")
 
+# missing symbols
+
+(def replacement 10)
+(defn lookup-symbol [sym env] (dyn 'replacement))
+
+(setdyn :missing-symbol lookup-symbol)
+
+(assert (= (eval-string "(+ a 5)") 15) "lookup missing symbol")
+
+(setdyn :missing-symbol nil)
+
+(assert-error "compile error" (eval-string "(+ a 5)"))
+
 (end-suite)
 


### PR DESCRIPTION
This PR supports looking up missing symbols during the compilation phase of evaluation by calling a function stored under the dynamic binding `:missing-symbol`.

## Background

Using the recently added `:redef` dynamic binding, the following workflow is now possible in a REPL-connected editor:[^1]

1. evaluate a buffer that imports a Janet module
2. in a separate buffer, edit the function definition contained in the Janet module
3. evaluate just the function definition
4. use the redefined function in the original buffer without further action

This is really cool and I'm extremely glad it's possible. Of course I'd like to do more. The following is not currently possible:

1. evaluate a buffer that imports a Janet module
2. _add a function definition_ to the Janet module
3. evaluate the function definition
4. use the new function in the original buffer without further action

## Implementation

This PR does two things:

1. If `janet_resolve_ext()` does not resolve a symbol in the environment, `janet_resolve_ext()` now checks if there is a function stored under the dynamic binding `:missing-symbol`. If there is, it calls that function with the symbol and the environment.

2. When a module is imported, the environment is added to a table keyed by prefix. The table is stored under the `:modules` dynamic binding.

These changes make the above-desired workflow possible. The user would provide a missing symbol lookup function that extracts the prefix from a missing symbol, checks whether a module in the current environment exists under that prefix and, if there is, checks whether the unprefixed symbol exists in the module's environment and, if so, returns its value.

Since the additional check in `janet_resolve_ext()` only occurs during compilation and only occurs when a symbol is not resolved, it adds minimal overhead. 

[^1]: I'm doing this in Neovim using the [Conjure plugin](https://github.com/Olical/conjure) and a custom netrepl server I'm running using my in-development project management tool, [Jeep](https://github.com/pyrmont/jeep). The netrepl server includes a custom `run-context` function that uses separate environments.