### PR TITLE
Improved various error messages when handling unexpected types.

### DIFF
--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -458,7 +458,7 @@ JANET_CORE_FN(janet_core_getproto,
                ? janet_wrap_struct(janet_struct_proto(st))
                : janet_wrap_nil();
     }
-    janet_panicf("expected struct|table, got %v", argv[0]);
+    janet_panicf("expected struct or table, got %v", argv[0]);
 }
 
 JANET_CORE_FN(janet_core_struct,

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -2911,7 +2911,7 @@ static JanetEVGenericMessage janet_go_thread_subr(JanetEVGenericMessage args) {
         JanetFiber *fiber;
         if (!janet_checktype(fiberv, JANET_FIBER)) {
             if (!janet_checktype(fiberv, JANET_FUNCTION)) {
-                janet_panicf("expected function|fiber, got %v", fiberv);
+                janet_panicf("expected function or fiber, got %v", fiberv);
             }
             JanetFunction *func = janet_unwrap_function(fiberv);
             if (func->def->min_arity > 1) {

--- a/src/core/inttypes.c
+++ b/src/core/inttypes.c
@@ -138,7 +138,7 @@ int64_t janet_unwrap_s64(Janet x) {
             break;
         }
     }
-    janet_panicf("bad s64 initializer: %t", x);
+    janet_panicf("can not convert %t %q to 64 bit signed integer", x, x);
     return 0;
 }
 
@@ -169,7 +169,7 @@ uint64_t janet_unwrap_u64(Janet x) {
             break;
         }
     }
-    janet_panicf("bad u64 initializer: %t", x);
+    janet_panicf("can not convert %t %q to a 64 bit unsigned integer", x, x);
     return 0;
 }
 

--- a/src/core/peg.c
+++ b/src/core/peg.c
@@ -1100,7 +1100,7 @@ static void spec_matchtime(Builder *b, int32_t argc, const Janet *argv) {
     Janet fun = argv[1];
     if (!janet_checktype(fun, JANET_FUNCTION) &&
             !janet_checktype(fun, JANET_CFUNCTION)) {
-        peg_panicf(b, "expected function|cfunction, got %v", fun);
+        peg_panicf(b, "expected function or cfunction, got %v", fun);
     }
     uint32_t tag = (argc == 3) ? emit_tag(b, argv[2]) : 0;
     uint32_t cindex = emit_constant(b, fun);

--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -736,7 +736,7 @@ static void pushtypes(JanetBuffer *buffer, int types) {
             if (first) {
                 first = 0;
             } else {
-                janet_buffer_push_u8(buffer, '|');
+                janet_buffer_push_cstring(buffer, (types == 1) ? " or " : ", ");
             }
             janet_buffer_push_cstring(buffer, janet_type_names[i]);
         }


### PR DESCRIPTION
```
error: bad slot #1, expected string|symbol|keyword|buffer, got ...
error: bad slot #1, expected a string, symbol, keyword or buffer, got ...
```

```
bad s64 initializer: "donkey"
can not convert string "donkey" to s64
```

In other places error message do not talk about "s64"  but about "64 bit signed integer", would that be preferable here as well?