### PR TITLE
handle null-byte case in scanformat (fixes #1105)

### DIFF
--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -809,9 +809,9 @@ static const char *scanformat(
     *(form++) = '%';
     const char *p2 = strfrmt;
     while (p2 <= p) {
-        if (strchr(FMT_REPLACE_INTTYPES, *p2) != NULL) {
+        char *loc = strchr(FMT_REPLACE_INTTYPES, *p2);
+        if (loc != NULL && *loc != '\0') {
             const char *mapping = get_fmt_mapping(*p2++);
-            if (!mapping) janet_panic("invalid format (found null)");
             size_t len = strlen(mapping);
             strcpy(form, mapping);
             form += len;

--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -811,6 +811,7 @@ static const char *scanformat(
     while (p2 <= p) {
         if (strchr(FMT_REPLACE_INTTYPES, *p2) != NULL) {
             const char *mapping = get_fmt_mapping(*p2++);
+            if (!mapping) janet_panic("invalid format (found null)");
             size_t len = strlen(mapping);
             strcpy(form, mapping);
             form += len;


### PR DESCRIPTION
When there is no format to be found after a %, get_fmt_mapping returns NULL.
It then gets called against strlen, which is a typical SEGV.
Check for NULL aginst mapping, which signals a null format being specified.

Note that there are other edge-conditions present.
Namely, consider: `(printf "hello % " "dave")` (format is still null).
Meanwhile, `(printf "hello % s" "dave")` (outputs "hello dave").