### PR TITLE
Avoid implementation-specific integer conversion in bit shifting tests

### DIFF
--- a/test/suite-corelib.janet
+++ b/test/suite-corelib.janet
@@ -29,11 +29,11 @@
 (assert (= 4 (blshift 1 2)) "left shift")
 (assert (= 1 (brshift 4 2)) "right shift")
 # unsigned shift
-(assert (= 32768 (brushift 0x80000000 16)) "right shift unsigned 1")
-(assert (= -32768 (brshift 0x80000000 16)) "right shift unsigned 2")
+(assert (= 32767 (brushift 0x7fffffff 16)) "right shift unsigned")
+(assert (= -32768 (brshift -0x80000000 16)) "right shift")
 # non-immediate forms
-(assert (= 32768 (brushift 0x80000000 (+ 0 16))) "right shift unsigned non-immediate")
-(assert (= -32768 (brshift 0x80000000 (+ 0 16))) "right shift non-immediate")
+(assert (= 32767 (brushift 0x7fffffff (+ 0 16))) "right shift unsigned non-immediate")
+(assert (= -32768 (brshift -0x80000000 (+ 0 16))) "right shift non-immediate")
 (assert (= 32768 (blshift 1 (+ 0 15))) "left shift non-immediate")
 # 7e46ead
 (assert (< 1 2 3 4 5 6) "less than integers")


### PR DESCRIPTION
The following four bit shifting tests using `brushift` and `brshift` in `test/suite-corelib.janet` fail when compiling on ARM (tested on both Apple M1 and Raspberry Pi ARMv7):

https://github.com/janet-lang/janet/blob/7272f43191501c794bd04549dc17379b0c1cd8ea/test/suite-corelib.janet#L31-L36

All the function calls return **`32767`**. As discussed below, I think this is because of undefined behaviour when type casting values outside the 32-bit integer range.

This PR fixes these tests by using operands that are within the 32-bit range.

## Discussion

My understanding is that differences between the x64 and ARM instruction sets are causing different values to result when the type casting in the `_vm_bitop_immediate` and `_vm_bitop` macros converts a Janet number to a 32-bit integer. (The macros are used by the `JOP_SHIFT_RIGHT_UNSIGNED_IMMEDIATE` and `JOP_SHIFT_RIGHT_UNSIGNED` Janet VM instructions.)

https://github.com/janet-lang/janet/blob/7272f43191501c794bd04549dc17379b0c1cd8ea/src/core/vm.c#L150

https://github.com/janet-lang/janet/blob/7272f43191501c794bd04549dc17379b0c1cd8ea/src/core/vm.c#L178

I believe this is because `0x80000000` is outside the range of 32-bit integers and behaviour for this is undefined. See the second paragraph of Section 6.3.1.4 of the [C99 standard](https://www.open-std.org/jtc1/sc22/WG14/www/docs/n1256.pdf#page=55) reads (emphasis added):

> When a value of integer type is converted to a real floating type, if the value being converted can be represented exactly in the new type, it is unchanged. If the value being converted is in the range of values that can be represented but cannot be represented exactly, the result is either the nearest higher or nearest lower representable value, chosen in an implementation-defined manner. **If the value being converted is outside the range of values that can be represented, the behavior is undefined.**

The best explanation of the relevant difference I could find is in ['Hello ARM: Exploring Undefined, Unspecified, and Implementation-defined Behavior in C++'](https://devblogs.microsoft.com/cppblog/hello-arm-exploring-undefined-unspecified-and-implementation-defined-behavior-in-c/):

> On the ARM architecture, when a floating-point value is converted to a 32-bit integer, it saturates; that is, it converts to the nearest value that the integer can represent, if the floating-point value is outside the range of the integer. For example, when converting to an unsigned integer, a negative floating-point value always converts to 0, and to 4294967295 if the floating-point value is too large for an unsigned integer to represent. When converting to a signed integer, the floating-point value is converted to -2147483648 if it is too small for a signed integer to represent, or to 2147483637 if it is too large. On x86 and x64 architectures, floating point conversion does not saturate; instead, the conversion wraps around if the target type is unsigned, or is set to -2147483648 if the target type is signed.

## Alternatives

It's very possible that the explanation above is wrong (given that it's all based on things I learnt about for the first time today). And perhaps the tests indicate a deeper problem with the C code and the tests _should_ pass. Maybe @zevv knows? If anything is wrong, please feel free to correct as necessary.