### PR TITLE
Allow one-term `:range` and `:down` forms

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -419,9 +419,11 @@
     (error (string "expected tuple for range, got " x))))
 
 (defn- range-template
-  [binding object rest op comparison]
+  [binding object kind rest op comparison]
   (let [[start stop step] (check-indexed object)]
-    (for-template binding start stop (or step 1) comparison op [rest])))
+    (case kind
+      :range (for-template binding (if stop start 0) (or stop start) (or step 1) comparison op [rest])
+      :down (for-template binding start (or stop 0) (or step 1) comparison op [rest]))))
 
 (defn- each-template
   [binding inx kind body]
@@ -477,10 +479,10 @@
   (def {(+ i 2) object} head)
   (let [rest (loop1 body head (+ i 3))]
     (case verb
-      :range (range-template binding object rest + <)
-      :range-to (range-template binding object rest + <=)
-      :down (range-template binding object rest - >)
-      :down-to (range-template binding object rest - >=)
+      :range (range-template binding object :range rest + <)
+      :range-to (range-template binding object :range rest + <=)
+      :down (range-template binding object :down rest - >)
+      :down-to (range-template binding object :down rest - >=)
       :keys (each-template binding object :keys [rest])
       :pairs (each-template binding object :pairs [rest])
       :in (each-template binding object :each [rest])

--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -204,6 +204,12 @@
 (assert (deep= (seq [x :down-to [10 0]] x) (seq [x :down [10 -1]] x))
         "loop :down-to")
 
+# one-term :range forms
+(assert (deep= (seq [x :range [10]] x) (seq [x :range [0 10]] x))
+        "one-term :range")
+(assert (deep= (seq [x :down [10]] x) (seq [x :down [10 0]] x))
+        "one-term :down")
+
 # 7880d7320
 (def res @{})
 (loop [[k v] :pairs @{1 2 3 4 5 6}]


### PR DESCRIPTION
Related: #1275

Makes `:range` more predictable, in particular that:
```janet
(loop [i :range [10]] body)
```
is equivalent to:
```janet
(loop [i :range [0 10] body)
```
rather than producing an infinite loop.

This is consistent with the behavior that the following forms:
```janet
(range 10)
(range 0 10)
```
are also equivalent.