### PR TITLE
Add source view to .ppasm output

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3520,6 +3520,24 @@
     (when-let [constants (dasm :constants)]
       (eprintf "  constants:  %.4q" constants))
     (eprintf "  slots:      %.4q\n" (frame :slots))
+    (when-let [src-path (in dasm :source)]
+      (when (and (fexists src-path)
+                 sourcemap)
+        (defn dump
+          [src cur]
+          (def offset 5)
+          (def beg (max 1 (- cur offset)))
+          (def lines (array/concat @[""] (string/split "\n" src)))
+          (def end (min (+ cur offset) (length lines)))
+          (def digits (inc (math/floor (math/log10 end))))
+          (def fmt-str (string "%" digits "d: %s"))
+          (for i beg end
+            (eprin " ") # breakpoint someday?
+            (eprin (if (= i cur) "> " "  "))
+            (eprintf fmt-str i (get lines i))))
+        (let [[sl _] (sourcemap pc)]
+          (dump (slurp src-path) sl)
+          (eprint))))
     (def padding (string/repeat " " 20))
     (loop [i :range [0 (length bytecode)]
            :let [instr (bytecode i)]]


### PR DESCRIPTION
This draft PR adds a Janet source view to the output of `.ppasm`.

In order to solicit and process feedback about placement, aesthetics, etc. the PR is currently a draft.  Please comment if interested :)

Below is a demo of how it can look:

```
$ ./build/janet -d
Janet 1.29.1-026c64fa linux/x64/gcc - '(doc)' for help
repl:1:> (import ../../scratch/debug)
@{_ @{:value <cycle 0>} debug/dump @{:private true} debug/fun @{:private true} debug/fun-2 @{:private true} :debug true :redef true}
repl:2:> (debug/fbreak debug/fun-2)
nil
repl:3:> (debug/fun-2 3)
debug: 
  in fun-2 [../../scratch/debug.janet] on line 9, column 3
  in _thunk [repl] (tailcall) on line 3, column 1
entering debug[1] - (quit) to exit
debug[1]:1:> (.ppasm)

  signal:     
  status:     debug
  function:   fun-2 [../../scratch/debug.janet]
  constants:  @[]
  slots:      @[3 nil nil nil nil nil]

    4:         b 2]
    5:     (+ x (* a b))))
    6: 
    7: (defn fun-2
    8:   [x]
 >  9:   (var y 0)
   10:   (for i 0 x
   11:     (+= y i))
   12:   y)
   13: 

*> ldi 2 0              # line 9, column 3
   ldi 3 0              # line 10, column 3
   lt 4 3 0            
   jmpno 4 5           
   movn 5 3            
   add 2 2 5            # line 11, column 5
   addim 3 3 1          # line 10, column 3
   jmp -5              
   ret 2                # line 7, column 1

nil
debug[1]:2:> 
```
