### PR TITLE
Add ppc64 to os/arch

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -183,6 +183,8 @@ JANET_CORE_FN(os_arch,
     return janet_ckeywordv("sparc");
 #elif (defined(__ppc__))
     return janet_ckeywordv("ppc");
+#elif (defined(__ppc64__) || defined(_ARCH_PPC64) || defined(_M_PPC))
+    return janet_ckeywordv("ppc64");
 #else
     return janet_ckeywordv("unknown");
 #endif


### PR DESCRIPTION
Same as #431 (Add ppc to os/arch) but for the 64-bit version.
This is tested on a Power9 CPU in Little-Endian mode, on Linux.