### PR TITLE
Rework `keys`, `values`, `pairs`

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1566,31 +1566,31 @@
 (defn keys
   "Get the keys of an associative data structure."
   [x]
-  (def arr @[])
-  (var k (next x nil))
-  (while (not= nil k)
-    (array/push arr k)
-    (set k (next x k)))
+  (def arr (array/new-filled (length x)))
+  (var i 0)
+  (eachk k x
+    (put arr i k)
+    (++ i))
   arr)
 
 (defn values
   "Get the values of an associative data structure."
   [x]
-  (def arr @[])
-  (var k (next x nil))
-  (while (not= nil k)
-    (array/push arr (in x k))
-    (set k (next x k)))
+  (def arr (array/new-filled (length x)))
+  (var i 0)
+  (each v x
+    (put arr i v)
+    (++ i))
   arr)
 
 (defn pairs
   "Get the key-value pairs of an associative data structure."
   [x]
-  (def arr @[])
-  (var k (next x nil))
-  (while (not= nil k)
-    (array/push arr (tuple k (in x k)))
-    (set k (next x k)))
+  (def arr (array/new-filled (length x)))
+  (var i 0)
+  (eachp p x
+    (put arr i p)
+    (++ i))
   arr)
 
 (defn frequencies


### PR DESCRIPTION
These functions may not be overly important, but that doesn't mean that they can't be optimized. The main performance gain here is creating an array with the correct capacity before iteration begins, rather than pushing to an empty array.
```janet
(use spork/test)

(def xs (range 1000))

(timeit-loop [:timeout 1] "keys  " (keys xs))
(timeit-loop [:timeout 1] "values" (values xs))
(timeit-loop [:timeout 1] "pairs " (pairs xs))
```
master:
```janet
keys   1.000s, 36.86µs/body
values 1.000s, 42.86µs/body
pairs  1.000s, 84.27µs/body
```
branch:
```janet
keys   1.000s, 14.75µs/body
values 1.000s, 19.11µs/body
pairs  1.000s, 56.36µs/body

```
`keys` and `values` are each over twice as fast, and `pairs` is approximately 50% faster.