### PR TITLE
Tweak ev/select docstring

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -985,11 +985,16 @@ JANET_CORE_FN(cfun_channel_pop,
 
 JANET_CORE_FN(cfun_channel_choice,
               "(ev/select & clauses)",
-              "Block until the first of several channel operations occur. Returns a tuple of the form [:give chan], [:take chan x], or [:close chan], where "
-              "a :give tuple is the result of a write and :take tuple is the result of a read. Each clause must be either a channel (for "
-              "a channel take operation) or a tuple [channel x] for a channel give operation. Operations are tried in order, such that the first "
-              "clauses will take precedence over later clauses. Both and give and take operations can return a [:close chan] tuple, which indicates that "
-              "the specified channel was closed while waiting, or that the channel was already closed.") {
+              "Block until the first of several channel operations occur. Returns a "
+	      "tuple of the form [:give chan], [:take chan x], or [:close chan], "
+	      "where a :give tuple is the result of a write and a :take tuple is the "
+	      "result of a read. Each clause must be either a channel (for a channel "
+	      "take operation) or a tuple [channel x] (for a channel give operation). "
+	      "Operations are tried in order such that earlier clauses take "
+	      "precedence over later clauses. Both give and take operations can "
+	      "return a [:close chan] tuple, which indicates that the specified "
+	      "channel was closed while waiting, or that the channel was already "
+	      "closed.") {
     janet_arity(argc, 1, -1);
     int32_t len;
     const Janet *data;


### PR DESCRIPTION
This PR contains changes to the `ev/select` docstring including:

* Wrapping text a bit (improves viewing under width-challenged situations such as certain diff comparisons)
* Additional set of parentheses surrounding explanatory text
* Alternate wording expressing earlier things taking precedence over later things
* Removal of extra `and`