### PR TITLE
Tweak fiber/last-value docstring

### DIFF
--- a/src/core/fiber.c
+++ b/src/core/fiber.c
@@ -662,7 +662,7 @@ JANET_CORE_FN(cfun_fiber_can_resume,
 }
 
 JANET_CORE_FN(cfun_fiber_last_value,
-              "(fiber/last-value)",
+              "(fiber/last-value fiber)",
               "Get the last value returned or signaled from the fiber.") {
     janet_fixarity(argc, 1);
     JanetFiber *fiber = janet_getfiber(argv, 0);


### PR DESCRIPTION
This PR contains a minor docstring tweak to `fiber/last-value`.  It just changes the signature of the function so that it has an argument.