### PR TITLE
Speed up `min`, `max`

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -702,30 +702,38 @@
   [f]
   (fn [x] (not (f x))))
 
+(defmacro- do-extreme
+  [order args]
+  ~(do
+     (def ds ,args)
+     (var k (next ds nil))
+     (var ret (get ds k))
+     (while (,not= nil (set k (next ds k)))
+       (def x (in ds k))
+       (if (,order x ret) (set ret x)))
+     ret))
+
 (defn extreme
   ``Returns the most extreme value in `args` based on the function `order`.
   `order` should take two values and return true or false (a comparison).
   Returns nil if `args` is empty.``
-  [order args]
-  (var [ret] args)
-  (each x args (if (order x ret) (set ret x)))
-  ret)
+  [order args] (do-extreme order args))
 
 (defn max
   "Returns the numeric maximum of the arguments."
-  [& args] (extreme > args))
+  [& args] (do-extreme > args))
 
 (defn min
   "Returns the numeric minimum of the arguments."
-  [& args] (extreme < args))
+  [& args] (do-extreme < args))
 
 (defn max-of
   "Returns the numeric maximum of the argument sequence."
-  [args] (extreme > args))
+  [args] (do-extreme > args))
 
 (defn min-of
   "Returns the numeric minimum of the argument sequence."
-  [args] (extreme < args))
+  [args] (do-extreme < args))
 
 (defn first
   "Get the first element from an indexed data structure."


### PR DESCRIPTION
Creates a helper macro so that the primitive comparators compile to vm ops directly. The boiler plating is approximately the same as would be generated by `each`, except that the key is advanced before the loop to avoid unnecessarily comparing the first value with itself. The result is approximately 4x faster for `min` and `max`, 5x faster for `min-of` and `max-of`, and roughly unchanged for `extreme`.
```janet
(use spork/test)
(use spork/misc)

(def rng (math/rng 12345))
(def a (randomize-array (range 100) rng))

(timeit-loop [:timeout 1] "min    " (min ;a))
(timeit-loop [:timeout 1] "max    " (max ;a))
(timeit-loop [:timeout 1] "min-of " (min-of a))
(timeit-loop [:timeout 1] "max-of " (max-of a))
(timeit-loop [:timeout 1] "extreme" (extreme < a))
```
master:
```janet
min     1.000s, 9.145µs/body
max     1.001s, 9.146µs/body
min-of  1.000s, 8.959µs/body
max-of  1.000s, 8.962µs/body
extreme 1.000s, 9.012µs/body
```
branch:
```janet
min     1.000s, 2.101µs/body
max     1.000s, 2.172µs/body
min-of  1.000s, 1.816µs/body
max-of  1.000s, 1.854µs/body
extreme 1.000s, 8.888µs/body
```
---
The stray comma before `not=` is necessary, oddly. With, it compiles to a single `jmpni` instruction. Without, it compiles to `ldn`, `neq`, `jmpno`.