### PR TITLE
normalize zero without branching

### DIFF
--- a/src/core/value.c
+++ b/src/core/value.c
@@ -322,7 +322,7 @@ int32_t janet_hash(Janet x) {
                 uint64_t u;
             } as;
             as.d = janet_unwrap_number(x);
-            as.d = as.d == 0 ? 0 : as.d; /* normalize negative 0 */
+            as.d += 0.0; /* normalize negative 0 */
             uint32_t lo = (uint32_t)(as.u & 0xFFFFFFFF);
             uint32_t hi = (uint32_t)(as.u >> 32);
             uint32_t hilo = (hi ^ lo) * 2654435769u;


### PR DESCRIPTION
Sorry if this is completely unnecessary, but I found a way to normalize the negative float without branching (https://stackoverflow.com/questions/9657993/how-to-convert-negative-zero-to-positive-zero-in-c/44707354#44707354).
I don't know a good way to profile this sort of change, so feel free to just disregard the PR.

If you have tips on how to benchmark this sort of change, I'd be happy to try it.