### PR TITLE
drop with a negative count now drops from the end

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1133,16 +1133,17 @@
   (take-until (complement pred) ind))
 
 (defn drop
-  ``Drop the first n elements in an indexed or bytes type. Returns a new tuple or string
-  instance, respectively.``
+  ``Drop the first `n elements in an indexed or bytes type. Returns a new tuple or string
+  instance, respectively. If `n` is negative, drops the last `n` elements instead.``
   [n ind]
   (def use-str (bytes? ind))
   (def f (if use-str string/slice tuple/slice))
   (def len (length ind))
-  # make sure start is in [0, len]
-  (def m (if (> n 0) n 0))
-  (def start (if (> m len) len m))
-  (f ind start -1))
+  (def [start end]
+    (if (>= n 0)
+      [(min n len) len]
+      [0 (max 0 (+ len n))]))
+  (f ind start end))
 
 (defn drop-until
   "Same as `(drop-while (complement pred) ind)`."

--- a/test/suite0005.janet
+++ b/test/suite0005.janet
@@ -83,8 +83,13 @@
 (assert (deep= (drop 10 []) []) "drop 2")
 (assert (deep= (drop 0 [1 2 3 4 5]) [1 2 3 4 5]) "drop 3")
 (assert (deep= (drop 10 [1 2 3]) []) "drop 4")
-(assert (deep= (drop -2 [:a :b :c]) [:a :b :c]) "drop 5")
-(assert-error :invalid-type (drop 3 {}) "drop 6")
+(assert (deep= (drop -1 [1 2 3]) [1 2]) "drop 5")
+(assert (deep= (drop -10 [1 2 3]) []) "drop 6")
+(assert (deep= (drop 1 "abc") "bc") "drop 7")
+(assert (deep= (drop 10 "abc") "") "drop 8")
+(assert (deep= (drop -1 "abc") "ab") "drop 9")
+(assert (deep= (drop -10 "abc") "") "drop 10")
+(assert-error :invalid-type (drop 3 {}) "drop 11")
 
 # drop-until
 


### PR DESCRIPTION
This is a functional change, as previously a negative count would be treated the same as 0. But it seems unlikely to cause problems in practice.

This brings a satisfying symmetry to the quadrants of this "table:"

- First element: `(first list)`
- Last element: `(last list)`
- Everything but the first element: `(drop 1 list)`
- Everything but the last element: `(drop -1 list)`

It might make sense to do the same thing for `take`, but because `take` works with fibers, we can't support it completely.

It might be preferable to have a separate `drop-last` function. The negative count thing seems nicer to me, but I don't know if there's precedent for it elsewhere in the standard library.