### PR TITLE
Move `bytes?`, `indexed?`, `dictionary?` to corelib

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -103,23 +103,13 @@
 (defn symbol? "Check if x is a symbol." [x] (= (type x) :symbol))
 (defn keyword? "Check if x is a keyword." [x] (= (type x) :keyword))
 (defn buffer? "Check if x is a buffer." [x] (= (type x) :buffer))
-(defn function? "Check if x is a function (not a cfunction)." [x]
-  (= (type x) :function))
+(defn function? "Check if x is a function (not a cfunction)." [x] (= (type x) :function))
 (defn cfunction? "Check if x a cfunction." [x] (= (type x) :cfunction))
 (defn table? "Check if x a table." [x] (= (type x) :table))
 (defn struct? "Check if x a struct." [x] (= (type x) :struct))
 (defn array? "Check if x is an array." [x] (= (type x) :array))
 (defn tuple? "Check if x is a tuple." [x] (= (type x) :tuple))
 (defn boolean? "Check if x is a boolean." [x] (= (type x) :boolean))
-(defn bytes? "Check if x is a string, symbol, keyword, or buffer." [x]
-  (def t (type x))
-  (if (= t :string) true (if (= t :symbol) true (if (= t :keyword) true (= t :buffer)))))
-(defn dictionary? "Check if x is a table or struct." [x]
-  (def t (type x))
-  (if (= t :table) true (= t :struct)))
-(defn indexed? "Check if x is an array or tuple." [x]
-  (def t (type x))
-  (if (= t :array) true (= t :tuple)))
 (defn truthy? "Check if x is truthy." [x] (if x true false))
 (defn true? "Check if x is true." [x] (= x true))
 (defn false? "Check if x is false." [x] (= x false))

--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -659,6 +659,27 @@ ret_false:
     return janet_wrap_false();
 }
 
+JANET_CORE_FN(janet_core_is_bytes,
+              "(bytes? x)",
+              "Check if x is a string, symbol, keyword, or buffer.") {
+    janet_fixarity(argc, 1);
+    return janet_wrap_boolean(janet_checktypes(argv[0], JANET_TFLAG_BYTES));
+}
+
+JANET_CORE_FN(janet_core_is_indexed,
+              "(indexed? x)",
+              "Check if x is an array or tuple.") {
+    janet_fixarity(argc, 1);
+    return janet_wrap_boolean(janet_checktypes(argv[0], JANET_TFLAG_INDEXED));
+}
+
+JANET_CORE_FN(janet_core_is_dictionary,
+              "(dictionary? x)",
+              "Check if x is a table or struct.") {
+    janet_fixarity(argc, 1);
+    return janet_wrap_boolean(janet_checktypes(argv[0], JANET_TFLAG_DICTIONARY));
+}
+
 JANET_CORE_FN(janet_core_signal,
               "(signal what x)",
               "Raise a signal with payload x. ") {
@@ -1053,6 +1074,9 @@ static void janet_load_libs(JanetTable *env) {
         JANET_CORE_REG("module/expand-path", janet_core_expand_path),
         JANET_CORE_REG("int?", janet_core_check_int),
         JANET_CORE_REG("nat?", janet_core_check_nat),
+        JANET_CORE_REG("bytes?", janet_core_is_bytes),
+        JANET_CORE_REG("indexed?", janet_core_is_indexed),
+        JANET_CORE_REG("dictionary?", janet_core_is_dictionary),
         JANET_CORE_REG("slice", janet_core_slice),
         JANET_CORE_REG("range", janet_core_range),
         JANET_CORE_REG("signal", janet_core_signal),


### PR DESCRIPTION
I understand that it's not desirable to move everything to `corelib.c`, especially things that can be implemented simply and concisely in Janet. However, for these three functions I think it may be warranted. Each of these functions compares multiple types, and are used in several places throughout `boot.janet`, and not only in compile-time expanded macros.

For example, in `flatten`:
```janet
(use spork/test)
(timeit-loop [:timeout 1] :flatten (flatten [[[1 2] 3] 4 [5 [6 7 8] 9]]))
```
master:
```janet
flatten 1.000s, 1.556µs/body
```
branch:
```janet
flatten 1.000s, 0.8098µs/body
```
Nearly half the time taken is spent checking the type.

For the interested, moving these functions increases the size of the executable by 128 bytes, at least on my system:
master:
```janet
$ du -b /usr/local/bin/janet
797104	/usr/local/bin/janet
```
branch:
```janet
$ du -b /usr/local/bin/janet
797232	/usr/local/bin/janet
```