### PR TITLE
Some basic fixes for DragonFly

### DIFF
--- a/src/core/features.h
+++ b/src/core/features.h
@@ -61,4 +61,9 @@
 #define _NETBSD_SOURCE
 #endif
 
+/* Needed for several things when building with -std=c99. */
+#if !__BSD_VISIBLE && defined(__DragonFly__)
+#define __BSD_VISIBLE 1
+#endif
+
 #endif

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -126,6 +126,8 @@ JANET_CORE_FN(os_which,
               "* :freebsd\n\n"
               "* :openbsd\n\n"
               "* :netbsd\n\n"
+              "* :dragonfly\n\n"
+              "* :bsd\n\n"
               "* :posix - A POSIX compatible system (default)\n\n"
               "May also return a custom keyword specified at build time.") {
     janet_fixarity(argc, 0);
@@ -150,6 +152,8 @@ JANET_CORE_FN(os_which,
     return janet_ckeywordv("netbsd");
 #elif defined(__OpenBSD__)
     return janet_ckeywordv("openbsd");
+#elif defined(__DragonFly__)
+    return janet_ckeywordv("dragonfly");
 #elif defined(JANET_BSD)
     return janet_ckeywordv("bsd");
 #else


### PR DESCRIPTION
* On DragonFly BSD, we need to define another macro to get access to all sorts of goodies in C99 mode
* Allow `(os/which)` to return `:dragonfly`, which makes the REPL banner look nicer at the very least

```
Janet 1.27.0-01aab666 dragonfly/x64/gcc - '(doc)' for help
repl:1:>
```