### PR TITLE
stop doc-format detecting other modes within code blocks

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3141,16 +3141,18 @@
       (def b (get line i))
       (cond
         (or (= b (chr "\n")) (= b (chr " "))) (endtoken)
-        (= b (chr `\`)) (do
-                          (++ token-length)
-                          (buffer/push token (get line (++ i))))
-        (= b (chr "_")) (delim :underline)
         (= b (chr "`")) (delim :code)
-        (= b (chr "*"))
-        (if (= (chr "*") (get line (+ i 1)))
-          (do (++ i)
-            (delim :bold))
-          (delim :italics))
+        (not (modes :code)) (cond
+          (= b (chr `\`)) (do
+                            (++ token-length)
+                            (buffer/push token (get line (++ i))))
+          (= b (chr "_")) (delim :underline)
+          (= b (chr "*"))
+            (if (= (chr "*") (get line (+ i 1)))
+              (do (++ i)
+                (delim :bold))
+              (delim :italics))
+          (do (++ token-length) (buffer/push token b)))
         (do (++ token-length) (buffer/push token b))))
     (endtoken)
     (tuple/slice tokens))


### PR DESCRIPTION
docs with inline code blocks used to have any instances of `_` or `*` trigger underline or italic, respectively, which is not how markdown handles this situation.

This pull request fixes this issue so that the content of code blocks is copied literally with no modification.