### PR TITLE
Promote (comment) to special form

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -164,10 +164,6 @@
   [sym val]
   ~(def ,sym (if (= nil ,sym) ,val ,sym)))
 
-(defmacro comment
-  "Ignores the body of the comment."
-  [&])
-
 (defmacro if-not
   "Shorthand for `(if (not condition) else then)`."
   [condition then &opt else]

--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -1128,9 +1128,18 @@ error2:
     return janetc_cslot(janet_wrap_nil());
 }
 
+static JanetSlot janetc_comment(JanetFopts opts, int32_t argn, const Janet *argv) {
+    (void) argn; (void) argv;
+    JanetSlot ret;
+    ret = janetc_value(opts, janet_wrap_array(janet_array(0)));
+    ret.flags |= JANET_SLOT_SPLICED;
+    return ret;
+}
+
 /* Keep in lexicographic order */
 static const JanetSpecial janetc_specials[] = {
     {"break", janetc_break},
+    {"comment", janetc_comment},
     {"def", janetc_def},
     {"do", janetc_do},
     {"fn", janetc_fn},
@@ -1142,7 +1151,7 @@ static const JanetSpecial janetc_specials[] = {
     {"unquote", janetc_unquote},
     {"upscope", janetc_upscope},
     {"var", janetc_var},
-    {"while", janetc_while}
+    {"while", janetc_while},
 };
 
 /* Find a special */


### PR DESCRIPTION
JANET_SLOT_SPLICED + empty array is used here.

The implementation is splice of empty array. It kind of works. When used at top-level, it returns `@[]`. (it's only visible in REPL though)

Is there a way to return `JanetSlot` that represents nothing?

Related: #1272 