### PR TITLE
`array/remove`: update final array index to be -1

### DIFF
--- a/src/core/array.c
+++ b/src/core/array.c
@@ -211,7 +211,7 @@ JANET_CORE_FN(cfun_array_slice,
               "Takes a slice of array or tuple from `start` to `end`. The range is half open, "
               "[start, end). Indexes can also be negative, indicating indexing from the "
               "end of the array. By default, `start` is 0 and `end` is the length of the array. "
-              "Note that index -1 is synonymous with index `(length arrtup)` to allow a full "
+              "Note that if the range is negative, it is taken as (start, end] to allow a full "
               "negative slice range. Returns a new array.") {
     JanetView view = janet_getindexed(argv, 0);
     JanetRange range = janet_getslice(argc, argv);
@@ -259,8 +259,8 @@ JANET_CORE_FN(cfun_array_insert,
               "(array/insert arr at & xs)",
               "Insert all `xs` into array `arr` at index `at`. `at` should be an integer between "
               "0 and the length of the array. A negative value for `at` will index backwards from "
-              "the end of the array, such that inserting at -1 appends to the array. "
-              "Returns the array.") {
+              "the end of the array, inserting after the index such that inserting at -1 appends to "
+              "the array. Returns the array.") {
     size_t chunksize, restsize;
     janet_arity(argc, 2, -1);
     JanetArray *array = janet_getarray(argv, 0);
@@ -297,7 +297,7 @@ JANET_CORE_FN(cfun_array_remove,
     int32_t at = janet_getinteger(argv, 1);
     int32_t n = 1;
     if (at < 0) {
-        at = array->count + at + 1;
+        at = array->count + at;
     }
     if (at < 0 || at > array->count)
         janet_panicf("removal index %d out of range [0,%d]", at, array->count);

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -175,8 +175,9 @@ JANET_CORE_FN(cfun_string_slice,
               "Returns a substring from a byte sequence. The substring is from "
               "index `start` inclusive to index `end`, exclusive. All indexing "
               "is from 0. `start` and `end` can also be negative to indicate indexing "
-              "from the end of the string. Note that index -1 is synonymous with "
-              "index `(length bytes)` to allow a full negative slice range. ") {
+              "from the end of the string. Note that if `start` is negative it is "
+              "exclusive, and if `end` is negative it is inclusive, to allow a full "
+              "negative slice range.") {
     JanetByteView view = janet_getbytes(argv, 0);
     JanetRange range = janet_getslice(argc, argv);
     return janet_stringv(view.bytes + range.start, range.end - range.start);

--- a/src/core/tuple.c
+++ b/src/core/tuple.c
@@ -69,9 +69,9 @@ JANET_CORE_FN(cfun_tuple_slice,
               "inclusive to index `end` exclusive. If `start` or `end` are not provided, "
               "they default to 0 and the length of `arrtup`, respectively. "
               "`start` and `end` can also be negative to indicate indexing "
-              "from the end of the input. Note that index -1 is synonymous with "
-              "index `(length arrtup)` to allow a full negative slice range. "
-              "Returns the new tuple.") {
+              "from the end of the input. Note that if `start` is negative it is "
+              "exclusive, and if `end` is negative it is inclusive, to allow a full "
+              "negative slice range. Returns the new tuple.") {
     JanetView view = janet_getindexed(argv, 0);
     JanetRange range = janet_getslice(argc, argv);
     return janet_wrap_tuple(janet_tuple_n(view.items + range.start, range.end - range.start));

--- a/test/suite-array.janet
+++ b/test/suite-array.janet
@@ -44,7 +44,7 @@
 (assert (deep= (array/remove @[1 2 3 4 5] 2) @[1 2 4 5]) "array/remove 1")
 (assert (deep= (array/remove @[1 2 3 4 5] 2 2) @[1 2 5]) "array/remove 2")
 (assert (deep= (array/remove @[1 2 3 4 5] 2 200) @[1 2]) "array/remove 3")
-(assert (deep= (array/remove @[1 2 3 4 5] -3 200) @[1 2 3]) "array/remove 4")
+(assert (deep= (array/remove @[1 2 3 4 5] -2 200) @[1 2 3]) "array/remove 4")
 
 
 # array/peek


### PR DESCRIPTION
Related issue: #1219

The problem with array index -1: Because `array/slice` does not include its end index in the result, it is not possible to slice to the end of the array. Also, because `array/insert` inserts before the given index, it is not possible to insert to the end of the array.

There are two possible solutions to this problem:
1. (Current Solution) Redefine the final index of an array to be -2.
2. (Proposed Solution) Redefine the behavior of `array/slice` and `array/insert` for negative indices.

Notably, the behavior of these two functions is identical for either solution.

I submit for consideration that the proposed solution is more correct and desirable. When indexing from the end of the array, the array should be viewed reversed, as if its end were its front. In other words, any action that would have occurred before the index should occur after the index, and vice versa.

Furthermore, the current solution breaks the symmetry between `array/insert` and `array/remove`:

Current solution:
```janet
(def a @[1 2 3 4 5])
(array/insert a -1 0) # -> @[1 2 3 4 5 0]
(array/remove a -1)   # -> @[1 2 3 4 5 0]

(def b @[1 2 3 4 5])
(array/insert b -2 0) # -> @[1 2 3 4 0 5]
(array/remove b -2)   # -> @[1 2 3 4 0]
```

Proposed solution:
```janet
(def a @[1 2 3 4 5])
(array/insert a -1 0) # -> @[1 2 3 4 5 0]
(array/remove a -1)   # -> @[1 2 3 4 5]

(def b @[1 2 3 4 5])
(array/insert b -2 0) # -> @[1 2 3 4 0 5]
(array/remove b -2)   # -> @[1 2 3 4 5]
```

Inserting at an index, and then immediately removing at the same index should certainly be a no-op.