### PR TITLE
add `(int/to-number)`: convert int/s64 and int/u64 to a number

### DIFF
--- a/src/core/inttypes.c
+++ b/src/core/inttypes.c
@@ -216,23 +216,22 @@ JANET_CORE_FN(cfun_to_number,
 
         if (janet_abstract_type(abst) == &janet_s64_type) {
             int64_t value = *((int64_t*)abst);
-            if (value > INT32_MAX) {
-                janet_panicf("cannot convert %q to a number, exceededs int32 max", argv[0]);
+            if (value > JANET_INTMAX_INT64) {
+                janet_panicf("cannot convert %q to a number, must be in the range [%q, %q]", argv[0], janet_wrap_number(JANET_INTMIN_DOUBLE), janet_wrap_number(JANET_INTMAX_DOUBLE));
             }
-            if (value < INT32_MIN) {
-                janet_panicf("cannot convert %q to a number, exceededs int32 min", argv[0]);
+            if (value < -JANET_INTMAX_INT64) {
+                janet_panicf("cannot convert %q to a number, must be in the range [%q, %q]", argv[0], janet_wrap_number(JANET_INTMIN_DOUBLE), janet_wrap_number(JANET_INTMAX_DOUBLE));
             }
-
-            return janet_wrap_integer(value);
+            return janet_wrap_number((double)value);
         }
 
         if (janet_abstract_type(abst) == &janet_u64_type) {
             uint64_t value = *((uint64_t*)abst);
-            if (value > INT32_MAX) {
-                janet_panicf("cannot convert %q to a number, exceededs int32 max", argv[0]);
+            if (value > JANET_INTMAX_INT64) {
+                janet_panicf("cannot convert %q to a number, must be in the range [%q, %q]", argv[0], janet_wrap_number(JANET_INTMIN_DOUBLE), janet_wrap_number(JANET_INTMAX_DOUBLE));
             }
 
-            return janet_wrap_integer(value);
+            return janet_wrap_number((double)value);
         }
     }
 

--- a/src/core/inttypes.c
+++ b/src/core/inttypes.c
@@ -207,6 +207,38 @@ JANET_CORE_FN(cfun_it_u64_new,
     return janet_wrap_u64(janet_unwrap_u64(argv[0]));
 }
 
+JANET_CORE_FN(cfun_to_number,
+              "(int/to-number value)",
+              "Convert an int/u64 or int/s64 to a number. Fails if the number is out of range for an int32.") {
+    janet_fixarity(argc, 1);
+    if (janet_type(argv[0]) == JANET_ABSTRACT) {
+        void* abst = janet_unwrap_abstract(argv[0]);
+
+        if (janet_abstract_type(abst) == &janet_s64_type) {
+            int64_t value = *((int64_t*)abst);
+            if (value > INT32_MAX) {
+                janet_panicf("cannot convert %q to a number, exceededs int32 max", argv[0]);
+            }
+            if (value < INT32_MIN) {
+                janet_panicf("cannot convert %q to a number, exceededs int32 min", argv[0]);
+            }
+
+            return janet_wrap_integer(value);
+        }
+
+        if (janet_abstract_type(abst) == &janet_u64_type) {
+            uint64_t value = *((uint64_t*)abst);
+            if (value > INT32_MAX) {
+                janet_panicf("cannot convert %q to a number, exceededs int32 max", argv[0]);
+            }
+
+            return janet_wrap_integer(value);
+        }
+    }
+
+    janet_panicf("expected int/u64 or int/s64, got %q", argv[0]);
+}
+
 /*
  * Code to support polymorphic comparison.
  * int/u64 and int/s64 support a "compare" method that allows
@@ -514,6 +546,7 @@ void janet_lib_inttypes(JanetTable *env) {
     JanetRegExt it_cfuns[] = {
         JANET_CORE_REG("int/s64", cfun_it_s64_new),
         JANET_CORE_REG("int/u64", cfun_it_u64_new),
+        JANET_CORE_REG("int/to-number", cfun_to_number),
         JANET_REG_END
     };
     janet_core_cfuns_ext(env, NULL, it_cfuns);

--- a/test/suite0006.janet
+++ b/test/suite0006.janet
@@ -39,6 +39,20 @@
    (def c (u64 "32rvv_vv_vv_vv"))
    (def d (u64 "123456789"))))
 
+# Conversion back to an int32
+(assert (= (int/to-number (u64 0xFaFa)) 0xFaFa))
+(assert (= (int/to-number (i64 0xFaFa)) 0xFaFa))
+
+(assert-error
+  "int64 out of bounds for int32"
+  (do
+    (int/to-number (u64 "0x7fff_ffff_ffff_ffff"))
+    (int/to-number (i64 "-0x7fff_ffff_ffff_ffff"))))
+
+(assert-error
+  "int/to-number fails on non-abstract types"
+  (int/to-number 1))
+
 (assert-no-error
  "create some int64 bigints"
  (do

--- a/test/suite0006.janet
+++ b/test/suite0006.janet
@@ -42,12 +42,17 @@
 # Conversion back to an int32
 (assert (= (int/to-number (u64 0xFaFa)) 0xFaFa))
 (assert (= (int/to-number (i64 0xFaFa)) 0xFaFa))
+(assert (= (int/to-number (u64 9007199254740991)) 9007199254740991))
+(assert (= (int/to-number (i64 9007199254740991)) 9007199254740991))
+(assert (= (int/to-number (i64 -9007199254740991)) -9007199254740991))
 
 (assert-error
-  "int64 out of bounds for int32"
-  (do
-    (int/to-number (u64 "0x7fff_ffff_ffff_ffff"))
-    (int/to-number (i64 "-0x7fff_ffff_ffff_ffff"))))
+  "u64 out of bounds for safe integer"
+  (int/to-number (u64 "9007199254740993"))
+
+(assert-error
+  "s64 out of bounds for safe integer"
+  (int/to-number (i64 "-9007199254740993"))))
 
 (assert-error
   "int/to-number fails on non-abstract types"


### PR DESCRIPTION
Currently, there's no way to get the core number back from an `int/` 64-bit integer.

This PR adds a function `(int/to-number)` which converts either an `int/s64` or `int/u64` to a number.
It fails if the input will not fit in a 32-bit int, and uses `janet_wrap_integer` internally.