### PR TITLE
Correct version 1.21.1 in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,7 @@
 
 project('janet', 'c',
   default_options : ['c_std=c99', 'build.c_std=c99', 'b_lundef=false', 'default_library=both'],
-  version : '1.21.0')
+  version : '1.21.1')
 
 # Global settings
 janet_path = join_paths(get_option('prefix'), get_option('libdir'), 'janet')


### PR DESCRIPTION
This causes incorrect version in meson compiles (including homebrew)

In the future you may want to consider using the `version: file` argument.