### PR TITLE
Use vm_commit

### DIFF
--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -980,7 +980,7 @@ static JanetSignal run_vm(JanetFiber *fiber, Janet in) {
             if (func->gc.flags & JANET_FUNCFLAG_TRACE) {
                 vm_do_trace(func, fiber->stacktop - fiber->stackstart, fiber->data + fiber->stackstart);
             }
-            janet_stack_frame(stack)->pc = pc;
+            vm_commit();
             if (janet_fiber_funcframe(fiber, func)) {
                 int32_t n = fiber->stacktop - fiber->stackstart;
                 janet_panicf("%v called with %d argument%s, expected %d",


### PR DESCRIPTION
This PR contains a suggestion to use `vm_commit();` in place of `janet_stack_frame(stack)->pc = pc;`.

The `vm_commit();` construct is used elsewhere within the `JOP_CALL` handling in which this instance of `janet_stack_frame(stack)->pc = pc;` appears:

* https://github.com/janet-lang/janet/blob/3a4d56afca2eee0e4dbca9a6400757d198e6d6f3/src/core/vm.c#L975
* https://github.com/janet-lang/janet/blob/3a4d56afca2eee0e4dbca9a6400757d198e6d6f3/src/core/vm.c#L993
* https://github.com/janet-lang/janet/blob/3a4d56afca2eee0e4dbca9a6400757d198e6d6f3/src/core/vm.c#L1002

Perhaps it makes sense to use `vm_commit();` on [line 983](https://github.com/janet-lang/janet/blob/3a4d56afca2eee0e4dbca9a6400757d198e6d6f3/src/core/vm.c#L983) as well?

Though I can see that if one wanted to leave the [`JANET_FUNCTION`-handling parts of `JOP_CALL`](https://github.com/janet-lang/janet/blob/3a4d56afca2eee0e4dbca9a6400757d198e6d6f3/src/core/vm.c#L978-L991) and [`JOP_TAILCALL`](https://github.com/janet-lang/janet/blob/3a4d56afca2eee0e4dbca9a6400757d198e6d6f3/src/core/vm.c#L1018-L1031) easier to compare, perhaps not using `vm_commit();` might be preferrable.