### PR TITLE
Mac clock shim not needed after 10.12

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -39,10 +39,6 @@
 #include <sys/stat.h>
 #include <signal.h>
 
-#ifdef JANET_APPLE
-#include <AvailabilityMacros.h>
-#endif
-
 #ifdef JANET_WINDOWS
 #include <windows.h>
 #include <direct.h>

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -63,12 +63,6 @@ extern char **environ;
 #endif
 #endif
 
-/* For macos */
-#ifdef JANET_APPLE
-#include <mach/clock.h>
-#include <mach/mach.h>
-#endif
-
 /* Not POSIX, but all Unixes but Solaris have this function. */
 #if defined(JANET_POSIX) && !defined(__sun)
 time_t timegm(struct tm *tm);

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -36,6 +36,10 @@
 #endif
 #endif
 
+#ifdef JANET_APPLE
+#include <AvailabilityMacros.h>
+#endif
+
 #include <inttypes.h>
 
 /* Base 64 lookup table for digits */

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -789,11 +789,6 @@ int32_t janet_sorted_keys(const JanetKV *dict, int32_t cap, int32_t *index_buffe
 
 /* Clock shims for various platforms */
 #ifdef JANET_GETTIME
-/* For macos */
-#ifdef JANET_APPLE
-#include <mach/clock.h>
-#include <mach/mach.h>
-#endif
 #ifdef JANET_WINDOWS
 int janet_gettime(struct timespec *spec) {
     FILETIME ftime;
@@ -806,7 +801,10 @@ int janet_gettime(struct timespec *spec) {
     spec->tv_nsec = wintime % 10000000LL * 100;
     return 0;
 }
-#elif defined(JANET_APPLE)
+/* clock_gettime() wasn't available on Mac until 10.12. */
+#elif defined(JANET_APPLE) && !defined(MAC_OS_X_VERSION_10_12)
+#include <mach/clock.h>
+#include <mach/mach.h>
 int janet_gettime(struct timespec *spec) {
     clock_serv_t cclock;
     mach_timespec_t mts;


### PR DESCRIPTION
# Summary

This PR:
- changes the Mac clock shim to only be used for Macs older than 10.12.
- moves the `AvailabilityMacros.h` include from `os.c` to `util.c`
- removes the unused `mach/clock.h` and `mach/mach.h` includes from `os.c`

# Details

In `util.c`, the Mac clock shim was included for all Macs:

```
if defined(JANET_APPLE)
```

However, `clock_gettime()` was added in 10.12, so the clock shim isn't needed from that point forward: 
- https://opensource.apple.com/releases/
- https://opensource.apple.com/source/Libc/Libc-1158.1.2/gen/clock_gettime.c.auto.html

This PR changes the preprocessor logic to only use the clock shim for Macs running OS X older than 10.12:

```
/* clock_gettime() wasn't available on Mac until 10.12. */
#elif defined(JANET_APPLE) && !defined(MAC_OS_X_VERSION_10_12)
```

Update: I also noticed `AvailabilityMacros.h` was included in `os.c`, but is only used in `util.c`, so I moved the include.

Update2: Also noticed that `mach/clock.h` and `mach/mach.h` were included in `os.c`, but are only needed for the shim.  I'd guess that the clock shim stuff used to live in `os.c` before being pulled out into `util.c`.
