### PR TITLE
exclude windows specific clib functions when no dynamic modules flag defined

### DIFF
--- a/src/core/util.c
+++ b/src/core/util.c
@@ -927,7 +927,7 @@ const char *error_clib(void) {
 }
 
 #else
-#if defined(JANET_WINDOWS)
+#if defined(JANET_WINDOWS) && !defined(JANET_NO_DYNAMIC_MODULES)
 
 static char error_clib_buf[256];
 char *error_clib(void) {


### PR DESCRIPTION
really found by @sogaiu while working on getting https://github.com/nesbox/TIC-80/pull/2079 building on windows.

Without this additional check the function definitions in `util.h` and `util.c` don't match up. but if I'm understanding everything correctly the intent of `JANET_NO_DYNAMIC_MODULES` is to really cut out all these functions 