### PR TITLE
Added tabseq2, an alternative to tabseq, which constructs a table by …

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -615,6 +615,17 @@
   (def $accum (gensym))
   ~(do (def ,$accum @{}) (loop ,head (,put ,$accum ,key-body (do ,;value-body))) ,$accum))
 
+(defmacro tabseq2
+  ``Similar to `loop`, but accumulates the loop body, expected to return a 2-tuple, into a
+  table as key and value respectively. See `loop` for details.``
+  [head & body]
+  (def $accum (gensym))
+  ~(do (def ,$accum @{})
+       (loop ,head
+             (let [[k v] (do ,;body)]
+               (put ,$accum k v)))
+       ,$accum))
+
 (defmacro generate
   ``Create a generator expression using the `loop` syntax. Returns a fiber
   that yields all values inside the loop in order. See `loop` for details.``


### PR DESCRIPTION
…looping over 2-tuples.

Apologies, I had the thought to add this and discovered a version was added only 3 days ago. Hopefully this is different enough to warrant a look. It takes minor inspiration from Python dictionary comprehensions: It iterates with `loop` just like `seq`, but the expected value of the body is a 2-tuple. So, one can create simple tables inline with a literal 2-tuple:

`(def my-table (tabseq2 [i :range [0 10]] [i (+ i 5)]))`

Or apply some more complex function on a collection's elements which, again, returns a 2-tuple of a key and value:

`(def my-table (tabseq2 [x :in some-coll] (some-2-tuple-func x)))`

Apologies if the `tabseq` already added accomplishes this and I'm just stepping on toes.