### PR TITLE
Remove thread-local state from GC

### DIFF
--- a/src/core/ffi.c
+++ b/src/core/ffi.c
@@ -179,13 +179,13 @@ typedef struct {
     JanetFFIMapping args[JANET_FFI_MAX_ARGS];
 } JanetFFISignature;
 
-int signature_mark(void *p, size_t s) {
+int signature_mark(JanetGCState *gcstate, void *p, size_t s) {
     (void) s;
     JanetFFISignature *sig = p;
     for (uint32_t i = 0; i < sig->arg_count; i++) {
         JanetFFIType t = sig->args[i].type;
         if (t.prim == JANET_FFI_TYPE_STRUCT) {
-            janet_mark(janet_wrap_abstract(t.st));
+            janet_mark(gcstate, janet_wrap_abstract(t.st));
         }
     }
     return 0;
@@ -198,13 +198,13 @@ static const JanetAbstractType janet_signature_type = {
     JANET_ATEND_GCMARK
 };
 
-int struct_mark(void *p, size_t s) {
+int struct_mark(JanetGCState *gcstate, void *p, size_t s) {
     (void) s;
     JanetFFIStruct *st = p;
     for (uint32_t i = 0; i < st->field_count; i++) {
         JanetFFIType t = st->fields[i].type;
         if (t.prim == JANET_FFI_TYPE_STRUCT) {
-            janet_mark(janet_wrap_abstract(t.st));
+            janet_mark(gcstate, janet_wrap_abstract(t.st));
         }
     }
     return 0;

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -132,9 +132,9 @@ JanetAsyncStatus net_machine_accept(JanetListenerState *s, JanetAsyncEvent event
         default:
             break;
         case JANET_ASYNC_EVENT_MARK: {
-            if (state->lstream) janet_mark(janet_wrap_abstract(state->lstream));
-            if (state->astream) janet_mark(janet_wrap_abstract(state->astream));
-            if (state->function) janet_mark(janet_wrap_function(state->function));
+            if (state->lstream) janet_mark(s->event, janet_wrap_abstract(state->lstream));
+            if (state->astream) janet_mark(s->event, janet_wrap_abstract(state->astream));
+            if (state->function) janet_mark(s->event, janet_wrap_function(state->function));
             break;
         }
         case JANET_ASYNC_EVENT_CLOSE:
@@ -218,7 +218,7 @@ JanetAsyncStatus net_machine_accept(JanetListenerState *s, JanetAsyncEvent event
         default:
             break;
         case JANET_ASYNC_EVENT_MARK: {
-            if (state->function) janet_mark(janet_wrap_function(state->function));
+            if (state->function) janet_mark(s->event, janet_wrap_function(state->function));
             break;
         }
         case JANET_ASYNC_EVENT_CLOSE:

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -561,12 +561,12 @@ static int janet_proc_gc(void *p, size_t s) {
     return 0;
 }
 
-static int janet_proc_mark(void *p, size_t s) {
+static int janet_proc_mark(JanetGCState *gcstate, void *p, size_t s) {
     (void) s;
     JanetProc *proc = (JanetProc *)p;
-    if (NULL != proc->in) janet_mark(janet_wrap_abstract(proc->in));
-    if (NULL != proc->out) janet_mark(janet_wrap_abstract(proc->out));
-    if (NULL != proc->err) janet_mark(janet_wrap_abstract(proc->err));
+    if (NULL != proc->in) janet_mark(gcstate, janet_wrap_abstract(proc->in));
+    if (NULL != proc->out) janet_mark(gcstate, janet_wrap_abstract(proc->out));
+    if (NULL != proc->err) janet_mark(gcstate, janet_wrap_abstract(proc->err));
     return 0;
 }
 

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -853,15 +853,15 @@ int janet_parser_has_more(JanetParser *parser) {
 
 /* C functions */
 
-static int parsermark(void *p, size_t size) {
+static int parsermark(JanetGCState *gcstate, void *p, size_t size) {
     size_t i;
     JanetParser *parser = (JanetParser *)p;
     (void) size;
     for (i = 0; i < parser->argcount; i++) {
-        janet_mark(parser->args[i]);
+        janet_mark(gcstate, parser->args[i]);
     }
     if (parser->flag & JANET_PARSER_GENERATED_ERROR) {
-        janet_mark(janet_wrap_string((const uint8_t *) parser->error));
+        janet_mark(gcstate, janet_wrap_string((const uint8_t *) parser->error));
     }
     return 0;
 }

--- a/src/core/peg.c
+++ b/src/core/peg.c
@@ -1354,12 +1354,12 @@ static uint32_t peg_compile1(Builder *b, Janet peg) {
  * Post-Compilation
  */
 
-static int peg_mark(void *p, size_t size) {
+static int peg_mark(JanetGCState *gcstate, void *p, size_t size) {
     (void) size;
     JanetPeg *peg = (JanetPeg *)p;
     if (NULL != peg->constants)
         for (uint32_t i = 0; i < peg->num_constants; i++)
-            janet_mark(peg->constants[i]);
+            janet_mark(gcstate, peg->constants[i]);
     return 0;
 }
 

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -199,7 +199,7 @@ extern const JanetAbstractType janet_address_type;
 #endif
 #ifdef JANET_EV
 void janet_lib_ev(JanetTable *env);
-void janet_ev_mark(void);
+void janet_ev_mark(JanetGCState*);
 int janet_make_pipe(JanetHandle handles[2], int mode);
 #endif
 #ifdef JANET_FFI

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1115,11 +1115,17 @@ typedef struct {
     const JanetAbstractType *at;
 } JanetMarshalContext;
 
+/* state that only exists during gc collection */
+typedef struct {
+    uint32_t depth;
+    size_t orig_rootcount;
+} JanetGCState;
+
 /* Defines an abstract type */
 struct JanetAbstractType {
     const char *name;
     int (*gc)(void *data, size_t len);
-    int (*gcmark)(void *data, size_t len);
+    int (*gcmark)(JanetGCState *gcstate, void *data, size_t len);
     int (*get)(void *data, Janet key, Janet *out);
     void (*put)(void *data, Janet key, Janet value);
     void (*marshal)(void *p, JanetMarshalContext *ctx);
@@ -1732,7 +1738,7 @@ JANET_API JanetTable *janet_env_lookup(JanetTable *env);
 JANET_API void janet_env_lookup_into(JanetTable *renv, JanetTable *env, const char *prefix, int recurse);
 
 /* GC */
-JANET_API void janet_mark(Janet x);
+JANET_API void janet_mark(JanetGCState *gcstate, Janet x);
 JANET_API void janet_sweep(void);
 JANET_API void janet_collect(void);
 JANET_API void janet_clear_memory(void);


### PR DESCRIPTION
I hope this is correct.

If `janetvm` is removed from thread-local, then Janet can be embedded better (multiple VM in a thread).