### PR TITLE
Add test files to meson suite 11 - 14

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -237,7 +237,11 @@ test_files = [
   'test/suite0007.janet',
   'test/suite0008.janet',
   'test/suite0009.janet',
-  'test/suite0010.janet'
+  'test/suite0010.janet',
+  'test/suite0011.janet',
+  'test/suite0012.janet',
+  'test/suite0013.janet',
+  'test/suite0014.janet'
 ]
 foreach t : test_files
   test(t, janet_nativeclient, args : files([t]), workdir : meson.current_source_dir())


### PR DESCRIPTION
As hinted at by @fd00 in https://github.com/janet-lang/janet/pull/1056#issuecomment-1370455004 , `meson.build` was missing some test suite files.
