### PR TITLE
fix some typos in docstrings

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1232,7 +1232,7 @@
 (defdyn *debug* "Enables a built in debugger on errors and other useful features for debugging in a repl.")
 (defdyn *exit* "When set, will cause the current context to complete. Can be set to exit from repl (or file), for example.")
 (defdyn *exit-value* "Set the return value from `run-context` upon an exit. By default, `run-context` will return nil.")
-(defdyn *task-id* "When spawning a thread or fiber, the task-id can be assigned for concurrecny control.")
+(defdyn *task-id* "When spawning a thread or fiber, the task-id can be assigned for concurrency control.")
 
 (defdyn *macro-form*
   "Inside a macro, is bound to the source form that invoked the macro")
@@ -1267,7 +1267,7 @@
 
 (defn keep-syntax
   ``Creates a tuple with the tuple type and sourcemap of `before` but the
-  elements of `after`. If either one of its argements is not a tuple, returns
+  elements of `after`. If either one of its arguments is not a tuple, returns
   `after` unmodified. Useful to preserve syntactic information when transforming
   an ast in macros.``
   [before after]

--- a/src/core/ffi.c
+++ b/src/core/ffi.c
@@ -1381,7 +1381,7 @@ JANET_CORE_FN(cfun_ffi_buffer_write,
               "(ffi/write ffi-type data &opt buffer index)",
               "Append a native type to a buffer such as it would appear in memory. This can be used "
               "to pass pointers to structs in the ffi, or send C/C++/native structs over the network "
-              "or to files. Returns a modifed buffer or a new buffer if one is not supplied.") {
+              "or to files. Returns a modified buffer or a new buffer if one is not supplied.") {
     janet_sandbox_assert(JANET_SANDBOX_FFI_USE);
     janet_arity(argc, 2, 4);
     JanetFFIType type = decode_ffi_type(argv[0]);
@@ -1548,7 +1548,7 @@ JANET_CORE_FN(cfun_ffi_pointer_cfunction,
 
 JANET_CORE_FN(cfun_ffi_supported_calling_conventions,
               "(ffi/calling-conventions)",
-              "Get an array of all supported calling conventions on the current arhcitecture. Some architectures may have some FFI "
+              "Get an array of all supported calling conventions on the current architecture. Some architectures may have some FFI "
               "functionality (ffi/malloc, ffi/free, ffi/read, ffi/write, etc.) but not support "
               "any calling conventions. This function can be used to get all supported calling conventions "
               "that can be used on this architecture. All architectures support the :none calling "

--- a/src/core/inttypes.c
+++ b/src/core/inttypes.c
@@ -239,7 +239,7 @@ JANET_CORE_FN(cfun_to_bytes,
               "Write the bytes of an `int/s64` or `int/u64` into a buffer.\n"
               "The `buffer` parameter specifies an existing buffer to write to, if unset a new buffer will be created.\n"
               "Returns the modified buffer.\n"
-              "The `endianness` paramater indicates the byte order:\n"
+              "The `endianness` parameter indicates the byte order:\n"
               "- `nil` (unset): system byte order\n"
               "- `:le`: little-endian, least significant byte first\n"
               "- `:be`: big-endian, most significant byte first\n") {

--- a/src/core/math.c
+++ b/src/core/math.c
@@ -119,7 +119,7 @@ double janet_rng_double(JanetRNG *rng) {
 
 JANET_CORE_FN(cfun_rng_make,
               "(math/rng &opt seed)",
-              "Creates a Psuedo-Random number generator, with an optional seed. "
+              "Creates a Pseudo-Random number generator, with an optional seed. "
               "The seed should be an unsigned 32 bit integer or a buffer. "
               "Do not use this for cryptography. Returns a core/rng abstract type."
              ) {
@@ -411,11 +411,11 @@ void janet_lib_math(JanetTable *env) {
     JANET_CORE_DEF(env, "math/int32-min", janet_wrap_number(INT32_MIN),
                    "The minimum contiguous integer representable by a 32 bit signed integer");
     JANET_CORE_DEF(env, "math/int32-max", janet_wrap_number(INT32_MAX),
-                   "The maximum contiguous integer represtenable by a 32 bit signed integer");
+                   "The maximum contiguous integer representable by a 32 bit signed integer");
     JANET_CORE_DEF(env, "math/int-min", janet_wrap_number(JANET_INTMIN_DOUBLE),
                    "The minimum contiguous integer representable by a double (2^53)");
     JANET_CORE_DEF(env, "math/int-max", janet_wrap_number(JANET_INTMAX_DOUBLE),
-                   "The maximum contiguous integer represtenable by a double (-(2^53))");
+                   "The maximum contiguous integer representable by a double (-(2^53))");
 #ifdef NAN
     JANET_CORE_DEF(env, "math/nan", janet_wrap_number(NAN), "Not a number (IEEE-754 NaN)");
 #else

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -554,7 +554,7 @@ JANET_CORE_FN(cfun_string_format,
               "- `j`: format to jdn (Janet data notation).\n"
               "\n"
               "The following conversion specifiers are used for \"pretty-printing\", where the upper-case "
-              "variants generate colored output. These speficiers can take a precision "
+              "variants generate colored output. These specifiers can take a precision "
               "argument to specify the maximum nesting depth to print.\n"
               "- `p`, `P`: pretty format, truncating if necessary\n"
               "- `m`, `M`: pretty format without truncating.\n"

--- a/test/suite-inttypes.janet
+++ b/test/suite-inttypes.janet
@@ -126,7 +126,7 @@
   (assert (deep= (int/to-bytes (u64 300) :be buf2)
                  @"abcd\x00\x00\x00\x00\x00\x00\x01\x2C")))
 
-# int/s64 and int/u64 paramater type checking
+# int/s64 and int/u64 parameter type checking
 # 6aea7c7f7
 (assert-error
   "bad value passed to int/to-bytes"


### PR DESCRIPTION
I noticed the typo in `*task-id*` so I ran spellcheck over the docstrings and found a couple more. Nothing too exciting here.