### PR TITLE
update if-let

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -668,18 +668,20 @@
   (def len (length bindings))
   (if (= 0 len) (error "expected at least 1 binding"))
   (if (odd? len) (error "expected an even number of bindings"))
+  (def res (gensym))
   (defn aux [i]
     (if (>= i len)
-      tru
+      ~(do (set ,res ,tru) true)
       (do
         (def bl (in bindings i))
         (def br (in bindings (+ 1 i)))
         (if (symbol? bl)
-          ~(if (def ,bl ,br) ,(aux (+ 2 i)) ,fal)
+          ~(if (def ,bl ,br) ,(aux (+ 2 i)))
           ~(if (def ,(def sym (gensym)) ,br)
-             (do (def ,bl ,sym) ,(aux (+ 2 i)))
-             ,fal)))))
-  (aux 0))
+             (do (def ,bl ,sym) ,(aux (+ 2 i))))))))
+  ~(do
+     (var ,res nil)
+     (if ,(aux 0) ,res ,fal)))
 
 (defmacro when-let
   "Same as `(if-let bindings (do ;body))`."

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -675,10 +675,10 @@
         (def bl (in bindings i))
         (def br (in bindings (+ 1 i)))
         (if (symbol? bl)
-          (tuple 'if (tuple 'def bl br) (aux (+ 2 i)) fal)
-          (tuple 'if (tuple 'def (def sym (gensym)) br)
-                 (tuple 'do (tuple 'def bl sym) (aux (+ 2 i)))
-                 fal)))))
+          ~(if (def ,bl ,br) ,(aux (+ 2 i)) ,fal)
+          ~(if (def ,(def sym (gensym)) ,br)
+             (do (def ,bl ,sym) ,(aux (+ 2 i)))
+             ,fal)))))
   (aux 0))
 
 (defmacro when-let

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -674,7 +674,11 @@
       (do
         (def bl (in bindings i))
         (def br (in bindings (+ 1 i)))
-        (tuple 'if (tuple 'def bl br) (aux (+ 2 i)) fal))))
+        (if (symbol? bl)
+          (tuple 'if (tuple 'def bl br) (aux (+ 2 i)) fal)
+          (tuple 'if (tuple 'def (def sym (gensym)) br)
+                 (tuple 'do (tuple 'def bl sym) (aux (+ 2 i)))
+                 fal)))))
   (aux 0))
 
 (defmacro when-let

--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -130,7 +130,12 @@
 (assert (= (if-let [[a b] my-array] a) 1) "if-let 5")
 (assert (= (if-let [{:a a :b b} {:a 1 :b 2}] b) 2) "if-let 6")
 (assert (= (if-let [[a b] nil] :t :f) :f) "if-let 7")
-(assert (= (if-let [a true b false] b a) true) "if-let 8")
+
+# #1191
+(var cnt 0)
+(defmacro upcnt [] (++ cnt))
+(assert (= (if-let [a true b true c true] nil (upcnt)) nil) "issue #1191")
+(assert (= cnt 1) "issue #1191")
 
 (assert (= 14 (sum (map inc @[1 2 3 4]))) "sum map")
 (def myfun (juxt + - * /))

--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -129,6 +129,8 @@
 (assert (= (if-let [a my-array k (next a 5)] :t :f) :f) "if-let 4")
 (assert (= (if-let [[a b] my-array] a) 1) "if-let 5")
 (assert (= (if-let [{:a a :b b} {:a 1 :b 2}] b) 2) "if-let 6")
+(assert (= (if-let [[a b] nil] :t :f) :f) "if-let 7")
+(assert (= (if-let [a true b false] b a) true) "if-let 8")
 
 (assert (= 14 (sum (map inc @[1 2 3 4]))) "sum map")
 (def myfun (juxt + - * /))


### PR DESCRIPTION
Fixes #1189

Code of the following form should not error:
```janet
(if-let [[a b] (possibly-nil-or-tuple)] ...)
```
in accordance with the documentation: _If any are false or nil, evaluate the fal form._

Fixes #1191

Macros with side-effects should not be expanded more than once. This is an issue that pre-dates the most recent change.