### PR TITLE
Produce dylibs on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ UNAME:=$(shell uname -s)
 ifeq ($(UNAME), Darwin)
 	CLIBS:=$(CLIBS) -ldl
 	SONAME_SETTER:=-Wl,-install_name,
+	JANET_LIBRARY=build/libjanet.dylib
 	LDCONFIG:=true
 else ifeq ($(UNAME), Linux)
 	CLIBS:=$(CLIBS) -lrt -ldl
@@ -165,7 +166,11 @@ build/c/janet.c: build/janet_boot src/boot/boot.janet
 ##### Amalgamation #####
 ########################
 
+ifeq ($(UNAME), Darwin)
+SONAME=libjanet.1.20.dylib
+else
 SONAME=libjanet.so.1.20
+endif
 
 build/c/shell.c: src/mainclient/shell.c
 	cp $< $@
@@ -279,10 +284,16 @@ install: $(JANET_TARGET) $(JANET_LIBRARY) $(JANET_STATIC_LIBRARY) build/janet.pc
 	cp -r build/janet.h '$(DESTDIR)$(INCLUDEDIR)/janet'
 	mkdir -p '$(DESTDIR)$(JANET_PATH)'
 	mkdir -p '$(DESTDIR)$(LIBDIR)'
-	cp $(JANET_LIBRARY) '$(DESTDIR)$(LIBDIR)/libjanet.so.$(shell $(JANET_TARGET) -e '(print janet/version)')'
+	if test $(UNAME) = Darwin ; then \
+		cp $(JANET_LIBRARY) '$(DESTDIR)$(LIBDIR)/libjanet.$(shell $(JANET_TARGET) -e '(print janet/version)').dylib' ; \
+		ln -sf $(SONAME) '$(DESTDIR)$(LIBDIR)/libjanet.dylib' ; \
+		ln -sf libjanet.$(shell $(JANET_TARGET) -e '(print janet/version)').dylib $(DESTDIR)$(LIBDIR)/$(SONAME) ; \
+	else \
+		cp $(JANET_LIBRARY) '$(DESTDIR)$(LIBDIR)/libjanet.so.$(shell $(JANET_TARGET) -e '(print janet/version)')' ; \
+		ln -sf $(SONAME) '$(DESTDIR)$(LIBDIR)/libjanet.so' ; \
+		ln -sf libjanet.so.$(shell $(JANET_TARGET) -e '(print janet/version)') $(DESTDIR)$(LIBDIR)/$(SONAME) ; \
+	fi
 	cp $(JANET_STATIC_LIBRARY) '$(DESTDIR)$(LIBDIR)/libjanet.a'
-	ln -sf $(SONAME) '$(DESTDIR)$(LIBDIR)/libjanet.so'
-	ln -sf libjanet.so.$(shell $(JANET_TARGET) -e '(print janet/version)') $(DESTDIR)$(LIBDIR)/$(SONAME)
 	mkdir -p '$(DESTDIR)$(JANET_MANPATH)'
 	cp janet.1 '$(DESTDIR)$(JANET_MANPATH)'
 	mkdir -p '$(DESTDIR)$(JANET_PKG_CONFIG_PATH)'


### PR DESCRIPTION
This PR changes the Makefile to produce dylibs on macOS.

It appears to work:

![Screen Shot 2022-03-31 at 12 13 20 AM](https://user-images.githubusercontent.com/223396/160981940-8f923981-6785-410d-95ad-2d7728046d07.png)

And it appears that Linux is unaffected:

![Screen Shot 2022-03-31 at 12 17 11 AM](https://user-images.githubusercontent.com/223396/160981975-b7d061d7-b71b-4a23-9e10-652a8de42e1c.png)

(heh, I just noticed the SONAME in the makefile needs to be bumped from 1.20 to 1.21)

This is the first time I've needed a conditional inside of a _target_ of a makefile.  I based my solution on the technique presented here https://stackoverflow.com/questions/15977796/if-conditions-in-a-makefile-inside-a-target but if there are better ways, I'm open!
