### PR TITLE
Avoid prematurely closing file descriptors when redirecting IO

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1145,14 +1145,16 @@ static Janet os_execute_impl(int32_t argc, Janet *argv, int is_spawn) {
         posix_spawn_file_actions_addclose(&actions, pipe_in);
     } else if (new_in != JANET_HANDLE_NONE && new_in != 0) {
         posix_spawn_file_actions_adddup2(&actions, new_in, 0);
-        posix_spawn_file_actions_addclose(&actions, new_in);
+        if (new_in != new_out && new_in != new_err)
+            posix_spawn_file_actions_addclose(&actions, new_in);
     }
     if (pipe_out != JANET_HANDLE_NONE) {
         posix_spawn_file_actions_adddup2(&actions, pipe_out, 1);
         posix_spawn_file_actions_addclose(&actions, pipe_out);
     } else if (new_out != JANET_HANDLE_NONE && new_out != 1) {
         posix_spawn_file_actions_adddup2(&actions, new_out, 1);
-        posix_spawn_file_actions_addclose(&actions, new_out);
+        if (new_out != new_err)
+            posix_spawn_file_actions_addclose(&actions, new_out);
     }
     if (pipe_err != JANET_HANDLE_NONE) {
         posix_spawn_file_actions_adddup2(&actions, pipe_err, 2);

--- a/test/suite-os.janet
+++ b/test/suite-os.janet
@@ -138,7 +138,11 @@
                                "/dev/null"))
                    (os/open path :w))
                  (with [dn (devnull)]
-                   (os/execute ["ls"] :px {:out dn :err dn})))
+                   (os/execute [(dyn :executable)
+                                "-e"
+                                "(print :foo) (eprint :bar)"]
+                               :px
+                               {:out dn :err dn})))
 
 (end-suite)
 

--- a/test/suite-os.janet
+++ b/test/suite-os.janet
@@ -94,9 +94,9 @@
   (assert (= (length buf) 2) "cryptorand appends to buffer"))
 
 # 80db68210
-(assert-no-error (os/clock :realtime) "realtime clock")
-(assert-no-error (os/clock :cputime) "cputime clock")
-(assert-no-error (os/clock :monotonic) "monotonic clock")
+(assert-no-error "realtime clock" (os/clock :realtime))
+(assert-no-error "cputime clock" (os/clock :cputime))
+(assert-no-error "monotonic clock" (os/clock :monotonic))
 
 (def before (os/clock :monotonic))
 (def after (os/clock :monotonic))
@@ -128,6 +128,17 @@
   (assert (= i (os/execute [(dyn :executable) "-e"
                             (string/format "(os/exit %d)" i)] :p))
           (string "os/execute " i)))
+
+# os/execute IO redirection
+(assert-no-error "IO redirection"
+                 (defn devnull []
+                   (def os (os/which))
+                   (def path (if (or (= os :mingw) (= os :windows))
+                               "NUL"
+                               "/dev/null"))
+                   (os/open path :w))
+                 (with [dn (devnull)]
+                   (os/execute ["ls"] :px {:out dn :err dn})))
 
 (end-suite)
 


### PR DESCRIPTION
Janet raises an error if `os/execute` is called with the same stream being used to redirect both STDOUT and STDERR:

```janet
(def dn1 (os/open "/dev/null" :w))
(def p1 (os/execute ["ls"] :px {:out dn1})) # will not raise an error

(def dn2 (os/open "/dev/null" :w))
(def p2 (os/execute ["ls"] :px {:out dn2 :err dn2})) # will raise an error
```

This problem currently affects JPM when installing with `--silent` (e.g. `jpm --silent install judge`). This PR prevents this error by avoiding the premature closing of file descriptors in `os_execute_impl`.

## Discussion

In 4a40e57cf059011e37aa45d43f48733b8e5546b0, @bakpakin made changes to `os_execute_impl` to address #881. For the purposes of this PR, the relevant lines are:

https://github.com/janet-lang/janet/blob/c3f4dc0c152dd1d08fdd96e406a2847e1a3f9b40/src/core/os.c#L1143-L1163

The problem is that if `new_out` and `new_err` are the same file descriptor, calling `posix_spawn_file_actions_addclose` for `new_out` before `pos_spawn_file_actions_adddup2` for `new_err` will cause an error when `posix_spawn` is later called.

## Alternatives

Another possible solution to this problem would be to establish a practice of not using the same file descriptor when redirecting IO. That seems to violate the principle of lease surprise and so is not the approach taken by this PR.