### PR TITLE
local symbols available when *debug* is true

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2769,18 +2769,14 @@
 
   # define variables available at breakpoint
   (def frame ((debug/stack fiber) 0))
-  (def slotsyms ((disasm (frame :function)) :slotsyms))
+  (def symbolslots ((disasm (frame :function)) :symbolslots))
   (def pc (frame :pc))
 
-  (loop [[start stop syms] :in slotsyms]
-    (when (and (or (= start :top)
-                   (<= start pc))
-               (or (= stop :top)
-                   (< pc stop)))
-      (loop [[sym instances] :pairs syms
-             [def-index slot] :in instances
-             :when (<= def-index pc)]
-        (put nextenv (symbol sym) @{:value (get-in frame [:slots slot])}))))
+  (loop [[birth death slot sym] :in symbolslots]
+    (when (and (<= birth pc)
+               (or (= death 0)
+                   (< pc death)))
+        (put nextenv (symbol sym) @{:value (get-in frame [:slots slot])})))
 
   (merge-into nextenv debugger-env)
   (defn debugger-chunks [buf p]

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2774,8 +2774,7 @@
 
   (loop [[birth death slot sym] :in symbolslots]
     (when (and (<= birth pc)
-               (or (= death 0)
-                   (< pc death)))
+               (< pc death))
         (put nextenv (symbol sym) @{:value (get-in frame [:slots slot])})))
 
   (merge-into nextenv debugger-env)

--- a/src/core/asm.c
+++ b/src/core/asm.c
@@ -883,6 +883,8 @@ static Janet janet_disasm_slotcount(JanetFuncDef *def) {
 }
 
 static Janet janet_disasm_symbolslots(JanetFuncDef *def) {
+    // *debug* was probably not true when compiling the function
+    if (def->symbolslots == NULL) { return janet_wrap_nil(); }
     JanetArray *symbolslots = janet_array(def->symbolslots_length);
     for (int32_t i = 0; i < def->symbolslots_length; i++) {
         JanetSymbolSlot ss = def->symbolslots[i];

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -218,7 +218,7 @@ JanetFuncDef *janet_funcdef_alloc(void) {
     def->closure_bitset = NULL;
     def->flags = 0;
     def->slotcount = 0;
-    def->slotsyms = 0;
+    def->symbolslots = 0;
     def->arity = 0;
     def->min_arity = 0;
     def->max_arity = INT32_MAX;
@@ -230,6 +230,7 @@ JanetFuncDef *janet_funcdef_alloc(void) {
     def->constants_length = 0;
     def->bytecode_length = 0;
     def->environments_length = 0;
+    def->symbolslots_length = 0;
     return def;
 }
 

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -218,6 +218,7 @@ JanetFuncDef *janet_funcdef_alloc(void) {
     def->closure_bitset = NULL;
     def->flags = 0;
     def->slotcount = 0;
+    def->slotsyms = 0;
     def->arity = 0;
     def->min_arity = 0;
     def->max_arity = INT32_MAX;

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -218,7 +218,7 @@ JanetFuncDef *janet_funcdef_alloc(void) {
     def->closure_bitset = NULL;
     def->flags = 0;
     def->slotcount = 0;
-    def->symbolslots = 0;
+    def->symbolslots = NULL;
     def->arity = 0;
     def->min_arity = 0;
     def->max_arity = INT32_MAX;

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -998,8 +998,8 @@ static void janetc_init(JanetCompiler *c, JanetTable *env, const uint8_t *where,
 static void janetc_deinit(JanetCompiler *c) {
     janet_v_free(c->buffer);
     janet_v_free(c->mapbuffer);
-    c->env = NULL;
     janet_v_free(c->local_symbols);
+    c->env = NULL;
 }
 
 /* Compile a form. */

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -1012,9 +1012,7 @@ JanetCompileResult janet_compile_lint(Janet source,
     janetc_init(&c, env, where, lints);
 
     /* Push a function scope */
-    if (janet_truthy(janet_dyn("debug"))) {
-        janet_v_push(c.local_symbols, NULL);
-    }
+    janet_v_push(c.local_symbols, NULL);
     janetc_scope(&rootscope, &c, JANET_SCOPE_FUNCTION | JANET_SCOPE_TOP, "root");
 
     /* Set initial form options */

--- a/src/core/compile.h
+++ b/src/core/compile.h
@@ -161,7 +161,7 @@ struct JanetCompiler {
     /* Hold the environment */
     JanetTable *env;
 
-    JanetArray *local_binds;
+    JanetSymbolSlot **local_symbols;
 
     /* Name of source to attach to generated functions */
     const uint8_t *source;

--- a/src/core/compile.h
+++ b/src/core/compile.h
@@ -112,6 +112,7 @@ typedef struct SymPair {
     JanetSlot slot;
     const uint8_t *sym;
     int keep;
+    int32_t bytecode_pos;
 } SymPair;
 
 /* A lexical scope during compilation */
@@ -159,6 +160,8 @@ struct JanetCompiler {
 
     /* Hold the environment */
     JanetTable *env;
+
+    JanetArray *local_binds;
 
     /* Name of source to attach to generated functions */
     const uint8_t *source;

--- a/src/core/gc.c
+++ b/src/core/gc.c
@@ -314,6 +314,7 @@ static void janet_deinit_block(JanetGCObject *mem) {
             janet_free(def->bytecode);
             janet_free(def->sourcemap);
             janet_free(def->closure_bitset);
+            janet_free(def->symbolslots);
         }
         break;
     }

--- a/src/core/marsh.c
+++ b/src/core/marsh.c
@@ -824,6 +824,8 @@ static const uint8_t *unmarshal_one_def(
         def->constants = NULL;
         def->bytecode = NULL;
         def->sourcemap = NULL;
+        def->symbolslots = NULL;
+        def->symbolslots_length = 0;
         janet_v_push(st->lookup_defs, def);
 
         /* Set default lengths to zero */

--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -753,6 +753,10 @@ static JanetSlot janetc_while(JanetFopts opts, int32_t argn, const Janet *argv) 
         if (c->buffer) janet_v__cnt(c->buffer) = labelwt;
         if (c->mapbuffer) janet_v__cnt(c->mapbuffer) = labelwt;
 
+
+        if (janet_truthy(janet_dyn("debug"))) {
+            janet_array_push(c->local_binds, janet_wrap_array(janet_array(0)));
+        }
         janetc_scope(&tempscope, c, JANET_SCOPE_FUNCTION, "while-iife");
 
         /* Recompile in the function scope */
@@ -829,6 +833,9 @@ static JanetSlot janetc_fn(JanetFopts opts, int32_t argn, const Janet *argv) {
 
     /* Begin function */
     c->scope->flags |= JANET_SCOPE_CLOSURE;
+    if (janet_truthy(janet_dyn("debug"))) {
+        janet_array_push(c->local_binds, janet_wrap_array(janet_array(0)));
+    }
     janetc_scope(&fnscope, c, JANET_SCOPE_FUNCTION, "function");
 
     if (argn == 0) {

--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -753,10 +753,7 @@ static JanetSlot janetc_while(JanetFopts opts, int32_t argn, const Janet *argv) 
         if (c->buffer) janet_v__cnt(c->buffer) = labelwt;
         if (c->mapbuffer) janet_v__cnt(c->mapbuffer) = labelwt;
 
-
-        if (janet_truthy(janet_dyn("debug"))) {
-            janet_v_push(c->local_symbols, NULL);
-        }
+        janet_v_push(c->local_symbols, NULL);
         janetc_scope(&tempscope, c, JANET_SCOPE_FUNCTION, "while-iife");
 
         /* Recompile in the function scope */
@@ -833,9 +830,7 @@ static JanetSlot janetc_fn(JanetFopts opts, int32_t argn, const Janet *argv) {
 
     /* Begin function */
     c->scope->flags |= JANET_SCOPE_CLOSURE;
-    if (janet_truthy(janet_dyn("debug"))) {
-        janet_v_push(c->local_symbols, NULL);
-    }
+    janet_v_push(c->local_symbols, NULL);
     janetc_scope(&fnscope, c, JANET_SCOPE_FUNCTION, "function");
 
     if (argn == 0) {

--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -755,7 +755,7 @@ static JanetSlot janetc_while(JanetFopts opts, int32_t argn, const Janet *argv) 
 
 
         if (janet_truthy(janet_dyn("debug"))) {
-            janet_array_push(c->local_binds, janet_wrap_array(janet_array(0)));
+            janet_v_push(c->local_symbols, NULL);
         }
         janetc_scope(&tempscope, c, JANET_SCOPE_FUNCTION, "while-iife");
 
@@ -834,7 +834,7 @@ static JanetSlot janetc_fn(JanetFopts opts, int32_t argn, const Janet *argv) {
     /* Begin function */
     c->scope->flags |= JANET_SCOPE_CLOSURE;
     if (janet_truthy(janet_dyn("debug"))) {
-        janet_array_push(c->local_binds, janet_wrap_array(janet_array(0)));
+        janet_v_push(c->local_symbols, NULL);
     }
     janetc_scope(&fnscope, c, JANET_SCOPE_FUNCTION, "function");
 

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1031,6 +1031,7 @@ struct JanetFuncDef {
     JanetSourceMapping *sourcemap;
     JanetString source;
     JanetString name;
+    Janet *slotsyms;
 
     int32_t flags;
     int32_t slotcount; /* The amount of stack space required for the function */
@@ -1041,6 +1042,7 @@ struct JanetFuncDef {
     int32_t bytecode_length;
     int32_t environments_length;
     int32_t defs_length;
+    int32_t slotsyms_length;
 };
 
 /* A function environment */

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -448,6 +448,7 @@ typedef struct JanetReg JanetReg;
 typedef struct JanetRegExt JanetRegExt;
 typedef struct JanetMethod JanetMethod;
 typedef struct JanetSourceMapping JanetSourceMapping;
+typedef struct JanetSymbolSlot JanetSymbolSlot;
 typedef struct JanetView JanetView;
 typedef struct JanetByteView JanetByteView;
 typedef struct JanetDictView JanetDictView;
@@ -1018,6 +1019,14 @@ struct JanetSourceMapping {
     int32_t column;
 };
 
+/* Symbol to slot mapping & lifetime structure. */
+struct JanetSymbolSlot {
+    uint32_t birth_pc;
+    uint32_t death_pc;
+    uint32_t slot_index;
+    const uint8_t *symbol;
+};
+
 /* A function definition. Contains information needed to instantiate closures. */
 struct JanetFuncDef {
     JanetGCObject gc;
@@ -1031,7 +1040,7 @@ struct JanetFuncDef {
     JanetSourceMapping *sourcemap;
     JanetString source;
     JanetString name;
-    Janet *slotsyms;
+    JanetSymbolSlot *symbolslots;
 
     int32_t flags;
     int32_t slotcount; /* The amount of stack space required for the function */
@@ -1042,7 +1051,7 @@ struct JanetFuncDef {
     int32_t bytecode_length;
     int32_t environments_length;
     int32_t defs_length;
-    int32_t slotsyms_length;
+    int32_t symbolslots_length;
 };
 
 /* A function environment */

--- a/test/suite0011.janet
+++ b/test/suite0011.janet
@@ -106,4 +106,3 @@
 (assert (= ((f 10) 37) 47) "asm environment tables")
 
 (end-suite)
-

--- a/test/suite0015.janet
+++ b/test/suite0015.janet
@@ -1,0 +1,27 @@
+# test *debug* flags
+
+(import ./helper :prefix "" :exit true)
+(start-suite 15)
+
+(assert (deep= (in (disasm (defn a [] (def x 10) x)) :slotsyms)
+               @[])
+  "no slotsyms when *debug* is false")
+
+(setdyn *debug* true)
+(assert (deep= (in (disasm (defn a [] (def x 10) x)) :slotsyms)
+               @[[:top :top @{"a" @[[0 0]] "x" @[[1 1]]}]])
+  "slotsyms when *debug* is true")
+(setdyn *debug* false)
+
+(setdyn *debug* true)
+(assert (deep= (in (disasm (defn a []
+                            (def x 10)
+                            (do
+                              (def y 20)
+                              (+ x y)))) :slotsyms)
+               @[[:top :top @{"a" @[[0 0]] "x" @[[1 1]]}]
+                 [2    5    @{"y" @[[2 2]]}]])
+  "inner slotsyms")
+(setdyn *debug* false)
+
+(end-suite)

--- a/test/suite0015.janet
+++ b/test/suite0015.janet
@@ -26,6 +26,17 @@
   "symbolslots survive disasm/asm")
 (setdyn *debug* false)
 
+# need to fix upvalues
+(comment
+  (setdyn *debug* true)
+  (setdyn :pretty-format "%.40M")
+    (def f (fn [x] (fn [y] (+ x y))))
+    (assert (deep= (map last (in (disasm (f 10)) :symbolslots))
+                  @["x" "y"])
+            "symbolslots upvalues")
+  (setdyn *debug* false)
+  )
+
 (setdyn *debug* true)
 (assert (deep= (in (disasm (defn a [arg]
                             (def x 10)

--- a/test/suite0015.janet
+++ b/test/suite0015.janet
@@ -3,8 +3,7 @@
 (import ./helper :prefix "" :exit true)
 (start-suite 15)
 
-(assert (deep= (in (disasm (defn a [] (def x 10) x)) :symbolslots)
-               @[])
+(assert (deep= (in (disasm (defn a [] (def x 10) x)) :symbolslots) nil)
   "no symbolslots when *debug* is false")
 
 (setdyn *debug* true)
@@ -12,7 +11,6 @@
                @[[0 2147483647 0 "a"] [1 2147483647 1 "x"]])
   "symbolslots when *debug* is true")
 (setdyn *debug* false)
-
 
 # need to fix assembling functions
 (comment

--- a/test/suite0015.janet
+++ b/test/suite0015.janet
@@ -12,15 +12,19 @@
   "symbolslots when *debug* is true")
 (setdyn *debug* false)
 
-# need to fix assembling functions
-(comment
-  (setdyn *debug* true)
-  (def f (asm (disasm (fn [x] (fn [y] (+ x y))))))
-  (assert (deep= (in (disasm f) :symbolslots)
-                @[[0 2147483647 0 "a"] [1 2147483647 1 "x"]])
-    "symbolslots survive disasm/asm")
-  (setdyn *debug* false)
-  )
+(setdyn *debug* true)
+(defn a [arg]
+    (def x 10)
+    (do
+      (def y 20)
+      (def z 30)
+      (+ x y z)))
+(def symbolslots (in (disasm a) :symbolslots))
+(def f (asm (disasm a)))
+(assert (deep= (in (disasm f) :symbolslots)
+                symbolslots)
+  "symbolslots survive disasm/asm")
+(setdyn *debug* false)
 
 (setdyn *debug* true)
 (assert (deep= (in (disasm (defn a [arg]


### PR DESCRIPTION
I wanted to allow the debugging programmer to evaluate local variables at the point of an error.

To this end I made the symbols available in the JanetFuncDef, and in the debugger I add the local variables to the debugger environment as to let the debugee play around with the values.

I have tried:
* defn
* def in defn
* def in do in defn
* defn in do in defn
* def in defn in defn
* def in do in defn in defn

And similar combinations.
I did not manage to expose variables defined outside a closure, but I imagine the `:environments` of the disassembly might hold the key.

I don't imagine this will be merged as is, but I wanted to give my best shot at this, and let others try it and see what errors might pop up.

My main concern is the structure of the `:slotsyms` data, which is useful but not clear. Maybe this should be changed to tables instead?

I added some basic tests as well.