### PR TITLE
1067 Reduced File IO flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ build/janet_boot: $(JANET_BOOT_OBJECTS)
 
 # Now the reason we bootstrap in the first place
 build/c/janet.c: build/janet_boot src/boot/boot.janet
-	build/janet_boot . JANET_PATH '$(JANET_PATH)' > $@
+	build/janet_boot . JANET_PATH '$(JANET_PATH)' 'src/boot/' 'boot.janet' > $@
 	cksum $@
 
 ########################
@@ -184,8 +184,8 @@ endif
 build/c/shell.c: src/mainclient/shell.c
 	cp $< $@
 
-build/janet.h: $(JANET_TARGET) src/include/janet.h $(JANETCONF_HEADER)
-	./$(JANET_TARGET) tools/patch-header.janet src/include/janet.h $(JANETCONF_HEADER) $@
+build/janet.h: build/janet_boot tools/patch-header.janet src/include/janet.h $(JANETCONF_HEADER)
+	build/janet_boot . JANET_PATH '$(JANET_PATH)' 'src/include/janet.h' '$(JANETCONF_HEADER)' '$@' 'tools/' 'patch-header.janet'
 
 build/janetconf.h: $(JANETCONF_HEADER)
 	cp $< $@

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1699,9 +1699,9 @@
 (defn slurp
   ``Read all data from a file with name `path` and then close the file.``
   [path]
-  (if-let [fopen (in root-env 'file/open)
-           fread (in root-env 'file/read)
-           fclose (in root-env 'file/close)]
+  (if-let [fopen (get-in root-env 'file/open)
+           fread (get-in root-env 'file/read)
+           fclose (get-in root-env 'file/close)]
     (do (def f (fopen path :rb))
         (if-not f (error (string "could not open file " path)))
         (def contents (fread f :all))
@@ -1712,9 +1712,9 @@
 (defn spit
   ``Write `contents` to a file at `path`. Can optionally append to the file.``
   [path contents &opt mode]
-  (if-let [fopen (in root-env 'file/open)
-           fwrite (in root-env 'file/write)
-           fclose (in root-env 'file/close)]
+  (if-let [fopen (get-in root-env 'file/open)
+           fwrite (get-in root-env 'file/write)
+           fclose (get-in root-env 'file/close)]
     (do (default mode :wb)
         (def f (fopen path mode))
         (if-not f (error (string "could not open file " path " with mode " mode)))
@@ -2301,8 +2301,8 @@
   [where line col]
   (if-not line (break))
   (unless (string? where) (break))
-  (if-let [fopen (in root-env 'file/open)
-           fread (in root-env 'file/read)]
+  (if-let [fopen (get-in root-env 'file/open)
+           fread (get-in root-env 'file/read)]
     (do (when-with [f (fopen where :r)]
                    (def source-code (fread f :all))
                    (var index 0)
@@ -2700,9 +2700,9 @@
 # If reduced IO, this function always returns nil
 (defn- fexists
   [path]
-  (if-let [fopen (in root-env 'file/open)
-           fread (in root-env 'file/read)
-           fclose (in root-env 'file/close)]
+  (if-let [fopen (get-in root-env 'file/open)
+           fread (get-in root-env 'file/read)
+           fclose (get-in root-env 'file/close)]
     (compif (dyn 'os/stat)
             (= :file (os/stat path :mode))
             (when-let [f (fopen path :rb)]
@@ -2827,7 +2827,7 @@
   `run-context` call. If `exit` is true, any top level errors will trigger a
   call to `(os/exit 1)` after printing the error.``
   [path &named exit env source expander evaluator read parser]
-  (if-let [fopen (in root-env 'file/open)]
+  (if-let [fopen (get-in root-env 'file/open)]
     (do (def f (case (type path)
                  :core/file path
                  :core/stream path
@@ -2912,7 +2912,7 @@
   ``A table of loading method names to loading functions.
   This table lets `require` and `import` load many different kinds
   of files as modules.``
-  (if-let [fopen (in root-env 'file/open)]
+  (if-let [fopen (get-in root-env 'file/open)]
     @{:native native-loader
       :source source-loader
       :preload preload-loader
@@ -3972,9 +3972,9 @@
           (def [line] (parser/where p))
           (string "repl:" line ":" (parser/state p :delimiters) "> "))
         (defn getstdin [prompt buf _]
-          (if-let [fwrite (in root-env 'file/write)
-                   fread (in root-env 'file/read)
-                   fflush (in root-env 'file/flush)]
+          (if-let [fwrite (get-in root-env 'file/write)
+                   fread (get-in root-env 'file/read)
+                   fflush (get-in root-env 'file/flush)]
             (do (fwrite stdout prompt)
                 (fflush stdout)
                 (fread stdin :line buf))

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2912,7 +2912,7 @@
   ``A table of loading method names to loading functions.
   This table lets `require` and `import` load many different kinds
   of files as modules.``
-  (if-let [fopen (get-in root-env ['file/open :value])]
+  (if (in root-env 'file/open)
     @{:native native-loader
       :source source-loader
       :preload preload-loader

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1699,9 +1699,9 @@
 (defn slurp
   ``Read all data from a file with name `path` and then close the file.``
   [path]
-  (if-let [fopen (get-in root-env 'file/open)
-           fread (get-in root-env 'file/read)
-           fclose (get-in root-env 'file/close)]
+  (if-let [fopen (get-in root-env ['file/open :value])
+           fread (get-in root-env ['file/read :value])
+           fclose (get-in root-env ['file/close :value])]
     (do (def f (fopen path :rb))
         (if-not f (error (string "could not open file " path)))
         (def contents (fread f :all))
@@ -1712,9 +1712,9 @@
 (defn spit
   ``Write `contents` to a file at `path`. Can optionally append to the file.``
   [path contents &opt mode]
-  (if-let [fopen (get-in root-env 'file/open)
-           fwrite (get-in root-env 'file/write)
-           fclose (get-in root-env 'file/close)]
+  (if-let [fopen (get-in root-env ['file/open :value])
+           fwrite (get-in root-env ['file/write :value])
+           fclose (get-in root-env ['file/close :value])]
     (do (default mode :wb)
         (def f (fopen path mode))
         (if-not f (error (string "could not open file " path " with mode " mode)))
@@ -2301,8 +2301,8 @@
   [where line col]
   (if-not line (break))
   (unless (string? where) (break))
-  (if-let [fopen (get-in root-env 'file/open)
-           fread (get-in root-env 'file/read)]
+  (if-let [fopen (get-in root-env ['file/open :value])
+           fread (get-in root-env ['file/read :value])]
     (do (when-with [f (fopen where :r)]
                    (def source-code (fread f :all))
                    (var index 0)
@@ -2700,9 +2700,9 @@
 # If reduced IO, this function always returns nil
 (defn- fexists
   [path]
-  (if-let [fopen (get-in root-env 'file/open)
-           fread (get-in root-env 'file/read)
-           fclose (get-in root-env 'file/close)]
+  (if-let [fopen (get-in root-env ['file/open :value])
+           fread (get-in root-env ['file/read :value])
+           fclose (get-in root-env ['file/close :value])]
     (compif (dyn 'os/stat)
             (= :file (os/stat path :mode))
             (when-let [f (fopen path :rb)]
@@ -2827,7 +2827,7 @@
   `run-context` call. If `exit` is true, any top level errors will trigger a
   call to `(os/exit 1)` after printing the error.``
   [path &named exit env source expander evaluator read parser]
-  (if-let [fopen (get-in root-env 'file/open)]
+  (if-let [fopen (get-in root-env ['file/open :value])]
     (do (def f (case (type path)
                  :core/file path
                  :core/stream path
@@ -2912,7 +2912,7 @@
   ``A table of loading method names to loading functions.
   This table lets `require` and `import` load many different kinds
   of files as modules.``
-  (if-let [fopen (get-in root-env 'file/open)]
+  (if-let [fopen (get-in root-env ['file/open :value])]
     @{:native native-loader
       :source source-loader
       :preload preload-loader
@@ -3972,9 +3972,9 @@
           (def [line] (parser/where p))
           (string "repl:" line ":" (parser/state p :delimiters) "> "))
         (defn getstdin [prompt buf _]
-          (if-let [fwrite (get-in root-env 'file/write)
-                   fread (get-in root-env 'file/read)
-                   fflush (get-in root-env 'file/flush)]
+          (if-let [fwrite (get-in root-env ['file/write :value])
+                   fread (get-in root-env ['file/read :value])
+                   fflush (get-in root-env ['file/flush :value])]
             (do (fwrite stdout prompt)
                 (fflush stdout)
                 (fread stdin :line buf))

--- a/src/conf/janetconf.h
+++ b/src/conf/janetconf.h
@@ -35,6 +35,7 @@
 /* #define JANET_NO_THREADS */
 /* #define JANET_NO_FFI */
 /* #define JANET_NO_FFI_JIT */
+#define JANET_REDUCED_IO
 
 /* Other settings */
 /* #define JANET_DEBUG */

--- a/src/conf/janetconf.h
+++ b/src/conf/janetconf.h
@@ -35,7 +35,7 @@
 /* #define JANET_NO_THREADS */
 /* #define JANET_NO_FFI */
 /* #define JANET_NO_FFI_JIT */
-#define JANET_REDUCED_IO
+/* #define JANET_REDUCED_IO */
 
 /* Other settings */
 /* #define JANET_DEBUG */

--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -558,6 +558,7 @@ JANET_CORE_FN(janet_core_hash,
     return janet_wrap_number(janet_hash(argv[0]));
 }
 
+#ifndef JANET_REDUCED_IO
 JANET_CORE_FN(janet_core_getline,
               "(getline &opt prompt buf env)",
               "Reads a line of input into a buffer, including the newline character, using a prompt. "
@@ -587,6 +588,7 @@ JANET_CORE_FN(janet_core_getline,
     }
     return janet_wrap_buffer(buf);
 }
+#endif
 
 JANET_CORE_FN(janet_core_trace,
               "(trace func)",
@@ -958,7 +960,9 @@ static void janet_load_libs(JanetTable *env) {
         JANET_CORE_REG("gcinterval", janet_core_gcinterval),
         JANET_CORE_REG("type", janet_core_type),
         JANET_CORE_REG("hash", janet_core_hash),
+#ifndef JANET_REDUCED_IO
         JANET_CORE_REG("getline", janet_core_getline),
+#endif
         JANET_CORE_REG("dyn", janet_core_dyn),
         JANET_CORE_REG("setdyn", janet_core_setdyn),
         JANET_CORE_REG("trace", janet_core_trace),

--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -558,7 +558,6 @@ JANET_CORE_FN(janet_core_hash,
     return janet_wrap_number(janet_hash(argv[0]));
 }
 
-#ifndef JANET_REDUCED_IO
 JANET_CORE_FN(janet_core_getline,
               "(getline &opt prompt buf env)",
               "Reads a line of input into a buffer, including the newline character, using a prompt. "
@@ -588,7 +587,6 @@ JANET_CORE_FN(janet_core_getline,
     }
     return janet_wrap_buffer(buf);
 }
-#endif
 
 JANET_CORE_FN(janet_core_trace,
               "(trace func)",
@@ -960,9 +958,7 @@ static void janet_load_libs(JanetTable *env) {
         JANET_CORE_REG("gcinterval", janet_core_gcinterval),
         JANET_CORE_REG("type", janet_core_type),
         JANET_CORE_REG("hash", janet_core_hash),
-#ifndef JANET_REDUCED_IO
         JANET_CORE_REG("getline", janet_core_getline),
-#endif
         JANET_CORE_REG("dyn", janet_core_dyn),
         JANET_CORE_REG("setdyn", janet_core_setdyn),
         JANET_CORE_REG("trace", janet_core_trace),

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -56,7 +56,7 @@ const JanetAbstractType janet_file_type = {
     JANET_ATEND_NEXT
 };
 
-#ifndef JANET_REDUCED_IO
+#if !defined(JANET_REDUCED_IO) || defined(JANET_BOOTSTRAP)
 /* Check arguments to fopen */
 static int32_t checkflags(const uint8_t *str) {
     int32_t flags = 0;
@@ -114,7 +114,7 @@ static void *makef(FILE *f, int32_t flags) {
     return iof;
 }
 
-#ifndef JANET_REDUCED_IO
+#if !defined(JANET_REDUCED_IO) || defined(JANET_BOOTSTRAP)
 JANET_CORE_FN(cfun_io_temp,
               "(file/temp)",
               "Open an anonymous temporary file that is removed on close. "
@@ -286,7 +286,7 @@ static int cfun_io_gc(void *p, size_t len) {
     return 0;
 }
 
-#ifndef JANET_REDUCED_IO
+#if !defined(JANET_REDUCED_IO) || defined(JANET_BOOTSTRAP)
 /* Close a file */
 JANET_CORE_FN(cfun_io_fclose,
               "(file/close f)",
@@ -343,7 +343,7 @@ JANET_CORE_FN(cfun_io_fseek,
 }
 #endif // JANET_REDUCED_IO
 
-#ifdef JANET_REDUCED_IO
+#if !defined(JANET_REDUCED_IO) || defined(JANET_BOOTSTRAP)
 static JanetMethod io_file_methods[] = {
     {NULL, NULL}
 };
@@ -771,7 +771,7 @@ void janet_lib_io(JanetTable *env) {
         JANET_CORE_REG("xprinf", cfun_io_xprinf),
         JANET_CORE_REG("flush", cfun_io_flush),
         JANET_CORE_REG("eflush", cfun_io_eflush),
-#ifndef JANET_REDUCED_IO
+#if !defined(JANET_REDUCED_IO) || defined(JANET_BOOTSTRAP)
         JANET_CORE_REG("file/temp", cfun_io_temp),
         JANET_CORE_REG("file/open", cfun_io_fopen),
         JANET_CORE_REG("file/close", cfun_io_fclose),
@@ -784,7 +784,7 @@ void janet_lib_io(JanetTable *env) {
     };
     janet_core_cfuns_ext(env, NULL, io_cfuns);
     janet_register_abstract_type(&janet_file_type);
-#ifdef JANET_REDUCED_IO
+#if !defined(JANET_REDUCED_IO) || defined(JANET_BOOTSTRAP)
     JANET_CORE_DEF(env, "stdout", janet_wrap_nil(), "The standard output file.");
     /* stderr */
     JANET_CORE_DEF(env, "stderr", janet_wrap_nil(), "The standard error file.");

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -345,15 +345,15 @@ JANET_CORE_FN(cfun_io_fseek,
 
 #if !defined(JANET_REDUCED_IO) || defined(JANET_BOOTSTRAP)
 static JanetMethod io_file_methods[] = {
-    {NULL, NULL}
-};
-#else
-static JanetMethod io_file_methods[] = {
     {"close", cfun_io_fclose},
     {"flush", cfun_io_fflush},
     {"read", cfun_io_fread},
     {"seek", cfun_io_fseek},
     {"write", cfun_io_fwrite},
+    {NULL, NULL}
+};
+#else
+static JanetMethod io_file_methods[] = {
     {NULL, NULL}
 };
 #endif

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -784,7 +784,13 @@ void janet_lib_io(JanetTable *env) {
     };
     janet_core_cfuns_ext(env, NULL, io_cfuns);
     janet_register_abstract_type(&janet_file_type);
-#ifndef JANET_REDUCED_IO
+#ifdef JANET_REDUCED_IO
+    JANET_CORE_DEF(env, "stdout", janet_wrap_nil(), "The standard output file.");
+    /* stderr */
+    JANET_CORE_DEF(env, "stderr", janet_wrap_nil(), "The standard error file.");
+    /* stdin */
+    JANET_CORE_DEF(env, "stdin", janet_wrap_nil(), "The standard input file.");
+#else
     int default_flags = JANET_FILE_NOT_CLOSEABLE | JANET_FILE_SERIALIZABLE;
     /* stdout */
     JANET_CORE_DEF(env, "stdout",

--- a/tools/patch-header.janet
+++ b/tools/patch-header.janet
@@ -1,3 +1,69 @@
-# Patch janet.h 
-(def [_ janeth janetconf output] (dyn :args))
+# Patch janet.h
+
+(def defn :macro
+   ```
+  (defn name & more)
+
+  Define a function. Equivalent to `(def name (fn name [args] ...))`.
+  ```
+  (fn defn [name & more]
+    (def len (length more))
+    (def modifiers @[])
+    (var docstr "")
+    (def fstart
+      (fn recur [i]
+        (def {i ith} more)
+        (def t (type ith))
+        (if (= t :tuple)
+          i
+          (do
+            (if (= t :string)
+              (set docstr ith)
+              (array/push modifiers ith))
+            (if (< i len) (recur (+ i 1)))))))
+    (def start (fstart 0))
+    (def args (in more start))
+    # Add function signature to docstring
+    (var index 0)
+    (def arglen (length args))
+    (def buf (buffer "(" name))
+    (while (< index arglen)
+      (buffer/push-string buf " ")
+      (buffer/format buf "%j" (in args index))
+      (set index (+ index 1)))
+    (array/push modifiers (string buf ")\n\n" docstr))
+    # Build return value
+    ~(def ,name ,;modifiers (fn ,name ,;(tuple/slice more start)))))
+
+(defn defmacro :macro
+   "Define a macro."
+  [name & more]
+  (setdyn name @{}) # override old macro definitions in the case of a recursive macro
+  (apply defn name :macro more))
+
+(defmacro if-not
+  "Shorthand for `(if (not condition) else then)`."
+  [condition then &opt else]
+  ~(if ,condition ,else ,then))
+
+(defn slurp
+  ``Read all data from a file with name `path` and then close the file.``
+  [path]
+  (def f (file/open path :rb))
+  (if-not f (error (string "could not open file " path)))
+  (def contents (file/read f :all))
+  (file/close f)
+  contents)
+
+(defn spit
+  ``Write `contents` to a file at `path`. Can optionally append to the file.``
+  [path contents &opt mode]
+  (def mode :wb)
+  (def f (file/open path mode))
+  (if-not f (error (string "could not open file " path " with mode " mode)))
+  (file/write f contents)
+  (file/close f)
+  nil)
+
+(def [_ _ _ _ janeth janetconf output] boot/args)
 (spit output (string/replace `#include "janetconf.h"` (slurp janetconf) (slurp janeth)))


### PR DESCRIPTION
Adds `JANET_REDUCED_IO` flag which removes these functions from `src/io.c` 
    ```
    cfun_io_temp
    cfun_io_fopen
    cfun_io_fread
    cfun_io_fwrite
    cfun_io_fflush
    janet_file_close
    cfun_io_gc
    cfun_io_fclose
    cfun_io_fseek
    ```

In `boot.janet`,  file related functions like `slurp` and `spit` throw errors when required file functions not available 

--- 

The big unsolved problem still here is that bootstrapping the amalgamation requires file IO, specifically in  `do-one-file`. 