### PR TITLE
Special case common `sort` usages

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -805,21 +805,31 @@
 ###
 ###
 
-(defn- median-of-three [a b c]
-  (if (not= (> a b) (> a c))
-    a
-    (if (not= (> b a) (> b c)) b c)))
+(defmacro- median-of-three
+  [x y z]
+  ~(if (<= ,x ,y)
+     (if (<= ,y ,z) ,y (if (<= ,z ,x) ,x ,z))
+     (if (<= ,z ,y) ,y (if (<= ,x ,z) ,x ,z))))
+
+(defmacro- sort-partition-template
+  [ind before? left right pivot]
+  ~(do
+     (while (,before? (in ,ind ,left) ,pivot) (++ ,left))
+     (while (,before? ,pivot (in ,ind ,right)) (-- ,right))))
 
 (defn- sort-help [a lo hi before?]
   (when (< lo hi)
-    (def pivot
-      (median-of-three (in a hi) (in a lo)
-                       (in a (math/floor (/ (+ lo hi) 2)))))
+    (def [x y z] [(in a lo)
+                  (in a (div (+ lo hi) 2))
+                  (in a hi)])
+    (def pivot (median-of-three x y z))
     (var left lo)
     (var right hi)
     (while true
-      (while (before? (in a left) pivot) (++ left))
-      (while (before? pivot (in a right)) (-- right))
+      (case before?
+        < (sort-partition-template a < left right pivot)
+        > (sort-partition-template a > left right pivot)
+        (sort-partition-template a before? left right pivot))
       (when (<= left right)
         (def tmp (in a left))
         (set (a left) (in a right))
@@ -827,8 +837,10 @@
         (++ left)
         (-- right))
       (if (>= left right) (break)))
-    (sort-help a lo right before?)
-    (sort-help a left hi before?))
+    (if (< lo right)
+      (sort-help a lo right before?))
+    (if (< left hi)
+      (sort-help a left hi before?)))
   a)
 
 (defn sort
@@ -836,7 +848,8 @@
   If a `before?` comparator function is provided, sorts elements using that,
   otherwise uses `<`.``
   [ind &opt before?]
-  (sort-help ind 0 (- (length ind) 1) (or before? <)))
+  (default before? <)
+  (sort-help ind 0 (- (length ind) 1) before?))
 
 (defn sort-by
   ``Sorts `ind` in-place by calling a function `f` on each element and


### PR DESCRIPTION
- Special case common sort usages (`<`, `>`) to use vm ops directly.
- Rewrite `median-of-three` to use 2.667 comparisons on average, rather than 5. It's not as clever, but it is faster.
- Avoid recursing if unnecessary.

The result is approximately 3x faster for these usages, and roughly unchanged for others.
```janet
(use spork/test)
(use spork/misc)

(def rng (math/rng 12345))
(def a (randomize-array (range 100) rng))

(timeit-loop [:timeout 1]
  "sorted "
  (sorted a))

(timeit-loop [:timeout 1]
  "sort   "
  (def b (array/slice a))
  (sort b))

(timeit-loop [:timeout 1]
  "reverse"
  (def b (array/slice a))
  (sort b >))

(timeit-loop [:timeout 1]
  "compare"
  (def b (array/slice a))
  (sort b compare<))
```
master:
```janet
sorted  1.000s, 99.43µs/body
sort    1.000s, 100.1µs/body
reverse 1.000s, 98.23µs/body
compare 1.000s, 131.7µs/body
```
branch:
```janet
sorted  1.000s, 28.41µs/body
sort    1.000s, 28.68µs/body
reverse 1.000s, 31.29µs/body
compare 1.000s, 126.9µs/body
```