### PR TITLE
Fix order in which *macro-lints* is set during expansion

### DIFF
--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -746,12 +746,14 @@ static int macroexpand1(
     int lock = janet_gclock();
     Janet mf_kw = janet_ckeywordv("macro-form");
     janet_table_put(c->env, mf_kw, x);
+    Janet ml_kw = janet_ckeywordv("macro-lints");
+    if (c->lints) {
+        janet_table_put(c->env, ml_kw, janet_wrap_array(c->lints));
+    }
     Janet tempOut;
     JanetSignal status = janet_continue(fiberp, janet_wrap_nil(), &tempOut);
     janet_table_put(c->env, mf_kw, janet_wrap_nil());
-    if (c->lints) {
-        janet_table_put(c->env, janet_ckeywordv("macro-lints"), janet_wrap_array(c->lints));
-    }
+    janet_table_put(c->env, ml_kw, janet_wrap_nil());
     janet_gcunlock(lock);
     if (status != JANET_SIGNAL_OK) {
         const uint8_t *es = janet_formatc("(macro) %V", tempOut);

--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -877,5 +877,11 @@
 (assert (= (thunk) 1) "delay 3")
 (assert (= counter 1) "delay 4")
 
-(end-suite)
+# maclintf
+(def env (table/clone (curenv)))
+((compile '(defmacro foo [] (maclintf :strict "oops")) env :anonymous))
+(def lints @[])
+(compile (tuple/setmap '(foo) 1 2) env :anonymous lints)
+(assert (deep= lints @[[:strict 1 2 "oops"]]) "maclintf 1")
 
+(end-suite)

--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -884,4 +884,15 @@
 (compile (tuple/setmap '(foo) 1 2) env :anonymous lints)
 (assert (deep= lints @[[:strict 1 2 "oops"]]) "maclintf 1")
 
+(def env (table/clone (curenv)))
+((compile '(defmacro foo [& body] (maclintf :strict "foo-oops") ~(do ,;body)) env :anonymous))
+((compile '(defmacro bar [] (maclintf :strict "bar-oops")) env :anonymous))
+(def lints @[])
+# Compile (foo (bar)), but with explicit source map values
+(def bar-invoke (tuple/setmap '(bar) 3 4))
+(compile (tuple/setmap ~(foo ,bar-invoke) 1 2) env :anonymous lints)
+(assert (deep= lints @[[:strict 1 2 "foo-oops"]
+                       [:strict 3 4 "bar-oops"]])
+        "maclintf 2")
+
 (end-suite)


### PR DESCRIPTION
Previously, `*macro-lints*` was set after the `macroexpand1` fiber was resumed, rather than just before.  And, `*macro-lints*` was never cleared.  This behavior was typically fine since the main users of `compile` pass the same lint array repeatedly, and the first macro expansion (somewhere in boot.janet) never produces a lint.  But, when compiling with a fresh lint array, if the first macro invocation produced a lint, the lint was always lost.