### PR TITLE
Add `contains?` helper function to boot.janet

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1069,9 +1069,7 @@
 (defn index-of
   ``Find the first key associated with a value x in a data structure, acting like a reverse lookup.
   Will not look at table prototypes.
-  Returns `dflt` if not found.
-  
-  This will throw an error if `ind` is not iterable.``
+  Returns `dflt` if not found.``
   [x ind &opt dflt]
   (var k (next ind nil))
   (var ret dflt)
@@ -1219,18 +1217,16 @@
   This includes buffers, dictionaries, arrays, fibers, and possibly abstract types.
   
   For tables and structs, this checks the values, not the keys.
-  For arrays, tuples (and any other iterable type), this simply checks if any of the values are eqyak.
+  For arrays, tuples (and any other iterable type), this simply checks if any of the values are equal.
   
   For buffer types (strings, buffers, keywords), this checks if the specified byte is present.
-  This is because, buffer types (strings, keywords, symbols) are iterable types, with byte values.
+  This is because, buffer types (strings, keywords, symbols) are simply sequences, with byte values.
   This means they will also work with `next` and `index-of`.
   
-  However, it also means this function will not check for substrings, only integer bytes.
+  However, it also means this function will not check for substrings, only integer bytes (which could be unexpected).
   In other words is `(contains? "foo bar" "foo")` is always false, because "foo" is not an integer byte
-  If you want to check for a substring in a buffer, then use `(not (nil? (string/find substr buffer)))`
-  
-  If the type is not iterable, this will return false.
-  This is in contrast to `index-of` and `next`, which will throw a type error.
+  If you want to check for a substring in a buffer, then use `(truthy? (string/find substr buffer))`,
+  or just `(if (string/find substr buffer) then else)`
   
   In general this function has O(n) performance, since it requires iterating over all the values.
   

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -120,9 +120,6 @@
 (defn indexed? "Check if x is an array or tuple." [x]
   (def t (type x))
   (if (= t :array) true (= t :tuple)))
-(defn collection? "Check if x is an array, tuple, table, or struct" [x]
-  (def t (type x))
-  (if (= t :array) true (if (= t :tuple) true (if (= t :table) true (= t :struct)))))
 (defn truthy? "Check if x is truthy." [x] (if x true false))
 (defn true? "Check if x is true." [x] (= x true))
 (defn false? "Check if x is false." [x] (= x false))

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1239,7 +1239,7 @@
   # NOTE: index-of throws excpetion if `collection` is not iterable
   #
   # We want to guard against that
-  (try (not (nil? (index-of val collection))) false))
+  (try (not (nil? (index-of val collection))) [[_] false]))
 
 
 (defdyn *defdyn-prefix* ``Optional namespace prefix to add to keywords declared with `defdyn`.

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1236,10 +1236,7 @@
   
   Note that tables or structs (dictionaries) never contain null values```
   [collection val]
-  # NOTE: index-of throws excpetion if `collection` is not iterable
-  #
-  # We want to guard against that
-  (try (not (nil? (index-of val collection))) [[_] false]))
+  (not (nil? (index-of val collection))))
 
 
 (defdyn *defdyn-prefix* ``Optional namespace prefix to add to keywords declared with `defdyn`.

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1072,7 +1072,9 @@
 (defn index-of
   ``Find the first key associated with a value x in a data structure, acting like a reverse lookup.
   Will not look at table prototypes.
-  Returns `dflt` if not found.``
+  Returns `dflt` if not found.
+  
+  This will throw an error if `ind` is not iterable.``
   [x ind &opt dflt]
   (var k (next ind nil))
   (var ret dflt)

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1198,9 +1198,6 @@
   ~(def ,alias :dyn ,;more ,kw))
 
 
-(defn- collection-type-error [val]
-  (errorf "Expected a collection (tuple|array|table|struct), but got %t" val))
-
 (defn contains-value?
   ```Checks if a collection contains the specified value.
 
@@ -1230,7 +1227,7 @@
             (nil? k) (break))
           (set k (next collection k))))
       res)
-    (collection-type-error collection)))
+    false))
 
 (defn contains-key?
   ```Checks if a collection contains the specified key.
@@ -1251,7 +1248,6 @@
 
   Noe that tables or structs (dictionaries) never contain null keys```
   [collection key]
-  (assert (collection? collection) (collection-type-error collection))
   (not (nil? (get collection key))))
 
 (defn contains?
@@ -1274,7 +1270,7 @@
   (cond
     (indexed? collection) (not (nil? (index-of val collection)))
     (dictionary? collection) (not (nil? (get collection val)))
-    (collection-type-error collection)))
+    false))
 
 
 (defdyn *defdyn-prefix* ``Optional namespace prefix to add to keywords declared with `defdyn`.

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1202,44 +1202,46 @@
 
 (defn contains-key?
   ```Checks if a collection contains the specified key.
-
+  
   Semantically equivalent to `(not (nil? (get collection key)))`.
-
-  Arrays, tuples, and buffer types (string/keyword) are indexed by integer keys.
-  For those types, this function simply checks if the index is valid.
-
+  
+  Arrays, tuples, and buffer types (string, buffer, keyword, symbol) are all indexed by integer keys.
+  For those types, this function simply checks if the index is less than the length. 
+  
   If this function succeeds, then a call to `(in collection key)` is guarenteed
   to succeed as well.
-
+  
   Note that tables or structs (dictionaries) never contain null keys```
   [collection key]
   (not (nil? (get collection key))))
 
 (defn contains?
-  ```Checks if a collection, buffer, or any other iterable type contains the specified value.
-
-  For tables and structs, this only checks the keys,
-  and not the values.
-
-  For arrays and tuples this takes O(n) time,
-  while for tables and structs this takes (average) O(1) time.
+  ```Checks if a collection contains the specified value.
   
-  Warning: For buffer types (strings, buffers, keywords), this checks if the specified byte is present.
-  Technically, buffers and strings are an iterable type, they will also work with `next` and `index-of`.
-
+  This supports any iterable type by way of the `next` function.
+  This includes buffers, dictionaries, arrays, fibers, and possibly abstract types.
+  
+  For tables and structs, this checks the values, not the keys.
+  For arrays, tuples (and any other iterable type), this simply checks if any of the values are eqyak.
+  
+  For buffer types (strings, buffers, keywords), this checks if the specified byte is present.
+  This is because, buffer types (strings, keywords, symbols) are iterable types, with byte values.
+  This means they will also work with `next` and `index-of`.
+  
+  However, it also means this function will not check for substrings, only integer bytes.
+  In other words is `(contains? "foo bar" "foo")` is always false, because "foo" is not an integer byte
+  If you want to check for a substring in a buffer, then use `(not (nil? (string/find substr buffer)))`
+  
   If the type is not iterable, this will return false.
-
-  NOTE on strings: `(contains? str val)  will only check for byte values of `val`, not substrings.
-  In other words is `(contains? "foo bar" foo") will return false (because "foo" is not an integer byte).
-  If you want to check for a substring in a buffer, then use `(not (nil? (string/find substr :foo)))`
-
+  This is in contrast to `index-of` and `next`, which will throw a type error.
+  
   In general this function has O(n) performance, since it requires iterating over all the values.
-
+  
   Note that tables or structs (dictionaries) never contain null values```
   [collection val]
   # NOTE: index-of throws excpetion if `collection` is not iterable
   #
-  # guard against that
+  # We want to guard against that
   (try (not (nil? (index-of val collection))) false))
 
 


### PR DESCRIPTION
Before adding this, the simplest way to do this was `(not (nil? (index-of val collection)))` or `(truthy? (index-of val collection))`.

In my opinion, this is significantly less clear than the new API `(contains? collection val)`. 

Also adds four new related functions:
- `collection?` - Tests for collection types (intentionally excluding strings)
- `contains-key?` - Checks if a collection contains a key
   - For arrays, this checks the index
- `contains-value?` - Checks if a collection contains a value

I would say this use case for `contains?` is pretty important. 

Most major programming languages offer some sort of contains function (Python, Java, Rust).
In Python it's even a keyword (`in`).

Some of the other functions are more debatable.

I intentionally excluded strings for the reasons described in the `contains?` comment.

## TODO
- [x] Informal smoke tests (on my laptop)
- [x] Add proper unit tests
- [x] Review & criticism
- [ ] Final docs cleanup
- [ ] Rebase into something coherent (