### PR TITLE
Remove old parser code

### DIFF
--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -612,7 +612,6 @@ static int atsign(JanetParser *p, JanetParseState *state, uint8_t c) {
             break;
     }
     pushstate(p, tokenchar, PFLAG_TOKEN);
-    push_buf(p, '@'); /* Push the leading at-sign that was dropped */
     return 0;
 }
 


### PR DESCRIPTION
This PR contains the removal of a line that looks obsolete.

I think the oldest version of the line in question is [here](https://github.com/janet-lang/janet/blob/05318669540ed8d02f2a2b841333290b61b12ccd/core/parse.c#L406).  AFAICT the code has evolved since that time in such a way such that the line no longer appears necessary.

I ran various tests without detecting problems and failed to turn up any issues working at the REPL.

Perhaps I've missed something though (^^;
