### PR TITLE
tuple.c docstrings

### DIFF
--- a/src/core/tuple.c
+++ b/src/core/tuple.c
@@ -65,12 +65,12 @@ JANET_CORE_FN(cfun_tuple_brackets,
 
 JANET_CORE_FN(cfun_tuple_slice,
               "(tuple/slice arrtup [,start=0 [,end=(length arrtup)]])",
-              "Take a sub sequence of an array or tuple from index start "
-              "inclusive to index end exclusive. If start or end are not provided, "
-              "they default to 0 and the length of arrtup respectively. "
-              "'start' and 'end' can also be negative to indicate indexing "
+              "Take a sub-sequence of an array or tuple from index `start` "
+              "inclusive to index `end` exclusive. If `start` or `end` are not provided, "
+              "they default to 0 and the length of `arrtup`, respectively. "
+              "`start` and `end` can also be negative to indicate indexing "
               "from the end of the input. Note that index -1 is synonymous with "
-              "index '(length arrtup)' to allow a full negative slice range. "
+              "index `(length arrtup)` to allow a full negative slice range. "
               "Returns the new tuple.") {
     JanetView view = janet_getindexed(argv, 0);
     JanetRange range = janet_getslice(argc, argv);
@@ -96,7 +96,7 @@ JANET_CORE_FN(cfun_tuple_type,
 JANET_CORE_FN(cfun_tuple_sourcemap,
               "(tuple/sourcemap tup)",
               "Returns the sourcemap metadata attached to a tuple, "
-              " which is another tuple (line, column).") {
+              "which is another tuple (line, column).") {
     janet_fixarity(argc, 1);
     const Janet *tup = janet_gettuple(argv, 0);
     Janet contents[2];


### PR DESCRIPTION
Added some backticks around code in docstrings to distinguish them from prose.