### PR TITLE
remove quotes in math/log-gamma docstring

### DIFF
--- a/src/core/math.c
+++ b/src/core/math.c
@@ -289,7 +289,7 @@ JANET_DEFINE_MATHOP(floor, floor, "Returns the largest integer value number that
 JANET_DEFINE_MATHOP(trunc, trunc, "Returns the integer between x and 0 nearest to x.")
 JANET_DEFINE_MATHOP(round, round, "Returns the integer nearest to x.")
 JANET_DEFINE_MATHOP(gamma, tgamma, "Returns gamma(x).")
-JANET_DEFINE_NAMED_MATHOP(lgamma, "log-gamma", lgamma, "Returns log-gamma(x).")
+JANET_DEFINE_NAMED_MATHOP(lgamma, log-gamma, lgamma, "Returns log-gamma(x).")
 JANET_DEFINE_MATHOP(log1p, log1p, "Returns (log base e of x) + 1 more accurately than (+ (math/log x) 1)")
 JANET_DEFINE_MATHOP(erf, erf, "Returns the error function of x.")
 JANET_DEFINE_MATHOP(erfc, erfc, "Returns the complementary error function of x.")


### PR DESCRIPTION
I broke this in ab224514f098fe744afff4e4036212e40eea7952.

Before this change:

```
Janet 1.27.0-01aab666 macos/aarch64/clang - '(doc)' for help
repl:1:> (doc math/log-gamma)


    cfunction
    src/core/math.c on line 292, column 1

    (math/"log-gamma" x)

    Returns log-gamma(x).
```

After this change:

```
Janet 1.27.0-4e7930fc macos/aarch64/clang - '(doc)' for help
repl:1:> (doc math/log-gamma)


    cfunction
    src/core/math.c on line 292, column 1

    (math/log-gamma x)

    Returns log-gamma(x).
```