### PR TITLE
Refactor __MACH__ to JANET_APPLE

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -68,7 +68,7 @@ extern char **environ;
 #endif
 
 /* For macos */
-#ifdef __MACH__
+#ifdef JANET_APPLE
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -790,7 +790,7 @@ int32_t janet_sorted_keys(const JanetKV *dict, int32_t cap, int32_t *index_buffe
 /* Clock shims for various platforms */
 #ifdef JANET_GETTIME
 /* For macos */
-#ifdef __MACH__
+#ifdef JANET_APPLE
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
@@ -806,7 +806,7 @@ int janet_gettime(struct timespec *spec) {
     spec->tv_nsec = wintime % 10000000LL * 100;
     return 0;
 }
-#elif defined(__MACH__)
+#elif defined(JANET_APPLE)
 int janet_gettime(struct timespec *spec) {
     clock_serv_t cclock;
     mach_timespec_t mts;

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -57,8 +57,8 @@ extern "C" {
 #define JANET_BSD 1
 #endif
 
-/* Check for Mac */
-#ifdef __APPLE__
+/* Check for macOS or OS X */
+#if defined(__APPLE__) && defined(__MACH__)
 #define JANET_APPLE 1
 #endif
 


### PR DESCRIPTION
# Summary:

This PR does two things:
- Change some uses of `__MACH__` to `JANET_APPLE`
- Change `JANET_APPLE` to check for both `__APPLE__` as well as `__MACH__`

# Details

Heyo Janet folk,

I came across an implementation of `clock_gettime` for older OS X machines which uses `mach_absolute_time`, but before I get into that...

I had noticed that sometimes `__MACH__` is used and sometimes `JANET_APPLE` is used.  This PR consolidates to using `JANET_APPLE` across the board (I hope that's what was intended by `JANET_APPLE`!).

Also, I realized I didn't actually understand the difference between `__MACH__` vs `__APPLE__`, so I dug a bit and it turns out `__APPLE__` is also defined on System 9, etc, so it looks like the most correct thing is actually to use both.

Apple seems to indicate as much here: https://developer.apple.com/library/archive/documentation/Porting/Conceptual/PortingUnix/compiling/compiling.html#//apple_ref/doc/uid/TP40002850-SW13

> To define a section of code to be compiled on OS X system, you should define a section using \_\_APPLE\_\_ with \_\_MACH\_\_ macros.

also this xcode-users mailing list post: https://lists.apple.com/archives/xcode-users/2006/Nov/msg00356.html

> many people seem to use: #if defined(\_\_APPLE\_\_) && defined(\_\_MACH\_\_)

> \_\_APPLE\_\_ is defined for builds on classic too, so may not limit the conditional enough.

as well as various stackoverflow posts, e.g. https://stackoverflow.com/a/26225829

> #if defined(\_\_APPLE\_\_) && defined(\_\_MACH\_\_)
