### PR TITLE
Update `each` keys before body

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -436,8 +436,8 @@
               :each ~(,in ,ds ,k)
               :keys k
               :pairs ~[,k (,in ,ds ,k)]))
-         ,;body
-         (set ,k (,next ,ds ,k))))))
+         (set ,k (,next ,ds ,k))
+         ,;body))))
 
 (defn- iterate-template
   [binding expr body]


### PR DESCRIPTION
Fixes #1220

Changes `each-template` to update the iteration key after bindings and before the body, rather than after the body. As the iteration key is not exposed to the body, I believe this has no consequence, other than to resolve the linked issue.
```janet
(let [t @{1 true 2 true 3 true 4 true}]
  (eachk k t
    (when (even? k)
      (put t k nil)))
  t)
```
master:
```janet
@{1 true 3 true 4 true}
```
branch:
```janet
@{1 true 3 true}
```