### PR TITLE
Rework `reverse`, again

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1447,9 +1447,11 @@
   byte values, reversed.`
   [t]
   (var n (length t))
-  (def ret (array/new-filled n))
-  (forv i 0 n
-    (put ret i (in t (-- n))))
+  (def ret (if (bytes? t)
+             (buffer/new-filled n)
+             (array/new-filled n)))
+  (each v t
+    (put ret (-- n) v))
   ret)
 
 (defn invert


### PR DESCRIPTION
Related: #1248

With [feedback](https://github.com/janet-lang/janet/issues/1248#issuecomment-1675925262) from @bakpakin.

before:
```janet
> (reverse [:a :b :c])
@[:c :b :a]
> (reverse "abc")
@[99 98 97]
> (reverse {1 2 3 4 5 6})
@[nil 2 nil]
```
after:
```janet
> (reverse [:a :b :c])
@[:c :b :a]
> (reverse "abc")
@"cba"
> (reverse {1 2 3 4 5 6})
@[6 4 2]
```