### PR TITLE
Improve cross compilation

### DIFF
--- a/test/suite0007.janet
+++ b/test/suite0007.janet
@@ -239,6 +239,12 @@
 (assert (= (os/mktime (os/date now true) true) now) "local os/mktime")
 (assert (= (os/mktime {:year 1970}) 0) "os/mktime default values")
 
+# OS strftime test
+
+(assert (= (os/strftime "%Y-%m-%d %H:%M:%S" 0) "1970-01-01 00:00:00") "strftime UTC epoch")
+(assert (= (os/strftime "%Y-%m-%d %H:%M:%S" 1388608200) "2014-01-01 20:30:00") "strftime january 2014")
+(assert (= (try (os/strftime "%%%d%t") ([err] err)) "invalid conversion specifier '%t'") "invalid conversion specifier")
+
 # Appending buffer to self
 
 (with-dyns [:out @""]


### PR DESCRIPTION
This PR adds some smoother support for easy cross compilation.

Building janet requires janet_boot to be run on the host at build time; for this some changes were made

- Added $(RUN) variable to allow a emulator to be specified
- Added ".exe" extension to binaries when using MINGW
- $(UNAME) can now be overridden from the make cmdline

Examples:

Cross compiling for win32 and running under wine:

```
make repl \
       CC=i686-w64-mingw32-gcc \
       LD=i686-w64-mingw32-gcc \
       UNAME=MINGW \
       RUN=wine

Janet 1.27.0-ad7c3bed mingw/x86/gcc - '(doc)' for help
```

Cross compiling for aarch64 and running under qemu:

```
make repl \
        CC=aarch64-none-linux-gnu-gcc \
        LD=aarch64-none-linux-gnu-gcc \
        RUN="qemu-aarch64 -L /tmp/aarch64/"

Janet 1.27.0-ad7c3bed linux/aarch64/gcc - '(doc)' for help
```