### PR TITLE
Fix warning in janet_gettime()

### DIFF
--- a/src/core/util.c
+++ b/src/core/util.c
@@ -933,7 +933,7 @@ int janet_gettime(struct timespec *spec, enum JanetTimeSource source) {
 }
 #else
 int janet_gettime(struct timespec *spec, enum JanetTimeSource source) {
-    clockid_t cid = JANET_TIME_REALTIME;
+    clockid_t cid = CLOCK_REALTIME;
     if (source == JANET_TIME_REALTIME) {
         cid = CLOCK_REALTIME;
     } else if (source == JANET_TIME_MONOTONIC) {


### PR DESCRIPTION
Sorry for the flood of PRs.

This one fixes a warning introduced by my own recent `os-clock` change (it did not show up in my local build but I just noticed in CI); it should not affect behavior in any way since the if-else chain is exhaustive and will overwrite the fault initial value of `cid` in any case.