### PR TITLE
#include <stdatomic.h> in `core/abstract.c`

### DIFF
--- a/src/core/abstract.c
+++ b/src/core/abstract.c
@@ -34,6 +34,8 @@
 #endif
 #endif
 
+#include <stdatomic.h>
+
 /* Create new userdata */
 void *janet_abstract_begin(const JanetAbstractType *atype, size_t size) {
     JanetAbstractHead *header = janet_gcalloc(JANET_MEMORY_NONE,


### PR DESCRIPTION
Added include for `stdatomic.h`, for compatibility with [`tcc`](https://bellard.org/tcc/), which otherwise complains about `__ATOMIC_RELAXED` being undeclared.