### PR TITLE
Fix janet_formatbv() type when handling %d %u int specifiers

### DIFF
--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -846,7 +846,7 @@ void janet_formatbv(JanetBuffer *b, const char *format, va_list args) {
                 }
                 case 'd':
                 case 'i': {
-                    int64_t n = va_arg(args, long);
+                    int64_t n = va_arg(args, int);
                     nb = snprintf(item, MAX_ITEM, form, n);
                     break;
                 }
@@ -854,7 +854,7 @@ void janet_formatbv(JanetBuffer *b, const char *format, va_list args) {
                 case 'X':
                 case 'o':
                 case 'u': {
-                    uint64_t n = va_arg(args, unsigned long);
+                    uint64_t n = va_arg(args, unsigned int);
                     nb = snprintf(item, MAX_ITEM, form, n);
                     break;
                 }


### PR DESCRIPTION
At https://github.com/janet-lang/janet/blob/master/src/core/pp.c#L849, janet_formatbv() pulls a long instead of an int when handling the %d specifier, potentially leading to wrong results:
```C
janet_eprintf(">>> %d\n", (int32_t) - 1);
```
output:
```
>>> 4294967295
```

In the wild this shows like this:

```janet
(buffer/slice @"" 3)                                                  
```
error thrown:
```
error: start index 3 out of range [4294967295,0]
```

The same goes for `%u`  and friends.
