### PR TITLE
Fix resumption values when closing a channel

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1171,9 +1171,9 @@ JANET_CORE_FN(cfun_channel_close,
                 janet_ev_post_event(vm, janet_thread_chan_cb, msg);
             } else {
                 if (writer.mode == JANET_CP_MODE_CHOICE_WRITE) {
-                    janet_schedule(writer.fiber, janet_wrap_nil());
-                } else {
                     janet_schedule(writer.fiber, make_close_result(channel));
+                } else {
+                    janet_schedule(writer.fiber, janet_wrap_nil());
                 }
             }
         }
@@ -1190,9 +1190,9 @@ JANET_CORE_FN(cfun_channel_close,
                 janet_ev_post_event(vm, janet_thread_chan_cb, msg);
             } else {
                 if (reader.mode == JANET_CP_MODE_CHOICE_READ) {
-                    janet_schedule(reader.fiber, janet_wrap_nil());
-                } else {
                     janet_schedule(reader.fiber, make_close_result(channel));
+                } else {
+                    janet_schedule(reader.fiber, janet_wrap_nil());
                 }
             }
         }

--- a/test/suite-ev.janet
+++ b/test/suite-ev.janet
@@ -321,5 +321,25 @@
 (assert (= item1 "hello"))
 (assert (= item2 "world"))
 
+# ev/take, suspended, channel closed
+(def ch (ev/chan))
+(ev/go |(ev/chan-close ch))
+(assert (= (ev/take ch) nil))
+
+# ev/give, suspended, channel closed
+(def ch (ev/chan))
+(ev/go |(ev/chan-close ch))
+(assert (= (ev/give ch 1) nil))
+
+# ev/select, suspended take operation, channel closed
+(def ch (ev/chan))
+(ev/go |(ev/chan-close ch))
+(assert (= (ev/select ch) [:close ch]))
+
+# ev/select, suspended give operation, channel closed
+(def ch (ev/chan))
+(ev/go |(ev/chan-close ch))
+(assert (= (ev/select [ch 1]) [:close ch]))
+
 (end-suite)
 


### PR DESCRIPTION
When suspended in `ev/give` or `ev/take`, closing the channel should cause the result of `ev/give` or `ev/take` to be `nil`. 
[ref](https://janet-lang.org/api/ev.html#ev/chan-close)

When suspended in `ev/select`, closing the channel should cause the result of `ev/select` to be `[:close ch]`.
[ref](https://janet-lang.org/api/ev.html#ev/select)

The results were flipped before.