### PR TITLE
More portable method of installing janet.h -> janet/janet.h symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ install: $(JANET_TARGET) $(JANET_LIBRARY) $(JANET_STATIC_LIBRARY) build/janet.pc
 	strip '$(DESTDIR)$(BINDIR)/janet'
 	mkdir -p '$(DESTDIR)$(INCLUDEDIR)/janet'
 	cp -r build/janet.h '$(DESTDIR)$(INCLUDEDIR)/janet'
-	ln -sf -T ./janet/janet.h '$(DESTDIR)$(INCLUDEDIR)/janet.h' || true #fixme bsd
+	ln -sf ./janet/janet.h '$(DESTDIR)$(INCLUDEDIR)/janet.h'
 	mkdir -p '$(DESTDIR)$(JANET_PATH)'
 	mkdir -p '$(DESTDIR)$(LIBDIR)'
 	if test $(UNAME) = Darwin ; then \


### PR DESCRIPTION
The problem that #994 was trying to solve (the symlink should be a relative path and not absolute) doesn't actually require the use of the GNU-only `-t`/`-T` option to ln(1).

