### PR TITLE
Move idempotent to corelib

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -129,19 +129,6 @@
 # For macros, we define an imcomplete odd? function that will be overriden.
 (defn odd? [x] (= 1 (mod x 2)))
 
-(def- non-atomic-types
-  {:array true
-   :tuple true
-   :table true
-   :buffer true
-   :symbol true
-   :struct true})
-
-(defn idempotent?
-  "Check if x is a value that evaluates to itself when compiled."
-  [x]
-  (not (in non-atomic-types (type x))))
-
 # C style macros and functions for imperative sugar. No bitwise though.
 (defn inc "Returns x + 1." [x] (+ x 1))
 (defn dec "Returns x - 1." [x] (- x 1))

--- a/test/suite-corelib.janet
+++ b/test/suite-corelib.janet
@@ -93,6 +93,22 @@
 (assert (not (abstract? 3)) "not abstract? 3")
 (assert (not (abstract? 5)) "not abstract? 5")
 
+# idempotent?
+(each item [@[1] [1] @{:a 1} {:a 1} @"a"]
+  (assert (= (idempotent? item) false) (string/format "(idempotent? %q)" item)))
+
+(each item ["a" :a 'a 1 (int/s64 1) (int/u64 1)]
+  (assert (= (idempotent? item) true) (string/format "(idempotent? %q)" item)))
+
+(defmacro macro-idempotent
+  [x]
+  (idempotent? x))
+
+(var var-x 1)
+(assert (= (macro-idempotent var-x) false) "macro idempotent var")
+(def def-x 1)
+(assert (= (macro-idempotent def-x) true) "macro idempotent def")
+
 # Module path expansion
 # ff3bb6627
 (setdyn :current-file "some-dir/some-file")


### PR DESCRIPTION
Related issue: #1192 

Moves `idempotent?` from `boot.janet` to `corelib.c`. This is done so that `var` bindings and `def` bindings can be distinguished within macros.

```janet
(defmacro macro-idempotent
  [x]
  (idempotent? x))

(var var-x 1)
(assert (= (macro-idempotent var-x) false) "macro idempotent var")

(def def-x 1)
(assert (= (macro-idempotent def-x) true) "macro idempotent def")
```