### PR TITLE
Add C escape sequences

### DIFF
--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -259,6 +259,14 @@ static int checkescape(uint8_t c) {
             return '\f';
         case 'v':
             return '\v';
+        case 'a':
+            return '\a';
+        case 'b':
+            return '\b';
+        case '\'':
+            return '\'';
+        case '?':
+            return '?';
         case 'e':
             return 27;
         case '"':

--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -152,6 +152,12 @@ static void janet_escape_string_impl(JanetBuffer *buffer, const uint8_t *str, in
             case '\v':
                 janet_buffer_push_bytes(buffer, (const uint8_t *)"\\v", 2);
                 break;
+            case '\a':
+                janet_buffer_push_bytes(buffer, (const uint8_t *)"\\a", 2);
+                break;
+            case '\b':
+                janet_buffer_push_bytes(buffer, (const uint8_t *)"\\b", 2);
+                break;
             case 27:
                 janet_buffer_push_bytes(buffer, (const uint8_t *)"\\e", 2);
                 break;


### PR DESCRIPTION
Some C escape sequences are not supported in Janet strings, namely:
- `\'`
- `\?`
- `\a`
- `\b`

Full list at https://en.cppreference.com/w/c/language/escape.
Supporting them could be useful to copy-paste strings from other languages (and I need `\b`).
