### PR TITLE
Added JANET_NO_AMALG flag to Makefile 

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4157,10 +4157,11 @@
 
   (defn do-one-file
     [fname]
-    (print "\n/* " fname " */")
-    (print "#line 0 \"" fname "\"\n")
-    (def source (slurp fname))
-    (print (string/replace-all "\r" "" source)))
+    (if-not (has-value? boot/args "image-only") (do
+      (print "\n/* " fname " */")
+      (print "#line 0 \"" fname "\"\n")
+      (def source (slurp fname))
+      (print (string/replace-all "\r" "" source)))))
 
   (do-one-file feature-header)
 


### PR DESCRIPTION
(Not sure if people are willing to pull in this added complexity, but giving it a shot anyway)


This change allows building Janet from the individual source files instead of from the amalgamated `janet.c`; this considerably speeds up parallel builds on modern CPUs;

```
 make clean; time make -j NO_AMALG=0 
[...]
real	0m7.882s
```

vs

```
make clean; time make -j NO_AMALG=1 
[...]
real	0m1.481s
```

For me this make the difference between "comfortably and quickly running my tests" and "getting slightly annoyed staring at my screen",