### PR TITLE
improved error messages for special forms

### DIFF
--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -264,7 +264,7 @@ static const Janet *janetc_make_sourcemap(JanetCompiler *c) {
 
 static JanetSlot janetc_varset(JanetFopts opts, int32_t argn, const Janet *argv) {
     if (argn != 2) {
-        janetc_cerror(opts.compiler, "expected 2 arguments");
+        janetc_cerror(opts.compiler, "expected 2 arguments to set");
         return janetc_cslot(janet_wrap_nil());
     }
     JanetFopts subopts = janetc_fopts_default(opts.compiler);
@@ -335,11 +335,11 @@ static JanetTable *handleattr(JanetCompiler *c, int32_t argn, const Janet *argv)
     return tab;
 }
 
-static JanetSlot dohead(JanetCompiler *c, JanetFopts opts, Janet *head, int32_t argn, const Janet *argv) {
+static JanetSlot dohead(const char *kind, JanetCompiler *c, JanetFopts opts, Janet *head, int32_t argn, const Janet *argv) {
     JanetFopts subopts = janetc_fopts_default(c);
     JanetSlot ret;
     if (argn < 2) {
-        janetc_cerror(c, "expected at least 2 arguments");
+        janetc_error(c, janet_formatc("expected at least 2 arguments to %s", kind));
         return janetc_cslot(janet_wrap_nil());
     }
     *head = argv[0];
@@ -404,7 +404,7 @@ static JanetSlot janetc_var(JanetFopts opts, int32_t argn, const Janet *argv) {
     JanetCompiler *c = opts.compiler;
     Janet head;
     JanetTable *attr_table = handleattr(c, argn, argv);
-    JanetSlot ret = dohead(c, opts, &head, argn, argv);
+    JanetSlot ret = dohead("var", c, opts, &head, argn, argv);
     if (c->result.status == JANET_COMPILE_ERROR)
         return janetc_cslot(janet_wrap_nil());
     destructure(c, argv[0], ret, varleaf, attr_table);
@@ -454,7 +454,7 @@ static JanetSlot janetc_def(JanetFopts opts, int32_t argn, const Janet *argv) {
     Janet head;
     opts.flags &= ~JANET_FOPTS_HINT;
     JanetTable *attr_table = handleattr(c, argn, argv);
-    JanetSlot ret = dohead(c, opts, &head, argn, argv);
+    JanetSlot ret = dohead("def", c, opts, &head, argn, argv);
     if (c->result.status == JANET_COMPILE_ERROR)
         return janetc_cslot(janet_wrap_nil());
     destructure(c, argv[0], ret, defleaf, attr_table);
@@ -708,7 +708,7 @@ static JanetSlot janetc_while(JanetFopts opts, int32_t argn, const Janet *argv) 
     uint8_t ifnjmp = JOP_JUMP_IF_NOT;
 
     if (argn < 2) {
-        janetc_cerror(c, "expected at least 2 arguments");
+        janetc_cerror(c, "expected at least 2 arguments to while");
         return janetc_cslot(janet_wrap_nil());
     }
 

--- a/src/core/value.c
+++ b/src/core/value.c
@@ -439,20 +439,21 @@ int janet_compare(Janet x, Janet y) {
     return status - 2;
 }
 
-static int32_t getter_checkint(Janet key, int32_t max) {
+static int32_t getter_checkint(JanetType type, Janet key, int32_t max) {
     if (!janet_checkint(key)) goto bad;
     int32_t ret = janet_unwrap_integer(key);
     if (ret < 0) goto bad;
     if (ret >= max) goto bad;
     return ret;
 bad:
-    janet_panicf("expected integer key in range [0, %d), got %v", max, key);
+    janet_panicf("expected integer key for %s in range [0, %d), got %v", janet_type_names[type], max, key);
 }
 
 /* Gets a value and returns. Can panic. */
 Janet janet_in(Janet ds, Janet key) {
     Janet value;
-    switch (janet_type(ds)) {
+    JanetType type = janet_type(ds);
+    switch (type) {
         default:
             janet_panicf("expected %T, got %v", JANET_TFLAG_LENGTHABLE, ds);
             break;
@@ -464,19 +465,19 @@ Janet janet_in(Janet ds, Janet key) {
             break;
         case JANET_ARRAY: {
             JanetArray *array = janet_unwrap_array(ds);
-            int32_t index = getter_checkint(key, array->count);
+            int32_t index = getter_checkint(type, key, array->count);
             value = array->data[index];
             break;
         }
         case JANET_TUPLE: {
             const Janet *tuple = janet_unwrap_tuple(ds);
             int32_t len = janet_tuple_length(tuple);
-            value = tuple[getter_checkint(key, len)];
+            value = tuple[getter_checkint(type, key, len)];
             break;
         }
         case JANET_BUFFER: {
             JanetBuffer *buffer = janet_unwrap_buffer(ds);
-            int32_t index = getter_checkint(key, buffer->count);
+            int32_t index = getter_checkint(type, key, buffer->count);
             value = janet_wrap_integer(buffer->data[index]);
             break;
         }
@@ -484,7 +485,7 @@ Janet janet_in(Janet ds, Janet key) {
         case JANET_SYMBOL:
         case JANET_KEYWORD: {
             const uint8_t *str = janet_unwrap_string(ds);
-            int32_t index = getter_checkint(key, janet_string_length(str));
+            int32_t index = getter_checkint(type, key, janet_string_length(str));
             value = janet_wrap_integer(str[index]);
             break;
         }
@@ -752,13 +753,14 @@ void janet_putindex(Janet ds, int32_t index, Janet value) {
 }
 
 void janet_put(Janet ds, Janet key, Janet value) {
-    switch (janet_type(ds)) {
+	JanetType type = janet_type(ds);
+    switch (type) {
         default:
             janet_panicf("expected %T, got %v",
                          JANET_TFLAG_ARRAY | JANET_TFLAG_BUFFER | JANET_TFLAG_TABLE, ds);
         case JANET_ARRAY: {
             JanetArray *array = janet_unwrap_array(ds);
-            int32_t index = getter_checkint(key, INT32_MAX - 1);
+            int32_t index = getter_checkint(type, key, INT32_MAX - 1);
             if (index >= array->count) {
                 janet_array_setcount(array, index + 1);
             }
@@ -767,7 +769,7 @@ void janet_put(Janet ds, Janet key, Janet value) {
         }
         case JANET_BUFFER: {
             JanetBuffer *buffer = janet_unwrap_buffer(ds);
-            int32_t index = getter_checkint(key, INT32_MAX - 1);
+            int32_t index = getter_checkint(type, key, INT32_MAX - 1);
             if (!janet_checkint(value))
                 janet_panicf("can only put integers in buffers, got %v", value);
             if (index >= buffer->count) {


### PR DESCRIPTION
This patch improves the error messages for special forms somewhat.

Below is a list with the wrong code, the old error message and the new error message:

```
(defn test [body msg_old msg_new]                                                                                      
  (def msg (try (eval body) ([err fib] err)))
  (if-not (= msg msg_old) (pp [body msg])))

(def foo @[1 2 3])

(test '(while true)    "expected at least 2 arguments"                                                                             
                       "expected at least 2 arguments to while")

(test '(var alice)     "expected at least 2 arguments"                                                                           
                       "expected at least 2 arguments to var") 

(test '(def bob)       "expected at least 2 arguments"                                                                           
                       "expected at least 2 arguments to def")

(test '(defn foo)      "(macro) expected integer key in range [0, 0), got 0"                                                                              
                       "(macro) expected integer key for tuple in range [0, 0), got 0")

(test '(set)           "expected 2 arguments"                                                                           
                       "expected 2 arguments to set")

(test '(set a)         "expected 2 arguments"                                                                           
                       "expected 2 arguments to set")

(test '(set (foo 5) 1) "expected 2 arguments"                                                                           
                       "expected 2 arguments to set") 
```