### PR TITLE
Make take and drop more symmetric

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1083,9 +1083,9 @@
 (defn- take-n-slice
   [f n ind]
   (def len (length ind))
-  (def negn (< n 0))
-  (def start (if negn (max 0 (+ len n)) 0))
-  (def end (if negn len (min n len)))
+  (def m (+ len n))
+  (def start (if (< n 0 m) m 0))
+  (def end (if (<= 0 n len) n len))
   (f ind start end))
 
 (defn take
@@ -1093,8 +1093,8 @@
   respectively. If `n` is negative, takes the last `n` elements instead.``
   [n ind]
   (cond
-    (bytes? ind) (take-n-slice string/slice n ind)
     (indexed? ind) (take-n-slice tuple/slice n ind)
+    (bytes? ind) (take-n-slice string/slice n ind)
     (dictionary? ind) (do
                         (var left n)
                         (tabseq [[i x] :pairs ind :until (< (-- left) 0)] i x))
@@ -1117,8 +1117,8 @@
   "Same as `(take-while (complement pred) ind)`."
   [pred ind]
   (cond
-    (bytes? ind) (take-until-slice string/slice pred ind)
     (indexed? ind) (take-until-slice tuple/slice pred ind)
+    (bytes? ind) (take-until-slice string/slice pred ind)
     (dictionary? ind) (tabseq [[i x] :pairs ind :until (pred x)] i x)
     (seq [x :in ind :until (pred x)] x)))
 
@@ -1131,10 +1131,10 @@
 (defn- drop-n-slice
   [f n ind]
   (def len (length ind))
-  (def negn (< n 0))
-  (def start (if negn 0 (min n len)))
-  (def end (if negn (max 0 (+ len n)) len))
-  (f ind start end))
+  (cond
+    (<= 0 n len) (f ind n)
+    (< (- len) n 0) (f ind 0 (+ len n))
+    (f ind 0 0)))
 
 (defn- drop-n-dict
   [f n ind]
@@ -1148,8 +1148,8 @@
   instance, respectively. If `n` is negative, drops the last `n` elements instead.``
   [n ind]
   (cond
-    (bytes? ind) (drop-n-slice string/slice n ind)
     (indexed? ind) (drop-n-slice tuple/slice n ind)
+    (bytes? ind) (drop-n-slice string/slice n ind)
     (struct? ind) (drop-n-dict struct/to-table n ind)
     (table? ind) (drop-n-dict table/clone n ind)
     (do
@@ -1175,8 +1175,8 @@
   "Same as `(drop-while (complement pred) ind)`."
   [pred ind]
   (cond
-    (bytes? ind) (drop-until-slice string/slice pred ind)
     (indexed? ind) (drop-until-slice tuple/slice pred ind)
+    (bytes? ind) (drop-until-slice string/slice pred ind)
     (struct? ind) (drop-until-dict struct/to-table pred ind)
     (table? ind) (drop-until-dict table/clone pred ind)
     (do (find pred ind) ind)))

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4189,12 +4189,11 @@
 
   (defn do-one-file
     [fname]
-    (if-not (has-value? boot/args "image-only")
-      (do
-        (print "\n/* " fname " */")
-        (print "#line 0 \"" fname "\"\n")
-        (def source (slurp fname))
-        (print (string/replace-all "\r" "" source)))))
+    (unless (has-value? boot/args "image-only")
+      (print "\n/* " fname " */")
+      (print "#line 0 \"" fname "\"\n")
+      (def source (slurp fname))
+      (print (string/replace-all "\r" "" source))))
 
   (do-one-file feature-header)
 

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1134,7 +1134,7 @@
   (cond
     (<= 0 n len) (f ind n)
     (< (- len) n 0) (f ind 0 (+ len n))
-    (f ind 0 0)))
+    (f ind len)))
 
 (defn- drop-n-dict
   [f n ind]

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1080,42 +1080,30 @@
     (set k (next ind k)))
   ret)
 
-(defn- take-n-fallback
-  [n xs]
-  (def res @[])
-  (when (> n 0)
-    (var left n)
-    (each x xs
-      (array/push res x)
-      (-- left)
-      (if (= 0 left) (break))))
-  res)
-
-(defn- take-until-fallback
-  [pred xs]
-  (def res @[])
-  (each x xs
-    (if (pred x) (break))
-    (array/push res x))
-  res)
-
-(defn- slice-n
+(defn- take-n-slice
   [f n ind]
   (def len (length ind))
-  # make sure end is in [0, len]
-  (def m (if (> n 0) n 0))
-  (def end (if (> m len) len m))
-  (f ind 0 end))
+  (def negn (< n 0))
+  (def start (if negn (max 0 (+ len n)) 0))
+  (def end (if negn len (min n len)))
+  (f ind start end))
 
 (defn take
-  "Take the first n elements of a fiber, indexed or bytes type. Returns a new array, tuple or string, respectively."
+  ``Take the first n elements of a fiber, indexed or bytes type. Returns a new array, tuple or string,
+  respectively. If `n` is negative, takes the last `n` elements instead.``
   [n ind]
   (cond
-    (bytes? ind) (slice-n string/slice n ind)
-    (indexed? ind) (slice-n tuple/slice n ind)
-    (take-n-fallback n ind)))
+    (bytes? ind) (take-n-slice string/slice n ind)
+    (indexed? ind) (take-n-slice tuple/slice n ind)
+    (do
+      (def res @[])
+      (var key nil)
+      (repeat n
+        (if (= nil (set key (next ind key))) (break))
+        (array/push res (in ind key)))
+      res)))
 
-(defn- slice-until
+(defn- take-until-slice
   [f pred ind]
   (def len (length ind))
   (def i (find-index pred ind))
@@ -1126,9 +1114,9 @@
   "Same as `(take-while (complement pred) ind)`."
   [pred ind]
   (cond
-    (bytes? ind) (slice-until string/slice pred ind)
-    (indexed? ind) (slice-until tuple/slice pred ind)
-    (take-until-fallback pred ind)))
+    (bytes? ind) (take-until-slice string/slice pred ind)
+    (indexed? ind) (take-until-slice tuple/slice pred ind)
+    (seq [x :in ind :until (pred x)] x)))
 
 (defn take-while
   `Given a predicate, take only elements from a fiber, indexed, or bytes type that satisfy
@@ -1136,27 +1124,41 @@
   [pred ind]
   (take-until (complement pred) ind))
 
+(defn- drop-n-slice
+  [f n ind]
+  (def len (length ind))
+  (def negn (< n 0))
+  (def start (if negn 0 (min n len)))
+  (def end (if negn (max 0 (+ len n)) len))
+  (f ind start end))
+
 (defn drop
-  ``Drop the first `n elements in an indexed or bytes type. Returns a new tuple or string
+  ``Drop the first `n` elements in an indexed or bytes type. Returns a new tuple or string
   instance, respectively. If `n` is negative, drops the last `n` elements instead.``
   [n ind]
-  (def use-str (bytes? ind))
-  (def f (if use-str string/slice tuple/slice))
+  (cond
+    (bytes? ind) (drop-n-slice string/slice n ind)
+    (indexed? ind) (drop-n-slice tuple/slice n ind)
+    (do
+      (var key nil)
+      (repeat n
+        (if (= nil (set key (next ind key))) (break)))
+      ind)))
+
+(defn- drop-until-slice
+  [f pred ind]
   (def len (length ind))
-  (def negn (>= n 0))
-  (def start (if negn (min n len) 0))
-  (def end (if negn len (max 0 (+ len n))))
-  (f ind start end))
+  (def i (find-index pred ind))
+  (def start (if (nil? i) len i))
+  (f ind start))
 
 (defn drop-until
   "Same as `(drop-while (complement pred) ind)`."
   [pred ind]
-  (def use-str (bytes? ind))
-  (def f (if use-str string/slice tuple/slice))
-  (def i (find-index pred ind))
-  (def len (length ind))
-  (def start (if (nil? i) len i))
-  (f ind start))
+  (cond
+    (bytes? ind) (drop-until-slice string/slice pred ind)
+    (indexed? ind) (drop-until-slice tuple/slice pred ind)
+    (do (find pred ind) ind)))
 
 (defn drop-while
   `Given a predicate, remove elements from an indexed or bytes type that satisfy
@@ -4166,11 +4168,12 @@
 
   (defn do-one-file
     [fname]
-    (if-not (has-value? boot/args "image-only") (do
-      (print "\n/* " fname " */")
-      (print "#line 0 \"" fname "\"\n")
-      (def source (slurp fname))
-      (print (string/replace-all "\r" "" source)))))
+    (if-not (has-value? boot/args "image-only")
+      (do
+        (print "\n/* " fname " */")
+        (print "#line 0 \"" fname "\"\n")
+        (def source (slurp fname))
+        (print (string/replace-all "\r" "" source)))))
 
   (do-one-file feature-header)
 

--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -513,6 +513,14 @@
 (def sqr2 (drop 10 (squares)))
 (assert (deep= (take 1 sqr2) @[100]) "drop fiber next value")
 
+(def dict @{:a 1 :b 2 :c 3 :d 4 :e 5})
+(def dict1 (take 2 dict))
+(def dict2 (drop 2 dict))
+
+(assert (= (length dict1) 2) "take dictionary")
+(assert (= (length dict2) 3) "drop dictionary")
+(assert (deep= (merge dict1 dict2) dict) "take-drop symmetry for dictionary")
+
 # Comment macro
 # issue #110 - 698e89aba
 (comment 1)


### PR DESCRIPTION
Related issue: #1178 

Allow `take` from the end of bytes or indexed (as `drop` does).
Allow `drop` from fibers (as `take` does).
Return table for `take` from dictionary types.
Allow `drop` from dictionary types (as `take` does).
Increase efficiency for `take` and `drop` with slices.
Check indexed types before bytes.

It isn't clear to me that there is a common use case for taking and dropping from dictionary types. However, the implementation is relatively straight-forward, particularly for take, so I don't know that it should be explicitly forbidden either.

`take` for indexed types isn't slowed any by this change, and `drop` has become significantly faster. `take` has become slightly slower for `bytes` objects due to the type check reordering. I believe that indexed types are a more common case, and in particular when efficiency is a concern.

```janet
(def ind (range 200))
(repeat 10_000_000 (take 100 ind))
master     8.399327
take-drop  7.313185

(repeat 10_000_000 (drop 100 ind))
master    11.91337
take-drop  6.92769

(repeat 1_000_000 (take-until |(> $ 100) ind))
master     7.40999
take-drop  7.256637

(repeat 1_000_000 (drop-until |(> $ 100) ind))
master     7.251279
take-drop  7.15903
```
