### PR TITLE
(os/cpu-count) should not be defined at all with JANET_REDUCED_OS

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -209,6 +209,8 @@ JANET_CORE_FN(os_exit,
     return janet_wrap_nil();
 }
 
+#ifndef JANET_REDUCED_OS
+
 JANET_CORE_FN(os_cpu_count,
               "(os/cpu-count &opt dflt)",
               "Get an approximate number of CPUs available on for this process to use. If "
@@ -250,7 +252,6 @@ JANET_CORE_FN(os_cpu_count,
 #endif
 }
 
-#ifndef JANET_REDUCED_OS
 
 #ifndef JANET_NO_PROCESSES
 


### PR DESCRIPTION
`(os/cpu-count)` is not registered in the core if JANET_REDUCED_OS is enabled, so we can compile it out entirely in that case.