### PR TITLE
Add `lengthable?`

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1554,32 +1554,41 @@
 (defn keys
   "Get the keys of an associative data structure."
   [x]
-  (def arr (array/new-filled (length x)))
-  (var i 0)
-  (eachk k x
-    (put arr i k)
-    (++ i))
-  arr)
+  (if (lengthable? x)
+    (do
+      (def arr (array/new-filled (length x)))
+      (var i 0)
+      (eachk k x
+        (put arr i k)
+        (++ i))
+      arr)
+    (seq [k :keys x] k)))
 
 (defn values
   "Get the values of an associative data structure."
   [x]
-  (def arr (array/new-filled (length x)))
-  (var i 0)
-  (each v x
-    (put arr i v)
-    (++ i))
-  arr)
+  (if (lengthable? x)
+    (do
+      (def arr (array/new-filled (length x)))
+      (var i 0)
+      (each v x
+        (put arr i v)
+        (++ i))
+      arr)
+    (seq [v :in x] v)))
 
 (defn pairs
   "Get the key-value pairs of an associative data structure."
   [x]
-  (def arr (array/new-filled (length x)))
-  (var i 0)
-  (eachp p x
-    (put arr i p)
-    (++ i))
-  arr)
+  (if (lengthable? x)
+    (do
+      (def arr (array/new-filled (length x)))
+      (var i 0)
+      (eachp p x
+        (put arr i p)
+        (++ i))
+      arr)
+    (seq [p :pairs x] p)))
 
 (defn frequencies
   "Get the number of occurrences of each value in an indexed data structure."

--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -680,6 +680,13 @@ JANET_CORE_FN(janet_core_is_dictionary,
     return janet_wrap_boolean(janet_checktypes(argv[0], JANET_TFLAG_DICTIONARY));
 }
 
+JANET_CORE_FN(janet_core_is_lengthable,
+              "(lengthable? x)",
+              "Check if x is a bytes, indexed, or dictionary.") {
+    janet_fixarity(argc, 1);
+    return janet_wrap_boolean(janet_checktypes(argv[0], JANET_TFLAG_LENGTHABLE));
+}
+
 JANET_CORE_FN(janet_core_signal,
               "(signal what x)",
               "Raise a signal with payload x. ") {
@@ -1077,6 +1084,7 @@ static void janet_load_libs(JanetTable *env) {
         JANET_CORE_REG("bytes?", janet_core_is_bytes),
         JANET_CORE_REG("indexed?", janet_core_is_indexed),
         JANET_CORE_REG("dictionary?", janet_core_is_dictionary),
+        JANET_CORE_REG("lengthable?", janet_core_is_lengthable),
         JANET_CORE_REG("slice", janet_core_slice),
         JANET_CORE_REG("range", janet_core_range),
         JANET_CORE_REG("signal", janet_core_signal),


### PR DESCRIPTION
- Adds `lengthable?` to corelib, as mentioned [here](https://github.com/janet-lang/janet/pull/1244#issuecomment-1671333649).
```
(lengthable? x)

Check if x is a bytes, indexed, or dictionary.
```
- Allows potentially non-lengthable items for `keys`, `values`, and `pairs`, as used for example in [spork/generators](https://github.com/janet-lang/spork/blob/ce3e4377b61f14cf4221bcb3c0c10a96382aede8/spork/generators.janet#L18-L21).

There's a few other core functions that I think could benefit from knowing whether an iterable has a pre-determined length.

