### PR TITLE
Ensure ev/gather fibers are fully canceled on error

### DIFF
--- a/test/suite-ev.janet
+++ b/test/suite-ev.janet
@@ -168,6 +168,13 @@
 (assert (deep= @[] (ev/gather)) "ev/gather 2")
 (assert-error "ev/gather 3" (ev/gather 1 2 (error 3)))
 
+(var cancel-counter 0)
+(assert-error "ev/gather 4.1" (ev/gather
+                               (defer (++ cancel-counter) (ev/take (ev/chan)))
+                               (defer (++ cancel-counter) (ev/take (ev/chan)))
+                               (error :oops)))
+(assert (= cancel-counter 2) "ev/gather 4.2")
+
 # Net testing
 # 2904c19ed
 (repeat 10


### PR DESCRIPTION
When an error occurs in an `ev/gather` form, it is possible that not all the sibling fibers are canceled.  This can lead to process hangs, if an uncanceled fiber blocks.

The problem is that `each` is not well-defined for tables that are being mutated.  So, sometimes the `(put fibers f nil)` in `cancel-all` causes iteration to skip entries.  It's not deterministic since the hash of a fiber is based on its address.  For integers, it is deterministic, and you can see the effect here:

```janet
(def t @{1 1
         2 2
         3 3})
(each x t
  (put t x nil))
(pp t) # => @{2 2 3 3}
```

A script like this can be used to reproduce the process hangs:

```bash
#!/bin/bash

# To use a different janet:
#     JANET=./build/janet ./gather-test
: ${JANET:=janet}
attempts=100
hangs=0

for i in $(seq $attempts); do
    timeout 0.5 "$JANET" -e '
(defn hang [] (ev/take (ev/chan)))
(protect
  (ev/gather
   (error :cancel)
   (hang)
   (hang)
   (hang)
   # Three hanging fibers is plenty, but adding more increases the frequency.
   # (hang)
   # (hang)
   # (hang)
   # (hang)
   ))
' || (( hangs++ ))
done

echo "attempts: $attempts"
echo "hangs:    $hangs"
```
---

This PR fixes the cancellation problem by first iterating the collection of fibers to call `ev/cancel`, then clearing the table all at once after.  It also changes the semantics of `ev/gather` to guarantee that all canceled fibers have completed before returning.  I think this is desirable but could be convinced otherwise.