### PR TITLE
Rework `reverse`

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1450,12 +1450,10 @@
   a new array. If a string or buffer is provided, returns an array of its
   byte values, reversed.`
   [t]
-  (def len (length t))
-  (var n (- len 1))
-  (def ret (array/new len))
-  (while (>= n 0)
-    (array/push ret (in t n))
-    (-- n))
+  (var n (length t))
+  (def ret (array/new-filled n))
+  (forv i 0 n
+    (put ret i (in t (-- n))))
   ret)
 
 (defn invert


### PR DESCRIPTION
Similar to the changes in #1241. The result is approximately twice as fast on any size argument.
```janet
(use spork/test)

(def a (range 10))
(def b (range 100))
(def c (range 1000))

(timeit-loop [:timeout 1] :a (reverse a))
(timeit-loop [:timeout 1] :b (reverse b))
(timeit-loop [:timeout 1] :c (reverse c))
```
master:
```janet
a 1.000s, 0.4635µs/body
b 1.000s, 3.296µs/body
c 1.000s, 31.49µs/body
```
branch:
```janet
a 1.000s, 0.2932µs/body
b 1.000s, 1.939µs/body
c 1.000s, 17.52µs/body
```
I try not to have more than one open PR at a time, but I thought I might slip these in before the release.