### PR TITLE
Add file/tell

### DIFF
--- a/src/core/io.c
+++ b/src/core/io.c
@@ -348,11 +348,24 @@ JANET_CORE_FN(cfun_io_fseek,
     return argv[0];
 }
 
+JANET_CORE_FN(cfun_io_ftell,
+              "(file/tell f)",
+              "Get the current value of the file position for file `f`.") {
+    janet_fixarity(argc, 1);
+    JanetFile *iof = janet_getabstract(argv, 0, &janet_file_type);
+    if (iof->flags & JANET_FILE_CLOSED)
+        janet_panic("file is closed");
+    long pos = ftell(iof->file);
+    if (pos == -1) janet_panic("error getting position in file");
+    return janet_wrap_number((double)pos);
+}
+
 static JanetMethod io_file_methods[] = {
     {"close", cfun_io_fclose},
     {"flush", cfun_io_fflush},
     {"read", cfun_io_fread},
     {"seek", cfun_io_fseek},
+    {"tell", cfun_io_ftell},
     {"write", cfun_io_fwrite},
     {NULL, NULL}
 };
@@ -783,6 +796,7 @@ void janet_lib_io(JanetTable *env) {
         JANET_CORE_REG("file/write", cfun_io_fwrite),
         JANET_CORE_REG("file/flush", cfun_io_fflush),
         JANET_CORE_REG("file/seek", cfun_io_fseek),
+        JANET_CORE_REG("file/tell", cfun_io_ftell),
         JANET_REG_END
     };
     janet_core_cfuns_ext(env, NULL, io_cfuns);

--- a/test/suite0007.janet
+++ b/test/suite0007.janet
@@ -294,9 +294,12 @@
 (assert-error "comptime issue" (eval '(comptime (error "oops"))))
 
 (with [f (file/temp)]
+  (assert (= 0 (file/tell f)) "start of file")
   (file/write f "foo\n")
+  (assert (= 4 (file/tell f)) "after written string")
   (file/flush f)
   (file/seek f :set 0)
+  (assert (= 0 (file/tell f)) "start of file again")
   (assert (= (string (file/read f :all)) "foo\n") "temp files work"))
 
 (var counter 0)


### PR DESCRIPTION
I'd like to reuse a single temp file by writing to it (e.g. via `os/execute`'s `{:out tf}`), seeking to the beginning of the file, and rereading just enough of the written content (and doing this repeatedly).

I'm not sure how to find out how much was written to the file though.

It seems like being able to use `ftell` (say wrapped in `file/tell`) could help with this as one could call `file/tell` before seeking to the beginning and then reading just enough bytes using the result from the `file/tell` call.

Does the addition of `file/tell` seem reasonable?

---

Regarding the code, IIUC, `ftell` returns a `long`, but I don't know how big that would be on the various platforms that Janet is supposed to run on.  I chose to go with `janet_wrap_number` and cast `ftell`'s return value to a `double`.  Does that seem reasonable?