### PR TITLE
Make PEGs treat bracketed tuples as sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## ??? - Unreleased
+- Bracketed tuples can now be used in place of `sequence`, such that `'["a" "b"]` is the same as `'(* "a" "b")`.
+
 ## 1.26.0 - 2023-01-07
 - Add `ffi/malloc` and `ffi/free`. Useful as tools of last resort.
 - Add `ffi/jitfn` to allow calling function pointers generated at runtime from machine code.

--- a/src/core/peg.c
+++ b/src/core/peg.c
@@ -1311,6 +1311,10 @@ static uint32_t peg_compile1(Builder *b, Janet peg) {
             const Janet *tup = janet_unwrap_tuple(peg);
             int32_t len = janet_tuple_length(tup);
             if (len == 0) peg_panic(b, "tuple in grammar must have non-zero length");
+            if (janet_tuple_flag(tup) & JANET_TUPLE_FLAG_BRACKETCTOR) {
+                spec_sequence(b, len, tup);
+                break;
+            }
             if (janet_checkint(tup[0])) {
                 int32_t n = janet_unwrap_integer(tup[0]);
                 if (n < 0) {

--- a/test/suite0003.janet
+++ b/test/suite0003.janet
@@ -409,6 +409,11 @@
 (check-match '(* (? "hi") -1) "hi" true)
 (check-match '(* (? "hi") -1) "no" false)
 
+# Bracket sequence
+
+(check-match '["a" "b"] "ab" true)
+(check-match '["a" ["b" "c"]] "ab" false)
+
 # Drop
 
 (check-deep '(drop '"hello") "hello" @[])


### PR DESCRIPTION
This is a backwards-incompatible change, and it's also completely subjective, so no hard feelings if you just close it :). Think of this more like an idea that I'm throwing out that happens to have some (trivial) code attached.

The `*` operator is probably my most frequently used PEG thing, and I think `[]` feels like a natural notation for sequencing that saves a couple characters. For example:

```janet
(def ip-address
 '{:dig (range "09")
   :0-4 (range "04")
   :0-5 (range "05")
   :byte (+
           ["25" :0-5]
           ["2" :0-4 :dig]
           ["1" :dig :dig]
           (between 1 2 :dig))
   :main [:byte "." :byte "." :byte "." :byte]})
```

Mildly easier to type? Mildly easier to read? Loses the nice symmetry with `+` and `*` though.