### PR TITLE
Add docstring to string/format

### DIFF
--- a/src/core/string.c
+++ b/src/core/string.c
@@ -535,7 +535,30 @@ JANET_CORE_FN(cfun_string_join,
 JANET_CORE_FN(cfun_string_format,
               "(string/format format & values)",
               "Similar to C's `snprintf`, but specialized for operating with Janet values. Returns "
-              "a new string.") {
+              "a new string.\n\n"
+              "The following conversion specifiers are supported, where the upper case specifiers generate "
+              "upper case output:\n"
+              "- `c`: ASCII character.\n"
+              "- `d`, `i`: integer, formatted as a decimal number.\n"
+              "- `x`, `X`: integer, formatted as a hexadecimal number.\n"
+              "- `o`: integer, formatted as an octal number.\n"
+              "- `f`, `F`: floating point number, formatted as a decimal number.\n"
+              "- `e`, `E`: floating point number, formatted in scientific notation.\n"
+              "- `g`, `G`: floating point number, formatted in its shortest form.\n"
+              "- `a`, `A`: floating point number, formatted as a hexadecimal number.\n"
+              "- `s`: formatted as a string, precision indicates padding and maximum length.\n"
+              "- `t`: emit the type of the given value.\n"
+              "- `v`: format with (describe x)"
+              "- `V`: format with (string x)"
+              "- `j`: format to jdn (Janet data notation).\n"
+              "\n"
+              "The following conversion specifiers are used for \"pretty-printing\", where the upper-case "
+              "variants generate colored output. These speficiers can take a precision "
+              "argument to specify the maximum nesting depth to print.\n"
+              "- `p`, `P`: pretty format, truncating if necessary\n"
+              "- `m`, `M`: pretty format without truncating.\n"
+              "- `q`, `Q`: pretty format on one line, truncating if necessary.\n"
+              "- `n`, `N`: pretty format on one line without truncation.\n") {
     janet_arity(argc, 1, -1);
     JanetBuffer *buffer = janet_buffer(0);
     const char *strfrmt = (const char *) janet_getstring(argv, 0);


### PR DESCRIPTION
This adds documentation to string/format, I would appreciate comments on the descriptions.

```
    Similar to C's snprintf, but specialized for operating with Janet 
    values. Returns a new string.

    The following conversion specifiers are supported, where the upper 
    case specifiers generate upper case output:

    * c: ASCII character.
    * d, i: integer, formatted as a decimal number.
    * x, X: integer, formatted as a hexadecimal number.
    * o: integer, formatted as an octal number.
    * f, F: floating point number, formatted as a decimal number.
    * e, E: floating point number, formatted in scientific notation.
    * g, G: floating point number, formatted in its shortest form.
    * a, A: floating point number, formatted as a hexadecimal number.
    * s: formatted as a string, precision indicates padding and maximum 
      length.
    * t: emit the type of the given value.
    * v: format with (describe x)- V: format with (string x)
    * j: format to jdn (Janet data notation)

    The following conversion specifiers are used for "pretty-printing", 
    where the upper-case variants generate colored output. These 
    speficiers can take a precision argument to specify the maximum 
    nesting depth to print.

    * p, P: pretty format, truncating if necessary
    * m, M: pretty format without truncating.
    * q, Q: pretty format on one line, truncating if necessary.
    * n, N: pretty format on one line without truncation.

```
