### PR TITLE
Add a new (sub) PEG special

### DIFF
--- a/src/core/peg.c
+++ b/src/core/peg.c
@@ -39,6 +39,10 @@
 typedef struct {
     const uint8_t *text_start;
     const uint8_t *text_end;
+    /* text_end will be restricted in a (sub) rule, but
+       outer_text_end will always contain the real end of
+       input, which we need to generate a line mapping */
+    const uint8_t *outer_text_end;
     const uint32_t *bytecode;
     const Janet *constants;
     JanetArray *captures;
@@ -114,12 +118,12 @@ static LineCol get_linecol_from_position(PegState *s, int32_t position) {
     /* Generate if not made yet */
     if (s->linemaplen < 0) {
         int32_t newline_count = 0;
-        for (const uint8_t *c = s->text_start; c < s->text_end; c++) {
+        for (const uint8_t *c = s->text_start; c < s->outer_text_end; c++) {
             if (*c == '\n') newline_count++;
         }
         int32_t *mem = janet_smalloc(sizeof(int32_t) * newline_count);
         size_t index = 0;
-        for (const uint8_t *c = s->text_start; c < s->text_end; c++) {
+        for (const uint8_t *c = s->text_start; c < s->outer_text_end; c++) {
             if (*c == '\n') mem[index++] = (int32_t)(c - s->text_start);
         }
         s->linemaplen = newline_count;
@@ -179,7 +183,7 @@ static const uint8_t *peg_rule(
     const uint32_t *rule,
     const uint8_t *text) {
 tail:
-    switch (*rule & 0x1F) {
+    switch (*rule) {
         default:
             janet_panic("unexpected opcode");
             return NULL;
@@ -480,6 +484,30 @@ tail:
             cap_load_keept(s, cs);
             pushcap(s, janet_wrap_array(sub_captures), tag);
             return result;
+        }
+
+        case RULE_SUB: {
+            const uint8_t *text_start = text;
+            const uint32_t *rule_window = s->bytecode + rule[1];
+            const uint32_t *rule_subpattern = s->bytecode + rule[2];
+            down1(s);
+            const uint8_t *window_end = peg_rule(s, rule_window, text);
+            up1(s);
+            if (!window_end) {
+                return NULL;
+            }
+            const uint8_t *saved_end = s->text_end;
+            s->text_end = window_end;
+            down1(s);
+            const uint8_t *next_text = peg_rule(s, rule_subpattern, text_start);
+            up1(s);
+            s->text_end = saved_end;
+
+            if (!next_text) {
+                return NULL;
+            }
+
+            return window_end;
         }
 
         case RULE_REPLACE:
@@ -1107,6 +1135,14 @@ static void spec_matchtime(Builder *b, int32_t argc, const Janet *argv) {
     emit_3(r, RULE_MATCHTIME, subrule, cindex, tag);
 }
 
+static void spec_sub(Builder *b, int32_t argc, const Janet *argv) {
+    peg_fixarity(b, argc, 2);
+    Reserve r = reserve(b, 3);
+    uint32_t subrule1 = peg_compile1(b, argv[0]);
+    uint32_t subrule2 = peg_compile1(b, argv[1]);
+    emit_2(r, RULE_SUB, subrule1, subrule2);
+}
+
 #ifdef JANET_INT_TYPES
 #define JANET_MAX_READINT_WIDTH 8
 #else
@@ -1190,6 +1226,7 @@ static const SpecialPair peg_specials[] = {
     {"sequence", spec_sequence},
     {"set", spec_set},
     {"some", spec_some},
+    {"sub", spec_sub},
     {"thru", spec_thru},
     {"to", spec_to},
     {"uint", spec_uint_le},
@@ -1431,7 +1468,7 @@ static void *peg_unmarshal(JanetMarshalContext *ctx) {
         uint32_t instr = bytecode[i];
         uint32_t *rule = bytecode + i;
         op_flags[i] |= 0x02;
-        switch (instr & 0x1F) {
+        switch (instr) {
             case RULE_LITERAL:
                 i += 2 + ((rule[1] + 3) >> 2);
                 break;
@@ -1523,6 +1560,14 @@ static void *peg_unmarshal(JanetMarshalContext *ctx) {
                 if (rule[2] >= clen) goto bad;
                 op_flags[rule[1]] |= 0x01;
                 i += 4;
+                break;
+            case RULE_SUB:
+                /* [rule, rule] */
+                if (rule[1] >= blen) goto bad;
+                if (rule[2] >= blen) goto bad;
+                op_flags[rule[1]] |= 0x01;
+                op_flags[rule[2]] |= 0x01;
+                i += 3;
                 break;
             case RULE_ERROR:
             case RULE_DROP:
@@ -1677,6 +1722,7 @@ static PegCall peg_cfun_init(int32_t argc, Janet *argv, int get_replace) {
     ret.s.mode = PEG_MODE_NORMAL;
     ret.s.text_start = ret.bytes.bytes;
     ret.s.text_end = ret.bytes.bytes + ret.bytes.len;
+    ret.s.outer_text_end = ret.s.text_end;
     ret.s.depth = JANET_RECURSION_GUARD;
     ret.s.captures = janet_array(0);
     ret.s.tagged_captures = janet_array(0);

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -2140,7 +2140,8 @@ typedef enum {
     RULE_LINE,         /* [tag] */
     RULE_COLUMN,       /* [tag] */
     RULE_UNREF,        /* [rule, tag] */
-    RULE_CAPTURE_NUM   /* [rule, tag] */
+    RULE_CAPTURE_NUM,  /* [rule, tag] */
+    RULE_SUB           /* [rule, rule] */
 } JanetPegOpcod;
 
 typedef struct {


### PR DESCRIPTION
~~The first commit in this branch condenses the two of the existing opcodes into a single opcode, so that there are still exactly 32 PEG opcodes. [I asked about this on Zulip](https://janet.zulipchat.com/#narrow/stream/399615-general/topic/implementation), and as I said there I'm still not very confident that this code is necessary. It does remove a conditional branch on the main bytecode loop, but I worry there might be some 32-bitness thing that I don't understand that might make it even more costly to remove.~~

It then proposes ~~two~~ one new special~~s~~:

# `sub`

`(sub window patt)` executes the `window` pattern, remembers how many bytes it matches, then executes `patt` over exactly the bytes matched by the `window`. This allows you to limit what the sub`patt`ern can match, e.g. `(sub (to "\n") :foo)` ensures that `:foo` does not have a chance to match beyond the current line. If `patt` also matches, then the full window is consumed by the `(sub)` rule.

Another good name for this might be `limit`, as in `(limit (to "\n") patt)`, but this doesn't really communicate that the full matched text is equal to the `window` pattern.

On the surface this is similar to `(cmt (% ...) ,|(peg/match ... $))`, but differs in several ways: the subpattern in `sub` can still refer to `:other` patterns inside struct rules, the `position` and other helpers are still relative to the whole input, the pattern can leave multiple captures...

---

# ~~`sep`~~

> I'll move this into its own PR, but I'm preserving the original description so the discussion still makes sense.

`(sep separator patt)` is a combination of `sub`, `to`, and `thru`. The canonical example would be something like `~(sep "," :w*)` to match comma-separated words.

It's similar to `~(some (* (sub (to (+ ,separator -1)) ,patt) (? ,separator)))`, except that it will not consume terminating separators: the final `(? ,separator)` rule is conditional on the *next* instance of the subpattern matching. A more accurate translation would be:

```janet
(defn sep [separator patt]
  ~(? (sub (to (+ ,separator -1)) ,patt) (any (* ,separator (sub (to (+ ,separator -1)) ,patt)))))
```

Which is pretty unwieldy. I think this is a common enough pattern to deserve an optimized helper -- it compiles to a lot less bytecode and doesn't match `separator`s twice.

Since `sep` repeats, it might be useful to have separte forms like `sep-any` and `sep-some`.

Neither of these combinators are really *necessary*, as you can do a one-pass thing that ensures that your inner patterns never advance past a separator (which is necessary in the case of a real csv parser that has to handle escapes). But they're convenient for lots of simple ad-hoc parsing tasks (hello from advent of code).