### PR TITLE
Tweak long-string|bytes peg in test suite files

### DIFF
--- a/test/suite0003.janet
+++ b/test/suite0003.janet
@@ -349,7 +349,7 @@
 (def janet-longstring
   ~{:delim (some "`")
     :open (capture :delim :n)
-    :close (cmt (* (not (> -1 "`")) (-> :n) (<- :delim)) ,=)
+    :close (cmt (* (not (> -1 "`")) (-> :n) (<- (backmatch :n))) ,=)
     :main (* :open (any (if-not :close 1)) :close -1)})
 
 (check-match janet-longstring "`john" false)
@@ -359,6 +359,7 @@
 (check-match janet-longstring "``  ``" true)
 (check-match janet-longstring "``` `` ```" true)
 (check-match janet-longstring "``  ```" false)
+(check-match janet-longstring "`a``b`" false)
 
 # Line and column capture
 

--- a/test/suite0007.janet
+++ b/test/suite0007.janet
@@ -60,7 +60,7 @@
     :buffer (/ '(* "@" :bytes) (constant :string))
     :long-bytes {:delim (some "`")
                  :open (capture :delim :n)
-                 :close (cmt (* (not (> -1 "`")) (-> :n) ':delim) ,=)
+                 :close (cmt (* (not (> -1 "`")) (-> :n) '(backmatch :n)) ,=)
                  :main (drop (* :open (any (if-not :close 1)) :close))}
     :long-string (/ ':long-bytes (constant :string))
     :long-buffer (/ '(* "@" :long-bytes) (constant :string))


### PR DESCRIPTION
At the repl, I get:
```
$ janet
Janet 1.27.0-440af9fd linux/x64/gcc - '(doc)' for help
repl:1:> (length [`a``b`])
2
repl:2:> `a``b`
"a"
"b"
```
That is, \`a\`\`b\` (no spaces) is recognized as two long-strings.

A couple of the test suite files (and the website docs), have bits that are similar to:

```janet
 ~{:delim (some "`")
   :open (capture :delim :n)
   :close (cmt (* (not (> -1 "`")) (-> :n) (<- :delim)) ,=)
   :main (* :open (any (if-not :close 1)) :close -1)}
```

\`a\`\`b\` gets recognized as a single thing instead of 2 with that (or similar).

This can be seen using a slightly modified peg (for capturing purposes) :

```janet
(def p
 ~{:delim (some "`")
   :open (capture :delim :n)
   :close (cmt (* (not (> -1 "`")) (-> :n) (<- :delim)) ,=)
   :main (capture (* :open (any (if-not :close 1)) :close -1))})
```

```
$ janet
Janet 1.27.0-440af9fd linux/x64/gcc - '(doc)' for help
repl:1:> (def p
repl:2:(>  ~{:delim (some "`")
repl:3:({>    :open (capture :delim :n)
repl:4:({>    :close (cmt (* (not (> -1 "`")) (-> :n) (<- :delim)) ,=)
repl:5:({>    :main (capture (* :open (any (if-not :close 1)) :close -1))})
{:close (cmt (* (not (> -1 "`")) (-> :n) (<- :delim)) <function =>) :delim (some "`") :main (capture (* :open (any (if-not :close 1)) :close -1)) :open (capture :delim :n)}
repl:6:> (peg/match p "`a``b`")
@["`" true "`a``b`"]
```

I think this is not the intended behavior.

This PR contains an attempt at a fix and an additional regression test case.

If it's not quite there, I hope someone else can fix it :)