### PR TITLE
Clarify the documentation of janet -E flag

### DIFF
--- a/janet.1
+++ b/janet.1
@@ -164,9 +164,14 @@ Execute a string of Janet source. Source code is executed in the order it is enc
 arguments are executed before later ones.
 
 .TP
-.BR \-E\ code arguments
+.BR \-E\ code\ arguments...
 Execute a single Janet expression as a Janet short-fn, passing the remaining command line arguments to the expression. This allows
 more concise one-liners with command line arguments.
+
+Example: janet -E '(print $0)' 12 is equivalent to '((short-fn (print $0)) 12)', which is in turn equivalent to
+`((fn [k] (print k)) 12)`
+
+See docs for the `short-fn` function for more details.
 
 .TP
 .BR \-d


### PR DESCRIPTION
This confused me, despite having a fair deal of janet experience.

Also I find the man-page roff format fairly counterintuitive. Maybe consider switching from raw man pages to something like [scdoc](https://git.sr.ht/~sircmpwn/scdoc)? Here is an [example file](https://git.sr.ht/~emersion/hut/tree/master/item/doc/hut.1.scd) and the [format docs](https://man.archlinux.org/man/scdoc.5.en).
