### PR TITLE
Update `any?`, `every?`

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1424,20 +1424,21 @@
     (fn [& r] (f ;more ;r))))
 
 (defn every?
-  ``Returns true if each value in `ind` is truthy, otherwise returns the first
-  falsey value.``
+  ``Evaluates to the last element of `ind` if all preceding elements are truthy,
+  otherwise evaluates to the first falsey argument.``
   [ind]
   (var res true)
   (loop [x :in ind :while res]
-    (if x nil (set res x)))
+    (set res x))
   res)
 
 (defn any?
-  ``Returns the first truthy value in `ind`, otherwise nil.``
+  ``Evaluates to the last element of `ind` if all preceding elements are falsey,
+  otherwise evaluates to the first truthy element.``
   [ind]
   (var res nil)
   (loop [x :in ind :until res]
-    (if x (set res x)))
+    (set res x))
   res)
 
 (defn reverse!

--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -113,12 +113,21 @@
 # 7478ad11
 (assert (= nil (any? [])) "any? 1")
 (assert (= nil (any? [false nil])) "any? 2")
-(assert (= nil (any? [nil false])) "any? 3")
+(assert (= false (any? [nil false])) "any? 3")
 (assert (= 1 (any? [1])) "any? 4")
 (assert (nan? (any? [nil math/nan nil])) "any? 5")
 (assert (= true
            (any? [nil nil false nil nil true nil nil nil nil false :a nil]))
         "any? 6")
+
+(assert (= true (every? [])) "every? 1")
+(assert (= true (every? [1 true])) "every? 2")
+(assert (= 1 (every? [true 1])) "every? 3")
+(assert (= nil (every? [nil])) "every? 4")
+(assert (= 2 (every? [1 math/nan 2])) "every? 5")
+(assert (= false
+           (every? [1 1 true 1 1 false 1 1 1 1 true :a nil]))
+        "every? 6")
 
 # Some higher order functions and macros
 # 5e2de33


### PR DESCRIPTION
Updates `any?` and `every?` to be exact functional analogues to `or` and `and`.

- `any?` returns the final value if all preceding values are falsey, rather than `nil`.
- `every?` returns the final value if all preceding values are truthy, rather than `true`.

I believe this makes their definitions more coherent. `any?` would sometimes return an element from the collection (if it were truthy), and sometimes `nil`. `every?` would sometimes return an element from the collection (if it were falsey), and sometimes `true`. After, each will always return an element from the collection.

As their meaning will not have changed when used as a predicate, I believe these changes can be made with minimal fallout. `every?` in particular is much more useful this way. Because of the spatial separation in the documentation, I have duplicated the docstrings from `or` and `and`.

For the interested, the implementation is approximately 10% faster for each.