### PR TITLE
Fix some docstring typos

### DIFF
--- a/src/core/buffer.c
+++ b/src/core/buffer.c
@@ -442,7 +442,7 @@ JANET_CORE_FN(cfun_buffer_blit,
 JANET_CORE_FN(cfun_buffer_format,
               "(buffer/format buffer format & args)",
               "Snprintf like functionality for printing values into a buffer. Returns "
-              " the modified buffer.") {
+              "the modified buffer.") {
     janet_arity(argc, 2, -1);
     JanetBuffer *buffer = janet_getbuffer(argv, 0);
     const char *strfrmt = (const char *) janet_getstring(argv, 1);

--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -654,7 +654,7 @@ JANET_CORE_FN(janet_core_memcmp,
               "(memcmp a b &opt len offset-a offset-b)",
               "Compare memory. Takes to byte sequences `a` and `b`, and "
               "return 0 if they have identical contents, a negative integer if a is less than b, "
-              "and a positive integer if a is greather than b. Optionally take a length and offsets "
+              "and a positive integer if a is greater than b. Optionally take a length and offsets "
               "to compare slices of the bytes sequences.") {
     janet_arity(argc, 2, 5);
     JanetByteView a = janet_getbytes(argv, 0);

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -2728,7 +2728,7 @@ error:
 
 JANET_CORE_FN(cfun_ev_go,
               "(ev/go fiber-or-fun &opt value supervisor)",
-              "Put a fiber on the event loop to be resumed later. If a function is used, it is wrapped"
+              "Put a fiber on the event loop to be resumed later. If a function is used, it is wrapped "
               "with `fiber/new` first. "
               "Optionally pass a value to resume with, otherwise resumes with nil. Returns the fiber. "
               "An optional `core/channel` can be provided as a supervisor. When various "
@@ -2939,7 +2939,7 @@ JANET_CORE_FN(cfun_ev_thread,
 
 JANET_CORE_FN(cfun_ev_give_supervisor,
               "(ev/give-supervisor tag & payload)",
-              "Send a message to the current supervior channel if there is one. The message will be a "
+              "Send a message to the current supervisor channel if there is one. The message will be a "
               "tuple of all of the arguments combined into a single message, where the first element is tag. "
               "By convention, tag should be a keyword indicating the type of message. Returns nil.") {
     janet_arity(argc, 1, -1);

--- a/src/core/math.c
+++ b/src/core/math.c
@@ -254,12 +254,14 @@ JANET_CORE_FN(janet_srand,
     return janet_wrap_nil();
 }
 
-#define JANET_DEFINE_MATHOP(name, fop, doc)\
-JANET_CORE_FN(janet_##name, "(math/" #name " x)", doc) {\
+#define JANET_DEFINE_NAMED_MATHOP(c_name, janet_name, fop, doc)\
+JANET_CORE_FN(janet_##c_name, "(math/" #janet_name " x)", doc) {\
     janet_fixarity(argc, 1); \
     double x = janet_getnumber(argv, 0); \
     return janet_wrap_number(fop(x)); \
 }
+
+#define JANET_DEFINE_MATHOP(name, fop, doc) JANET_DEFINE_NAMED_MATHOP(name, name, fop, doc)
 
 JANET_DEFINE_MATHOP(acos, acos, "Returns the arccosine of x.")
 JANET_DEFINE_MATHOP(asin, asin, "Returns the arcsin of x.")
@@ -269,7 +271,7 @@ JANET_DEFINE_MATHOP(cosh, cosh, "Returns the hyperbolic cosine of x.")
 JANET_DEFINE_MATHOP(acosh, acosh, "Returns the hyperbolic arccosine of x.")
 JANET_DEFINE_MATHOP(sin, sin, "Returns the sine of x.")
 JANET_DEFINE_MATHOP(sinh, sinh, "Returns the hyperbolic sine of x.")
-JANET_DEFINE_MATHOP(asinh, asinh, "Returns the hypberbolic arcsine of x.")
+JANET_DEFINE_MATHOP(asinh, asinh, "Returns the hyperbolic arcsine of x.")
 JANET_DEFINE_MATHOP(tan, tan, "Returns the tangent of x.")
 JANET_DEFINE_MATHOP(tanh, tanh, "Returns the hyperbolic tangent of x.")
 JANET_DEFINE_MATHOP(atanh, atanh, "Returns the hyperbolic arctangent of x.")
@@ -287,7 +289,7 @@ JANET_DEFINE_MATHOP(floor, floor, "Returns the largest integer value number that
 JANET_DEFINE_MATHOP(trunc, trunc, "Returns the integer between x and 0 nearest to x.")
 JANET_DEFINE_MATHOP(round, round, "Returns the integer nearest to x.")
 JANET_DEFINE_MATHOP(gamma, tgamma, "Returns gamma(x).")
-JANET_DEFINE_MATHOP(lgamma, lgamma, "Returns log-gamma(x).")
+JANET_DEFINE_NAMED_MATHOP(lgamma, "log-gamma", lgamma, "Returns log-gamma(x).")
 JANET_DEFINE_MATHOP(log1p, log1p, "Returns (log base e of x) + 1 more accurately than (+ (math/log x) 1)")
 JANET_DEFINE_MATHOP(erf, erf, "Returns the error function of x.")
 JANET_DEFINE_MATHOP(erfc, erfc, "Returns the complementary error function of x.")
@@ -303,7 +305,7 @@ JANET_CORE_FN(janet_##name, signature, doc) {\
 JANET_DEFINE_MATH2OP(atan2, atan2, "(math/atan2 y x)", "Returns the arctangent of y/x. Works even when x is 0.")
 JANET_DEFINE_MATH2OP(pow, pow, "(math/pow a x)", "Returns a to the power of x.")
 JANET_DEFINE_MATH2OP(hypot, hypot, "(math/hypot a b)", "Returns c from the equation c^2 = a^2 + b^2.")
-JANET_DEFINE_MATH2OP(nextafter, nextafter,  "(math/next x y)", "Returns the next representable floating point vaue after x in the direction of y.")
+JANET_DEFINE_MATH2OP(nextafter, nextafter,  "(math/next x y)", "Returns the next representable floating point value after x in the direction of y.")
 
 JANET_CORE_FN(janet_not, "(not x)", "Returns the boolean inverse of x.") {
     janet_fixarity(argc, 1);

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -728,7 +728,7 @@ JANET_CORE_FN(cfun_net_getpeername,
 
 JANET_CORE_FN(cfun_net_address_unpack,
               "(net/address-unpack address)",
-              "Given an address returned by net/adress, return a host, port pair. Unix domain sockets "
+              "Given an address returned by net/address, return a host, port pair. Unix domain sockets "
               "will have only the path in the returned tuple.") {
     janet_fixarity(argc, 1);
     struct sockaddr *sa = janet_getabstract(argv, 0, &janet_address_type);
@@ -798,7 +798,7 @@ JANET_CORE_FN(cfun_stream_chunk,
 }
 
 JANET_CORE_FN(cfun_stream_recv_from,
-              "(net/recv-from stream nbytes buf &opt timoeut)",
+              "(net/recv-from stream nbytes buf &opt timeout)",
               "Receives data from a server stream and puts it into a buffer. Returns the socket-address the "
               "packet came from. Takes an optional timeout in seconds, after which will return nil.") {
     janet_arity(argc, 3, 4);

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1859,7 +1859,7 @@ static Janet os_stat_or_lstat(int do_lstat, int32_t argc, Janet *argv) {
 JANET_CORE_FN(os_stat,
               "(os/stat path &opt tab|key)",
               "Gets information about a file or directory. Returns a table if the second argument is a keyword, returns "
-              " only that information from stat. If the file or directory does not exist, returns nil. The keys are:\n\n"
+              "only that information from stat. If the file or directory does not exist, returns nil. The keys are:\n\n"
               "* :dev - the device that the file is on\n\n"
               "* :mode - the type of file, one of :file, :directory, :block, :character, :fifo, :socket, :link, or :other\n\n"
               "* :int-permissions - A Unix permission integer like 8r744\n\n"


### PR DESCRIPTION
Only interesting/controversial thing here is that `math/log-gamma`'s usage said `math/lgamma`, which is less a typo and more an overeager macro.