### PR TITLE
posix_spawn(p) doesn't always set errno

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1085,7 +1085,14 @@ static Janet os_execute_impl(int32_t argc, Janet *argv, int is_spawn) {
 
     os_execute_cleanup(envp, child_argv);
     if (status) {
-        janet_panicf("%p: %s", argv[0], strerror(errno));
+        switch (errno) {
+            // on macOS, the binary not existing does not cause errno to be set
+            case 0:
+                janet_panicf("%p: No such file or directory", argv[0]);
+                break;
+            default:
+                janet_panicf("%p: %s", argv[0], strerror(errno));
+        }
     }
 
 #endif

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1085,14 +1085,7 @@ static Janet os_execute_impl(int32_t argc, Janet *argv, int is_spawn) {
 
     os_execute_cleanup(envp, child_argv);
     if (status) {
-        switch (errno) {
-            // on macOS, the binary not existing does not cause errno to be set
-            case 0:
-                janet_panicf("%p: No such file or directory", argv[0]);
-                break;
-            default:
-                janet_panicf("%p: %s", argv[0], strerror(errno));
-        }
+		janet_panicf("%p: %s", argv[0], strerror(errno ? errno : ENOENT));
     }
 
 #endif


### PR DESCRIPTION
This also sets the stage up for custom errno handling, in case more expressive error messages for other failure conditions end up being desirable.
Fixes #1015