### PR TITLE
Fix documentation of peg/replace

### DIFF
--- a/src/core/peg.c
+++ b/src/core/peg.c
@@ -1865,7 +1865,7 @@ JANET_CORE_FN(cfun_peg_replace_all,
 }
 
 JANET_CORE_FN(cfun_peg_replace,
-              "(peg/replace peg repl text &opt start & args)",
+              "(peg/replace peg subst text &opt start & args)",
               "Replace first match of `peg` in `text` with `subst`, returning a new buffer. "
               "The peg does not need to make captures to do replacement. "
               "If `subst` is a function, it will be called with the "


### PR DESCRIPTION
It looks like this piece of text was overseen while renaming `repl` to `subst` in commit 485099fd6e9e88fdc7521fff7e54a6d7023e9871.