### PR TITLE
added make install & install-jpm-git to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ cd somewhere/my/projects/janet
 make
 make test
 make repl
+make install
+make install-jpm-git
 ```
 
 Find out more about the available make targets by running `make help`.
@@ -103,6 +105,8 @@ cd somewhere/my/projects/janet
 make CC=gcc-x86
 make test
 make repl
+make install
+make install-jpm-git
 ```
 
 ### FreeBSD
@@ -116,6 +120,8 @@ cd somewhere/my/projects/janet
 gmake
 gmake test
 gmake repl
+gmake install
+gmake install-jpm-git
 ```
 
 ### NetBSD


### PR DESCRIPTION
There weren't instructions about running `make install` or `make install-jpm-git` and it wasn't obvious why i didn't get a  `jpm` executable until i found the `install-jpm-git` make target. 

I've only tested on macOS but i assume it'll work the same on the other systems I updated it for. 