### PR TITLE
Use (c) instead of 2-byte sequence in boot.janet

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1,5 +1,5 @@
 # The core janet library
-# Copyright 2023 © Calvin Rose
+# Copyright (c) 2023 Calvin Rose
 
 ###
 ###


### PR DESCRIPTION
Currently `boot.janet` [contains the byte sequence C2 A9 (that represents a copyright symbol) very near the beginning of the file](https://github.com/janet-lang/janet/blob/d42afd21e5514e7b6b683c36387772ebdd7b88d8/src/boot/boot.janet#L2).  AFAICT, this is the only non-ASCII in the file.

[Edited original posting to remove what is likely my misunderstanding.]

I think there may be an issue with Emacs' handling of typical `TAGS` index files that get generated for `boot.janet`, which it does not have for some other files such as `tools/gendocs.janet`.  [Relevant code](https://github.com/emacs-mirror/emacs/commit/08b894ab8b9eeea4cd707560ecd84debab174ff3) may have been written in the days of source being unibyte.

This PR has a change to replace C2 A9 with `(c)` as is done in other files in this repository -- [here](https://github.com/janet-lang/janet/blob/d42afd21e5514e7b6b683c36387772ebdd7b88d8/src/core/abstract.c#L2) is an example -- this makes things work out, but admittedly, the problem is not really with Janet's source.