### PR TITLE
Add int/to-bytes: Serialize int/[su]64 to a buffer

### DIFF
--- a/test/suite0006.janet
+++ b/test/suite0006.janet
@@ -91,6 +91,27 @@
  "trap INT64_MIN / -1"
  (:/ (int/s64 "-0x8000_0000_0000_0000") -1))
 
+# int/s64 and int/u64 serialization
+(assert (= (int/to-bytes (u64 0)) [0 0 0 0 0 0 0 0]))
+
+(assert (= (int/to-bytes (i64 1) :le) [1 0 0 0 0 0 0 0]))
+(assert (= (int/to-bytes (i64 1) :be) [0 0 0 0 0 0 0 1]))
+(assert (= (int/to-bytes (i64 -1)) [0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF]))
+(assert (= (int/to-bytes (i64 -5) :be) [0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF (- 0xFF 4)]))
+
+(assert (= (int/to-bytes (u64 1) :le) [1 0 0 0 0 0 0 0]))
+(assert (= (int/to-bytes (u64 1) :be) [0 0 0 0 0 0 0 1]))
+(assert (= (int/to-bytes (u64 300) :be) [0 0 0 0 0 0 0x01 0x2C]))
+
+(assert-error
+ "bad value passed to int/to-bytes"
+ (int/to-bytes 1))
+
+(assert-error
+  "invalid endianness passed to int/to-bytes"
+   (int/to-bytes (u64 0) :little))
+
+
 # Dynamic bindings
 (setdyn :a 10)
 (assert (= 40 (with-dyns [:a 25 :b 15] (+ (dyn :a) (dyn :b)))) "dyn usage 1")

--- a/test/suite0006.janet
+++ b/test/suite0006.janet
@@ -92,17 +92,25 @@
  (:/ (int/s64 "-0x8000_0000_0000_0000") -1))
 
 # int/s64 and int/u64 serialization
-(assert (= (int/to-bytes (u64 0)) [0 0 0 0 0 0 0 0]))
+(assert (deep= (int/to-bytes (u64 0)) @"\x00\x00\x00\x00\x00\x00\x00\x00"))
 
-(assert (= (int/to-bytes (i64 1) :le) [1 0 0 0 0 0 0 0]))
-(assert (= (int/to-bytes (i64 1) :be) [0 0 0 0 0 0 0 1]))
-(assert (= (int/to-bytes (i64 -1)) [0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF]))
-(assert (= (int/to-bytes (i64 -5) :be) [0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF (- 0xFF 4)]))
+(assert (deep= (int/to-bytes (i64 1) :le) @"\x01\x00\x00\x00\x00\x00\x00\x00"))
+(assert (deep= (int/to-bytes (i64 1) :be) @"\x00\x00\x00\x00\x00\x00\x00\x01"))
+(assert (deep= (int/to-bytes (i64 -1)) @"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"))
+(assert (deep= (int/to-bytes (i64 -5) :be) @"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFB"))
 
-(assert (= (int/to-bytes (u64 1) :le) [1 0 0 0 0 0 0 0]))
-(assert (= (int/to-bytes (u64 1) :be) [0 0 0 0 0 0 0 1]))
-(assert (= (int/to-bytes (u64 300) :be) [0 0 0 0 0 0 0x01 0x2C]))
+(assert (deep= (int/to-bytes (u64 1) :le) @"\x01\x00\x00\x00\x00\x00\x00\x00"))
+(assert (deep= (int/to-bytes (u64 1) :be) @"\x00\x00\x00\x00\x00\x00\x00\x01"))
+(assert (deep= (int/to-bytes (u64 300) :be) @"\x00\x00\x00\x00\x00\x00\x01\x2C"))
 
+# int/s64 int/u64 to existing buffer
+(let [buf1 @""
+      buf2 @"abcd"]
+  (assert (deep= (int/to-bytes (i64 1) :le buf1) @"\x01\x00\x00\x00\x00\x00\x00\x00"))
+  (assert (deep= buf1 @"\x01\x00\x00\x00\x00\x00\x00\x00"))
+  (assert (deep= (int/to-bytes (u64 300) :be buf2) @"abcd\x00\x00\x00\x00\x00\x00\x01\x2C")))
+
+# int/s64 and int/u64 paramater type checking
 (assert-error
  "bad value passed to int/to-bytes"
  (int/to-bytes 1))
@@ -110,6 +118,10 @@
 (assert-error
   "invalid endianness passed to int/to-bytes"
    (int/to-bytes (u64 0) :little))
+
+(assert-error
+  "invalid buffer passed to int/to-bytes"
+   (int/to-bytes (u64 0) :little :buffer))
 
 
 # Dynamic bindings


### PR DESCRIPTION
Add `int/to-bytes` which writes the bytes of an `int/` type to a buffer. 
Optionally takes a byte order and existing buffer to write to.
