### PR TITLE
Update and ascii-sort string escapes in peg

### DIFF
--- a/test/suite-peg.janet
+++ b/test/suite-peg.janet
@@ -367,7 +367,7 @@
                  (set "!$%&*+-./:<?=>@^_|"))
     :token (some :symchars)
     :hex (range "09" "af" "AF")
-    :escape (* "\\" (+ (set "ntrvzf0e\"\\")
+    :escape (* "\\" (+ (set `"'0?\abefnrtvz`)
                        (* "x" :hex :hex)
                        (error (constant "bad hex escape"))))
     :comment (/ '(* "#" (any (if-not (+ "\n" -1) 1))) (constant :comment))


### PR DESCRIPTION
Some escape sequences were added to Janet in [d6337e77](https://github.com/janet-lang/janet/commit/d63379e7777b1269ad4e8e075c971503b1732c30). This PR is an attempt to update the PEG for Janet in `test/suite-peg.janet`.

As the number of items is increasing, it seemed prudent to sort the items to make maintenance easier (e.g. avoidance of duplicates, locating a particular item, etc.). The sorting order chosen was based on what was found via the ascii(7) man page.

In an attempt to reduce the amount of "backslashing", also changed the string delimiter to backtick.