### PR TITLE
Add to propagate docstring (#1365)

### DIFF
--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -1150,11 +1150,14 @@ JanetTable *janet_core_env(JanetTable *replacements) {
     janet_quick_asm(env, JANET_FUN_PROP,
                     "propagate", 2, 2, 2, 2, propagate_asm, sizeof(propagate_asm),
                     JDOC("(propagate x fiber)\n\n"
-                         "Propagate a signal from a fiber to the current fiber. The resulting "
-                         "stack trace from the current fiber will include frames from fiber. If "
-                         "fiber is in a state that can be resumed, resuming the current fiber will "
-                         "first resume fiber. This function can be used to re-raise an error without "
-                         "losing the original stack trace."));
+                         "Propagate a signal from a fiber to the current fiber and "
+                         "set the last value of the current fiber to `x`.  The signal "
+                         "value is then available as the status of the current fiber. "
+                         "The resulting stack trace from the current fiber will include "
+                         "frames from fiber. If fiber is in a state that can be resumed, "
+                         "resuming the current fiber will first resume `fiber`. "
+                         "This function can be used to re-raise an error without losing "
+                         "the original stack trace."));
     janet_quick_asm(env, JANET_FUN_DEBUG,
                     "debug", 1, 0, 1, 1, debug_asm, sizeof(debug_asm),
                     JDOC("(debug &opt x)\n\n"


### PR DESCRIPTION
This PR is an attempt to address a bit more of #1365.  Specifically, it adds a bit more detail to the docstring of `propagate`.

Some of the more relevant discussion starts at around [this comment](https://github.com/janet-lang/janet/issues/1365#issuecomment-1908236312).