### PR TITLE
Add  clock sources to os/clock (:realtime, :monotonic, :cputime)

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1280,8 +1280,8 @@ JANET_CORE_FN(os_time,
 JANET_CORE_FN(os_clock,
               "(os/clock &opt source)",
               "Return the number of whole + fractional seconds of the requested clock source.\n\n"
-              "The `source` argument is the identifier of the particular clock source to use, when not "
-              "specified the default is `:realtime`:\n"
+              "The `source` argument selects the clock source to use, when not specified the default "
+              "is `:realtime`:\n"
               "- :realtime: Return the real (i.e., wall-clock) time. This clock is affected by discontinuous "
               "  jumps in the system time\n"
               "- :monotonic: Return the number of whole + fractional seconds since some fixed point in "
@@ -1299,7 +1299,7 @@ JANET_CORE_FN(os_clock,
         } else if (janet_cstrcmp(sourcestr, "cputime") == 0) {
             source = JANET_TIME_CPUTIME;
         } else {
-            janet_panicf("expected :real-time, :monotonic, or :cputime, got %v", argv[0]);
+            janet_panicf("expected :realtime, :monotonic, or :cputime, got %v", argv[0]);
         }
     }
     struct timespec tv;

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1278,14 +1278,32 @@ JANET_CORE_FN(os_time,
 }
 
 JANET_CORE_FN(os_clock,
-              "(os/clock)",
-              "Return the number of whole + fractional seconds since some fixed point in time. The clock "
-              "is guaranteed to be non-decreasing in real time.") {
+              "(os/clock &opt source)",
+              "Return the number of whole + fractional seconds of the requested clock source.\n\n"
+              "The `source` argument is the identifier of the particular clock source to use, when not "
+              "specified the default is `:realtime`:\n"
+              "- :realtime: Return the real (i.e., wall-clock) time. This clock is affected by discontinuous "
+              "  jumps in the system time\n"
+              "- :monotonic: Return the number of whole + fractional seconds since some fixed point in "
+              "  time. The clock is guaranteed to be non-decreasing in real time.\n"
+              "- :cputime: Return the CPU time consumed by this process  (i.e. all threads in the process)\n") {
     janet_sandbox_assert(JANET_SANDBOX_HRTIME);
-    janet_fixarity(argc, 0);
-    (void) argv;
+    janet_arity(argc, 0, 1);
+    enum JanetTimeSource source = JANET_TIME_REALTIME;
+    if (argc == 1) {
+        JanetKeyword sourcestr = janet_getkeyword(argv, 0);
+        if (janet_cstrcmp(sourcestr, "realtime") == 0) {
+            source = JANET_TIME_REALTIME;
+        } else if (janet_cstrcmp(sourcestr, "monotonic") == 0) {
+            source = JANET_TIME_MONOTONIC;
+        } else if (janet_cstrcmp(sourcestr, "cputime") == 0) {
+            source = JANET_TIME_CPUTIME;
+        } else {
+            janet_panicf("expected :real-time, :monotonic, or :cputime, got %v", argv[0]);
+        }
+    }
     struct timespec tv;
-    if (janet_gettime(&tv)) janet_panic("could not get time");
+    if (janet_gettime(&tv, source)) janet_panic("could not get time");
     double dtime = tv.tv_sec + (tv.tv_nsec / 1E9);
     return janet_wrap_number(dtime);
 }

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -902,7 +902,7 @@ int janet_gettime(struct timespec *spec) {
 }
 #else
 int janet_gettime(struct timespec *spec) {
-    return clock_gettime(CLOCK_REALTIME, spec);
+    return clock_gettime(CLOCK_MONOTONIC, spec);
 }
 #endif
 #endif

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -901,8 +901,20 @@ int janet_gettime(struct timespec *spec) {
     return 0;
 }
 #else
-int janet_gettime(struct timespec *spec) {
-    return clock_gettime(CLOCK_MONOTONIC, spec);
+int janet_gettime(struct timespec *spec, enum JanetTimeSource source) {
+    clockid_t cid = JANET_TIME_REALTIME;
+    switch (source) {
+        case JANET_TIME_REALTIME:
+            cid = CLOCK_REALTIME;
+            break;
+        case JANET_TIME_MONOTONIC:
+            cid = CLOCK_MONOTONIC;
+            break;
+        case JANET_TIME_CPUTIME:
+            cid = CLOCK_PROCESS_CPUTIME_ID;
+            break;
+    }
+    return clock_gettime(cid, spec);
 }
 #endif
 #endif

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -126,7 +126,12 @@ void janet_core_cfuns_ext(JanetTable *env, const char *regprefix, const JanetReg
 
 /* Clock gettime */
 #ifdef JANET_GETTIME
-int janet_gettime(struct timespec *spec);
+enum JanetTimeSource {
+    JANET_TIME_REALTIME,
+    JANET_TIME_MONOTONIC,
+    JANET_TIME_CPUTIME
+};
+int janet_gettime(struct timespec *spec, enum JanetTimeSource source);
 #endif
 
 /* strdup */

--- a/test/suite0007.janet
+++ b/test/suite0007.janet
@@ -334,16 +334,16 @@
 (assert (pos? (length (gensym))) "gensym not empty, regression #753")
 
 
-# os/clock
+# os/clock. These tests might prove fragile under CI because they
+# rely on measured time. We'll see.
 
 (defmacro measure-time [clocks & body]
-  (def t1 (gensym))
-  (def t2 (gensym))
+  (def [t1 t2] [(gensym) (gensym)])
   ~(do
     (def ,t1 (map |(os/clock $) ,clocks))
     ,;body
     (def ,t2 (map |(os/clock $) ,clocks))
-    (zipcoll ,clocks [ (- (,t2 0) (,t1 0)) (- (,t2 1) (,t1 1)) (- (,t2 2) (,t1 2))]))
+    (zipcoll ,clocks (map |(- ;$) (map tuple ,t2 ,t1))))
 )
 
 # Spin for 0.1 seconds


### PR DESCRIPTION
 instead of CLOCK_REALTIME, this matches the description from the documentation of os/clock. Fixes issue #1144