### PR TITLE
net/ev: Cleaned up unused NetStateConnect, fixed janet_async_end() ev refcount

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -258,12 +258,12 @@ void janet_async_end(JanetFiber *fiber) {
         fiber->ev_callback(fiber, JANET_ASYNC_EVENT_DEINIT);
         janet_gcunroot(janet_wrap_abstract(fiber->ev_stream));
         fiber->ev_callback = NULL;
-        if (fiber->ev_state) {
-            if (!(fiber->flags & JANET_FIBER_EV_FLAG_IN_FLIGHT)) {
+        if (!(fiber->flags & JANET_FIBER_EV_FLAG_IN_FLIGHT)) {
+            if (fiber->ev_state) {
                 janet_free(fiber->ev_state);
-                janet_ev_dec_refcount();
+                fiber->ev_state = NULL;
             }
-            fiber->ev_state = NULL;
+            janet_ev_dec_refcount();
         }
     }
 }

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -122,13 +122,9 @@ static void janet_net_socknoblock(JSock s) {
 
 /* State machine for async connect */
 
-typedef struct {
-    int did_connect;
-} NetStateConnect;
 
 void net_callback_connect(JanetFiber *fiber, JanetAsyncEvent event) {
     JanetStream *stream = fiber->ev_stream;
-    NetStateConnect *state = (NetStateConnect *)fiber->ev_state;
     switch (event) {
         default:
             break;
@@ -155,7 +151,6 @@ void net_callback_connect(JanetFiber *fiber, JanetAsyncEvent event) {
 #endif
     if (r == 0) {
         if (res == 0) {
-            state->did_connect = 1;
             janet_schedule(fiber, janet_wrap_abstract(stream));
         } else {
             janet_cancel(fiber, janet_cstringv(strerror(res)));
@@ -169,9 +164,7 @@ void net_callback_connect(JanetFiber *fiber, JanetAsyncEvent event) {
 }
 
 static JANET_NO_RETURN void net_sched_connect(JanetStream *stream) {
-    NetStateConnect *state = janet_malloc(sizeof(NetStateConnect));
-    state->did_connect = 0;
-    janet_async_start(stream, JANET_ASYNC_LISTEN_WRITE, net_callback_connect, state);
+    janet_async_start(stream, JANET_ASYNC_LISTEN_WRITE, net_callback_connect, NULL);
 }
 
 /* State machine for accepting connections. */


### PR DESCRIPTION
Not sure if this makes proper sense, needs some review.

This cleans up the unused `NetStateConnect` state in the connect state machine, but not allocating any state to pass to `janet_async_start()` hung my janet at cleanup time; I believe the refcount dec should not depend on state of `evdata` 