### PR TITLE
made profile.janet override default dyns such as :pretty-format

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3783,11 +3783,12 @@
         (def getter (if raw-stdin getstdin getline))
         (defn getchunk [buf p]
           (getter (getprompt p) buf env))
-        (setdyn :pretty-format (if colorize "%.20Q" "%.20q"))
-        (setdyn :err-color (if colorize true))
-        (setdyn :doc-color (if colorize true))
-        (setdyn :lint-error error-level)
-        (setdyn :lint-warn error-level)
+        # prioritize dyns set in profile.janet
+        (setdyn :pretty-format (get env :pretty-format (if colorize "%.20Q" "%.20q")))
+        (setdyn :err-color (get env :err-color (if colorize true)))
+        (setdyn :doc-color (get env :doc-color (if colorize true)))
+        (setdyn :lint-error (get env :lint-error error-level))
+        (setdyn :lint-warn (get env :lint-warn error-level))
         (repl getchunk nil env)))))
 
 ###


### PR DESCRIPTION
I want to be able to change `:pretty-format` when using the repl.

I realize there are multiple ways that this can be done, so this is just a suggestion. Main problem with this implementation is the question "should command line args or profile.janet have precedence?".

In this case I chose to let profile.janet win, but if it should be the other way around, let me know.