### PR TITLE
Use `/dev/urandom` for `janet_cryptorand` on cygwin

### DIFF
--- a/src/core/util.c
+++ b/src/core/util.c
@@ -869,7 +869,7 @@ int janet_cryptorand(uint8_t *out, size_t n) {
         }
     }
     return 0;
-#elif defined(JANET_LINUX) || ( defined(JANET_APPLE) && !defined(MAC_OS_X_VERSION_10_7) )
+#elif defined(JANET_LINUX) || defined(JANET_CYGWIN) || ( defined(JANET_APPLE) && !defined(MAC_OS_X_VERSION_10_7) )
     /* We should be able to call getrandom on linux, but it doesn't seem
        to be uniformly supported on linux distros.
        On Mac, arc4random_buf wasn't available on until 10.7.

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -67,6 +67,11 @@ extern "C" {
 #define JANET_LINUX 1
 #endif
 
+/* Check for Cygwin */
+#if defined(__CYGWIN__)
+#define JANET_CYGWIN 1
+#endif
+
 /* Check Unix */
 #if defined(_AIX) \
     || defined(__APPLE__) /* Darwin */ \


### PR DESCRIPTION
`/test/suite0007.janet` failed on cygwin

```
 9/11 test/suite0007.janet         FAIL            1.54s   exit status 1
>>> MALLOC_PERTURB_=150 /cygdrive/e/janet/build/janet.exe /cygdrive/e/janet/build/../test/suite0007.janet
―――――――――――――――――――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――
stderr:
Starting suite 7...
error: unable to get sufficient random data
  in os/cryptorand [src/core/os.c] on line 1284
  in cryptorand-check [/cygdrive/e/janet/build/../test/suite0007.janet] on line 265, column 4294967316
  in _thunk [/cygdrive/e/janet/build/../test/suite0007.janet] (tailcall) on line 272, column 4294967305
―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
```
