### PR TITLE
Update os/realpath docstring

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1976,7 +1976,7 @@ JANET_CORE_FN(os_rename,
 JANET_CORE_FN(os_realpath,
               "(os/realpath path)",
               "Get the absolute path for a given path, following ../, ./, and symlinks. "
-              "Returns an absolute path as a string. Will raise an error on Windows.") {
+              "Returns an absolute path as a string.") {
     janet_fixarity(argc, 1);
     const char *src = janet_getcstring(argv, 0);
 #ifdef JANET_NO_REALPATH


### PR DESCRIPTION
It seems janet's [`os/realpath` has worked on Windows since 1.10.0](https://github.com/janet-lang/janet/blob/master/CHANGELOG.md#1100---2020-06-14):

> Make os/realpath work on windows.

Looks like `os/realpath`'s docstring has a bit of old info in it:

> Will raise an error on Windows.

that goes back earlier than 1.10.0 when `os/realpath` didn't work on Windows, e.g. for a commit on 2020-03-25:

* https://github.com/janet-lang/janet/blob/3d1de237f6a46af261c45d07d3ff9ce3ba46f458/src/core/os.c#L1179-L1192
* https://github.com/janet-lang/janet/blob/3d1de237f6a46af261c45d07d3ff9ce3ba46f458/src/core/os.c#L1405-L1407

This PR removes the text.
