### PR TITLE
Fix: make `proc_get_status` compliant to OS documentation.

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -505,8 +505,11 @@ static int proc_get_status(JanetProc *proc) {
         status = WEXITSTATUS(status);
     } else if (WIFSTOPPED(status)) {
         status = WSTOPSIG(status) + 128;
-    } else {
+    } else if (WIFSIGNALED(status)){
         status = WTERMSIG(status) + 128;
+    } else {
+        /* Could possibly return -1 but for now, just panic */
+        janet_panicf("Undefined status code for process termination, %d.", status);
     }
     return status;
 }


### PR DESCRIPTION
As discused over gitter, `WIFSIGNALED` macro must be checked before one uses the `WTERMSIG` macro. This change reflects that necessity and adds a final else clause which will panic if no status code could be determined.

Also relevant is information gathered by @sogaiu in [question-about-WTERMSIG-in-janet.md](https://gist.github.com/sogaiu/92149bc1c085e4b7da40f650a4965b6a).

The idea here (currently, though it could be changed) is to panic when an unknown status code is encountered, as well as comply to the `man 2 waitpid` documentation.