### PR TITLE
Use `size_t` for Janet types length and capacity and the API those types use

### DIFF
--- a/examples/numarray/numarray.c
+++ b/examples/numarray/numarray.c
@@ -70,7 +70,7 @@ void num_array_put(void *p, Janet key, Janet value) {
     if (!janet_checktype(value, JANET_NUMBER))
         janet_panic("expected number value");
 
-    index = (size_t)janet_unwrap_integer(key);
+    index = janet_unwrap_size(key);
     if (index < array->size) {
         array->data[index] = janet_unwrap_number(value);
     }
@@ -96,7 +96,7 @@ int num_array_get(void *p, Janet key, Janet *out) {
         return janet_getmethod(janet_unwrap_keyword(key), methods, out);
     if (!janet_checkint(key))
         janet_panic("expected integer key");
-    index = (size_t)janet_unwrap_integer(key);
+    index = janet_unwrap_size(key);
     if (index >= array->size) {
         return 0;
     } else {

--- a/src/boot/array_test.c
+++ b/src/boot/array_test.c
@@ -26,8 +26,6 @@
 #include "tests.h"
 
 int array_test() {
-
-    int i;
     JanetArray *array1, *array2;
 
     array1 = janet_array(10);
@@ -53,7 +51,7 @@ int array_test() {
     janet_array_push(array2, janet_cstringv("six"));
     janet_array_push(array2, janet_cstringv("seven"));
 
-    for (i = 0; i < array2->count; i++) {
+    for (size_t i = 0; i < array2->count; i++) {
         assert(janet_equals(array1->data[i], array2->data[i]));
     }
 

--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -104,7 +104,7 @@ int main(int argc, const char **argv) {
     }
     fclose(boot_file);
 
-    status = janet_dobytes(env, boot_buffer, (int32_t) boot_size, boot_filename, NULL);
+    status = janet_dobytes(env, boot_buffer, boot_size, boot_filename, NULL);
     janet_free(boot_buffer);
 
     /* Deinitialize vm */

--- a/src/boot/buffer_test.c
+++ b/src/boot/buffer_test.c
@@ -26,8 +26,6 @@
 #include "tests.h"
 
 int buffer_test() {
-
-    int i;
     JanetBuffer *buffer1, *buffer2;
 
     buffer1 = janet_buffer(100);
@@ -54,7 +52,7 @@ int buffer_test() {
     assert(buffer1->capacity >= buffer1->count);
     assert(buffer2->capacity >= buffer2->count);
 
-    for (i = 0; i < buffer1->count; i++) {
+    for (size_t i = 0; i < buffer1->count; i++) {
         assert(buffer1->data[i] == buffer2->data[i]);
     }
 

--- a/src/boot/number_test.c
+++ b/src/boot/number_test.c
@@ -38,7 +38,7 @@ static void test_valid_str(const char *str) {
     double cnum, jnum;
     jnum = 0.0;
     cnum = atof(str);
-    err = janet_scan_number((const uint8_t *) str, (int32_t) strlen(str), &jnum);
+    err = janet_scan_number((const uint8_t *) str, strlen(str), &jnum);
     assert(!err);
     assert(cnum == jnum);
 }

--- a/src/core/array.c
+++ b/src/core/array.c
@@ -90,8 +90,6 @@ void janet_array_ensure(JanetArray *array, size_t capacity, size_t growth) {
 
 /* Set the count of an array. Extend with nil if needed. */
 void janet_array_setcount(JanetArray *array, size_t count) {
-    if (count < 0)
-        return;
     if (count > array->count) {
         size_t i;
         janet_array_ensure(array, count, 1);
@@ -104,7 +102,7 @@ void janet_array_setcount(JanetArray *array, size_t count) {
 
 /* Push a value to the top of the array */
 void janet_array_push(JanetArray *array, Janet x) {
-    if (array->count == INT32_MAX) {
+    if (array->count == JANET_INTMAX_INT64) {
         janet_panic("array overflow");
     }
     size_t newcount = array->count + 1;
@@ -322,8 +320,6 @@ JANET_CORE_FN(cfun_array_remove,
         janet_panicf("removal index %d out of range [0,%d]", at, array->count);
     if (argc == 3) {
         n = janet_getsize(argv, 2);
-        if (n < 0)
-            janet_panicf("expected non-negative integer for argument n, got %v", argv[2]);
     }
     if (at + n > array->count) {
         n = array->count - at;

--- a/src/core/array.c
+++ b/src/core/array.c
@@ -201,7 +201,7 @@ JANET_CORE_FN(cfun_array_push,
               "Push all the elements of xs to the end of an array. Modifies the input array and returns it.") {
     janet_arity(argc, 1, -1);
     JanetArray *array = janet_getarray(argv, 0);
-    if (JANET_INTMAX_INT64 - argc + 1 <= array->count) {
+    if ((size_t) JANET_INTMAX_INT64 - argc + 1 <= array->count) {
         janet_panic("array overflow");
     }
     size_t newcount = array->count - 1 + argc;
@@ -248,10 +248,9 @@ JANET_CORE_FN(cfun_array_concat,
               "which must be an array. If any of the parts are arrays or tuples, their elements will "
               "be inserted into the array. Otherwise, each part in `parts` will be appended to `arr` in order. "
               "Return the modified array `arr`.") {
-    size_t i;
     janet_arity(argc, 1, -1);
     JanetArray *array = janet_getarray(argv, 0);
-    for (i = 1; i < argc; i++) {
+    for (int32_t i = 1; i < argc; i++) {
         switch (janet_type(argv[i])) {
             default:
                 janet_array_push(array, argv[i]);
@@ -284,15 +283,15 @@ JANET_CORE_FN(cfun_array_insert,
     size_t chunksize, restsize;
     janet_arity(argc, 2, -1);
     JanetArray *array = janet_getarray(argv, 0);
-    size_t at = janet_getinteger(argv, 1);
+    int32_t at = janet_getinteger(argv, 1);
     if (at < 0) {
         at = array->count + at + 1;
     }
-    if (at < 0 || at > array->count)
+    if (at < 0 || (size_t) at > array->count)
         janet_panicf("insertion index %d out of range [0,%d]", at, array->count);
     chunksize = (argc - 2) * sizeof(Janet);
     restsize = (array->count - at) * sizeof(Janet);
-    if (JANET_INTMAX_INT64 - (argc - 2) < array->count) {
+    if ((size_t) JANET_INTMAX_INT64 - (argc - 2) < array->count) {
         janet_panic("array overflow");
     }
     janet_array_ensure(array, array->count + argc - 2, 2);
@@ -314,15 +313,15 @@ JANET_CORE_FN(cfun_array_remove,
               "Returns the array.") {
     janet_arity(argc, 2, 3);
     JanetArray *array = janet_getarray(argv, 0);
-    size_t at = janet_getinteger(argv, 1);
+    int32_t at = janet_getinteger(argv, 1);
     size_t n = 1;
     if (at < 0) {
         at = array->count + at;
     }
-    if (at < 0 || at > array->count)
+    if (at < 0 || (size_t) at > array->count)
         janet_panicf("removal index %d out of range [0,%d]", at, array->count);
     if (argc == 3) {
-        n = janet_getinteger(argv, 2);
+        n = janet_getsize(argv, 2);
         if (n < 0)
             janet_panicf("expected non-negative integer for argument n, got %v", argv[2]);
     }

--- a/src/core/array.c
+++ b/src/core/array.c
@@ -77,7 +77,7 @@ void janet_array_ensure(JanetArray *array, size_t capacity, size_t growth) {
     Janet *old = array->data;
     if (capacity <= array->capacity) return;
     size_t new_capacity = (capacity) * growth;
-    if (new_capacity > JANET_INTMAX_INT64) new_capacity = JANET_INTMAX_INT64;
+    if (new_capacity > JANET_INTMAX_SIZE) new_capacity = JANET_INTMAX_SIZE;
     capacity = new_capacity;
     newData = janet_realloc(old, capacity * sizeof(Janet));
     if (NULL == newData) {
@@ -102,7 +102,7 @@ void janet_array_setcount(JanetArray *array, size_t count) {
 
 /* Push a value to the top of the array */
 void janet_array_push(JanetArray *array, Janet x) {
-    if (array->count == JANET_INTMAX_INT64) {
+    if (array->count == JANET_INTMAX_SIZE) {
         janet_panic("array overflow");
     }
     size_t newcount = array->count + 1;
@@ -199,7 +199,7 @@ JANET_CORE_FN(cfun_array_push,
               "Push all the elements of xs to the end of an array. Modifies the input array and returns it.") {
     janet_arity(argc, 1, -1);
     JanetArray *array = janet_getarray(argv, 0);
-    if ((size_t) JANET_INTMAX_INT64 - argc + 1 <= array->count) {
+    if ((size_t) JANET_INTMAX_SIZE - argc + 1 <= array->count) {
         janet_panic("array overflow");
     }
     size_t newcount = array->count - 1 + argc;
@@ -281,15 +281,15 @@ JANET_CORE_FN(cfun_array_insert,
     size_t chunksize, restsize;
     janet_arity(argc, 2, -1);
     JanetArray *array = janet_getarray(argv, 0);
-    int32_t at = janet_getinteger(argv, 1);
+    ssize_t at = janet_getssize(argv, 1);
     if (at < 0) {
         at = array->count + at + 1;
     }
     if (at < 0 || (size_t) at > array->count)
-        janet_panicf("insertion index %d out of range [0,%d]", at, array->count);
+      janet_panicf("insertion index %d out of range [0,%d]", at, array->count);
     chunksize = (argc - 2) * sizeof(Janet);
     restsize = (array->count - at) * sizeof(Janet);
-    if ((size_t) JANET_INTMAX_INT64 - (argc - 2) < array->count) {
+    if ((size_t) JANET_INTMAX_SIZE - (argc - 2) < array->count) {
         janet_panic("array overflow");
     }
     janet_array_ensure(array, array->count + argc - 2, 2);
@@ -311,7 +311,7 @@ JANET_CORE_FN(cfun_array_remove,
               "Returns the array.") {
     janet_arity(argc, 2, 3);
     JanetArray *array = janet_getarray(argv, 0);
-    int32_t at = janet_getinteger(argv, 1);
+    ssize_t at = janet_getssize(argv, 1);
     size_t n = 1;
     if (at < 0) {
         at = array->count + at;

--- a/src/core/asm.c
+++ b/src/core/asm.c
@@ -282,7 +282,7 @@ static int32_t doarg_1(
         case JANET_TUPLE: {
             const Janet *t = janet_unwrap_tuple(x);
             if (argtype == JANET_OAT_TYPE) {
-                int32_t i = 0;
+                size_t i = 0;
                 ret = 0;
                 for (i = 0; i < janet_tuple_length(t); i++) {
                     ret |= doarg_1(a, JANET_OAT_SIMPLETYPE, t[i]);
@@ -492,7 +492,7 @@ static JanetAssembleResult janet_asm1(JanetAssembler *parent, Janet source, int 
     JanetAssembler a;
     Janet s = source;
     JanetFuncDef *def;
-    int32_t count, i;
+    size_t count, i;
     const Janet *arr;
     Janet x;
     (void) flags;
@@ -578,8 +578,7 @@ static JanetAssembleResult janet_asm1(JanetAssembler *parent, Janet source, int 
             Janet v = arr[i];
             if (janet_checktype(v, JANET_TUPLE)) {
                 const Janet *t = janet_unwrap_tuple(v);
-                int32_t j;
-                for (j = 0; j < janet_tuple_length(t); j++) {
+                for (size_t j = 0; j < janet_tuple_length(t); j++) {
                     if (!janet_checktype(t[j], JANET_SYMBOL))
                         janet_asm_error(&a, "slot names must be symbols");
                     janet_table_put(&a.slots, t[j], janet_wrap_integer(i));
@@ -615,8 +614,7 @@ static JanetAssembleResult janet_asm1(JanetAssembler *parent, Janet source, int 
         x = janet_get1(s, janet_ckeywordv("defs"));
     }
     if (janet_indexed_view(x, &arr, &count)) {
-        int32_t i;
-        for (i = 0; i < count; i++) {
+        for (size_t i = 0; i < count; i++) {
             JanetAssembleResult subres;
             Janet subname;
             int32_t newlen;
@@ -701,7 +699,7 @@ static JanetAssembleResult janet_asm1(JanetAssembler *parent, Janet source, int 
     /* Check for source mapping */
     x = janet_get1(s, janet_ckeywordv("sourcemap"));
     if (janet_indexed_view(x, &arr, &count)) {
-        janet_asm_assert(&a, count == def->bytecode_length, "sourcemap must have the same length as the bytecode");
+        janet_asm_assert(&a, count == (size_t) def->bytecode_length, "sourcemap must have the same length as the bytecode");
         def->sourcemap = janet_malloc(sizeof(JanetSourceMapping) * (size_t) count);
         if (NULL == def->sourcemap) {
             JANET_OUT_OF_MEMORY;
@@ -775,7 +773,7 @@ static JanetAssembleResult janet_asm1(JanetAssembler *parent, Janet source, int 
         if (def->environments_length) {
             def->environments = janet_realloc(def->environments, def->environments_length * sizeof(int32_t));
         }
-        for (int32_t i = 0; i < count; i++) {
+        for (size_t i = 0; i < count; i++) {
             if (!janet_checkint(arr[i])) {
                 janet_asm_error(&a, "expected integer");
             }

--- a/src/core/asm.c
+++ b/src/core/asm.c
@@ -595,7 +595,7 @@ static JanetAssembleResult janet_asm1(JanetAssembler *parent, Janet source, int 
     x = janet_get1(s, janet_ckeywordv("constants"));
     if (janet_indexed_view(x, &arr, &count)) {
         def->constants_length = count;
-        def->constants = janet_malloc(sizeof(Janet) * (size_t) count);
+        def->constants = janet_malloc(sizeof(Janet) * count);
         if (NULL == def->constants) {
             JANET_OUT_OF_MEMORY;
         }

--- a/src/core/buffer.c
+++ b/src/core/buffer.c
@@ -314,7 +314,7 @@ JANET_CORE_FN(cfun_buffer_chars,
     return argv[0];
 }
 
-static int should_reverse_bytes(const Janet *argv, size_t argc) {
+static int should_reverse_bytes(const Janet *argv, int32_t argc) {
     JanetKeyword order_kw = janet_getkeyword(argv, argc);
     if (!janet_cstrcmp(order_kw, "le")) {
 #if JANET_BIG_ENDIAN

--- a/src/core/buffer.c
+++ b/src/core/buffer.c
@@ -226,9 +226,8 @@ JANET_CORE_FN(cfun_buffer_frombytes,
               "(buffer/from-bytes & byte-vals)",
               "Creates a buffer from integer parameters with byte values. All integers "
               "will be coerced to the range of 1 byte 0-255.") {
-    size_t i;
     JanetBuffer *buffer = janet_buffer(argc);
-    for (i = 0; i < argc; i++) {
+    for (int32_t i = 0; i < argc; i++) {
         size_t c = janet_getsize(argv, i);
         buffer->data[i] = c & 0xFF;
     }
@@ -275,10 +274,9 @@ JANET_CORE_FN(cfun_buffer_u8,
               "(buffer/push-byte buffer & xs)",
               "Append bytes to a buffer. Will expand the buffer as necessary. "
               "Returns the modified buffer. Will throw an error if the buffer overflows.") {
-    size_t i;
     janet_arity(argc, 1, -1);
     JanetBuffer *buffer = janet_getbuffer(argv, 0);
-    for (i = 1; i < argc; i++) {
+    for (int32_t i = 1; i < argc; i++) {
         janet_buffer_push_u8(buffer, (uint8_t)(janet_getinteger(argv, i) & 0xFF));
     }
     return argv[0];
@@ -289,10 +287,9 @@ JANET_CORE_FN(cfun_buffer_word,
               "Append machine words to a buffer. The 4 bytes of the integer are appended "
               "in twos complement, little endian order, unsigned for all x. Returns the modified buffer. Will "
               "throw an error if the buffer overflows.") {
-    size_t i;
     janet_arity(argc, 1, -1);
     JanetBuffer *buffer = janet_getbuffer(argv, 0);
-    for (i = 1; i < argc; i++) {
+    for (int32_t i = 1; i < argc; i++) {
         double number = janet_getnumber(argv, i);
         uint32_t word = (uint32_t) number;
         if (word != number)
@@ -308,10 +305,9 @@ JANET_CORE_FN(cfun_buffer_chars,
               "Will accept any of strings, keywords, symbols, and buffers. "
               "Returns the modified buffer. "
               "Will throw an error if the buffer overflows.") {
-    size_t i;
     janet_arity(argc, 1, -1);
     JanetBuffer *buffer = janet_getbuffer(argv, 0);
-    for (i = 1; i < argc; i++) {
+    for (int32_t i = 1; i < argc; i++) {
         JanetByteView view = janet_getbytes(argv, i);
         if (view.bytes == buffer->data) {
             janet_buffer_ensure(buffer, buffer->count + view.len, 2);
@@ -553,7 +549,7 @@ static void bitloc(int32_t argc, Janet *argv, JanetBuffer **b, size_t *index, in
     int64_t bitindex = (int64_t) x;
     int64_t byteindex = bitindex >> 3;
     int which_bit = bitindex & 7;
-    if (bitindex != x || bitindex < 0 || byteindex >= buffer->count)
+    if (bitindex != x || bitindex < 0 || (size_t) byteindex >= buffer->count)
         janet_panicf("invalid bit index %v", argv[1]);
     *b = buffer;
     *index = (size_t) byteindex;

--- a/src/core/buffer.c
+++ b/src/core/buffer.c
@@ -90,8 +90,8 @@ void janet_buffer_ensure(JanetBuffer *buffer, size_t capacity, size_t growth) {
     uint8_t *old = buffer->data;
     if (capacity <= buffer->capacity) return;
     janet_buffer_can_realloc(buffer);
-    size_t big_capacity = (capacity) * growth;
-    capacity = big_capacity > JANET_INTMAX_SIZE ? JANET_INTMAX_SIZE : big_capacity;
+    uint64_t big_capacity = (uint64_t) capacity*growth;
+    capacity = big_capacity > JANET_INTMAX_SIZE ? JANET_INTMAX_SIZE : (size_t) big_capacity;
     janet_gcpressure(capacity - buffer->capacity);
     new_data = janet_realloc(old, capacity * sizeof(uint8_t));
     if (NULL == new_data) {
@@ -115,7 +115,7 @@ void janet_buffer_setcount(JanetBuffer *buffer, size_t count) {
  * next n bytes pushed to the buffer will not cause a reallocation */
 void janet_buffer_extra(JanetBuffer *buffer, size_t n) {
     /* Check for buffer overflow */
-    if (n + buffer->count > JANET_INTMAX_SIZE) {
+    if ((int64_t)n + buffer->count > JANET_INTMAX_SIZE) {
         janet_panic("buffer overflow");
     }
     size_t new_size = buffer->count + n;

--- a/src/core/buffer.c
+++ b/src/core/buffer.c
@@ -39,8 +39,8 @@ static void janet_buffer_can_realloc(JanetBuffer *buffer) {
 static JanetBuffer *janet_buffer_init_impl(JanetBuffer *buffer, size_t capacity) {
     uint8_t *data = NULL;
     if (capacity < 4) capacity = 4;
-    if (capacity > JANET_INTMAX_INT64)
-      capacity = JANET_INTMAX_INT64;
+    if (capacity > JANET_INTMAX_SIZE)
+      capacity = JANET_INTMAX_SIZE;
     janet_gcpressure(capacity);
     data = janet_malloc(sizeof(uint8_t) * capacity);
     if (NULL == data) {
@@ -91,7 +91,7 @@ void janet_buffer_ensure(JanetBuffer *buffer, size_t capacity, size_t growth) {
     if (capacity <= buffer->capacity) return;
     janet_buffer_can_realloc(buffer);
     size_t big_capacity = (capacity) * growth;
-    capacity = big_capacity > JANET_INTMAX_INT64 ? JANET_INTMAX_INT64 : big_capacity;
+    capacity = big_capacity > JANET_INTMAX_SIZE ? JANET_INTMAX_SIZE : big_capacity;
     janet_gcpressure(capacity - buffer->capacity);
     new_data = janet_realloc(old, capacity * sizeof(uint8_t));
     if (NULL == new_data) {
@@ -115,13 +115,13 @@ void janet_buffer_setcount(JanetBuffer *buffer, size_t count) {
  * next n bytes pushed to the buffer will not cause a reallocation */
 void janet_buffer_extra(JanetBuffer *buffer, size_t n) {
     /* Check for buffer overflow */
-    if (n + buffer->count > JANET_INTMAX_INT64) {
+    if (n + buffer->count > JANET_INTMAX_SIZE) {
         janet_panic("buffer overflow");
     }
     size_t new_size = buffer->count + n;
     if (new_size > buffer->capacity) {
         janet_buffer_can_realloc(buffer);
-        size_t new_capacity = (new_size > (JANET_INTMAX_INT64 / 2)) ? JANET_INTMAX_INT64 : (new_size * 2);
+        size_t new_capacity = (new_size > (JANET_INTMAX_SIZE / 2)) ? JANET_INTMAX_SIZE : (new_size * 2);
         uint8_t *new_data = janet_realloc(buffer->data, new_capacity * sizeof(uint8_t));
         janet_gcpressure(new_capacity - buffer->capacity);
         if (NULL == new_data) {
@@ -618,8 +618,8 @@ JANET_CORE_FN(cfun_buffer_blit,
     } else {
         length_src = src.len - offset_src;
     }
-    int64_t last = (int64_t) offset_dest + length_src;
-    if (last > JANET_INTMAX_INT64)
+    size_t last = offset_dest + length_src;
+    if (last > JANET_INTMAX_SIZE)
         janet_panic("buffer blit out of range");
     size_t last32 = (size_t) last;
     janet_buffer_ensure(dest, last32, 2);

--- a/src/core/buffer.c
+++ b/src/core/buffer.c
@@ -62,7 +62,6 @@ JanetBuffer *janet_buffer_init(JanetBuffer *buffer, size_t capacity) {
 
 /* Initialize an unmanaged buffer */
 JanetBuffer *janet_pointer_buffer_unsafe(void *memory, size_t capacity, size_t count) {
-    if (count < 0) janet_panic("count < 0");
     if (capacity < count) janet_panic("capacity < count");
     JanetBuffer *buffer = janet_gcalloc(JANET_MEMORY_BUFFER, sizeof(JanetBuffer));
     buffer->gc.flags |= JANET_BUFFER_FLAG_NO_REALLOC;
@@ -104,8 +103,6 @@ void janet_buffer_ensure(JanetBuffer *buffer, size_t capacity, size_t growth) {
 
 /* Ensure that the buffer has enough internal capacity */
 void janet_buffer_setcount(JanetBuffer *buffer, size_t count) {
-    if (count < 0)
-        return;
     if (count > buffer->count) {
         size_t oldcount = buffer->count;
         janet_buffer_ensure(buffer, count, 1);
@@ -210,7 +207,6 @@ JANET_CORE_FN(cfun_buffer_new_filled,
               "Returns the new buffer.") {
     janet_arity(argc, 1, 2);
     size_t count = janet_getsize(argv, 0);
-    if (count < 0) count = 0;
     int32_t byte = 0;
     if (argc == 2) {
         byte = janet_getinteger(argv, 1) & 0xFF;
@@ -478,7 +474,7 @@ JANET_CORE_FN(cfun_buffer_push_at,
     JanetBuffer *buffer = janet_getbuffer(argv, 0);
     size_t index = janet_getsize(argv, 1);
     size_t old_count = buffer->count;
-    if (index < 0 || index > old_count) {
+    if (index > old_count) {
         janet_panicf("index out of range [0, %d)", old_count);
     }
     buffer->count = index;
@@ -518,7 +514,6 @@ JANET_CORE_FN(cfun_buffer_popn,
     janet_fixarity(argc, 2);
     JanetBuffer *buffer = janet_getbuffer(argv, 0);
     size_t n = janet_getsize(argv, 1);
-    if (n < 0) janet_panic("n must be non-negative");
     if (buffer->count < n) {
         buffer->count = 0;
     } else {
@@ -620,7 +615,6 @@ JANET_CORE_FN(cfun_buffer_blit,
         if (!janet_checktype(argv[4], JANET_NIL))
             src_end = janet_gethalfrange(argv, 4, src.len, "src-end");
         length_src = src_end - offset_src;
-        if (length_src < 0) length_src = 0;
     } else {
         length_src = src.len - offset_src;
     }

--- a/src/core/capi.c
+++ b/src/core/capi.c
@@ -340,6 +340,14 @@ size_t janet_getsize(const Janet *argv, int32_t n) {
     return (size_t) janet_unwrap_number(x);
 }
 
+ssize_t janet_getssize(const Janet *argv, int32_t n) {
+    Janet x = argv[n];
+    if (!janet_checkssize(x)) {
+        janet_panicf("bad slot #%d, expected ssize, got %v", n, x);
+    }
+    return (ssize_t) janet_unwrap_number(x);
+}
+
 int32_t janet_gethalfrange(const Janet *argv, int32_t n, int32_t length, const char *which) {
     int32_t raw = janet_getinteger(argv, n);
     int32_t not_raw = raw;
@@ -490,6 +498,12 @@ size_t janet_optsize(const Janet *argv, int32_t argc, int32_t n, size_t dflt) {
     if (argc <= n) return dflt;
     if (janet_checktype(argv[n], JANET_NIL)) return dflt;
     return janet_getsize(argv, n);
+}
+
+ssize_t janet_optssize(const Janet *argv, int32_t argc, int32_t n, ssize_t dflt) {
+    if (argc <= n) return dflt;
+    if (janet_checktype(argv[n], JANET_NIL)) return dflt;
+    return janet_getssize(argv, n);
 }
 
 void *janet_optabstract(const Janet *argv, int32_t argc, int32_t n, const JanetAbstractType *at, void *dflt) {

--- a/src/core/capi.c
+++ b/src/core/capi.c
@@ -232,19 +232,19 @@ const char *janet_getcbytes(const Janet *argv, int32_t n) {
             char *new_string = janet_smalloc(b->count + 1);
             memcpy(new_string, b->data, b->count);
             new_string[b->count] = 0;
-            if (strlen(new_string) != (size_t) b->count) goto badzeros;
+            if (strlen(new_string) != b->count) goto badzeros;
             return new_string;
         } else {
             /* Ensure trailing 0 */
             janet_buffer_push_u8(b, 0);
             b->count--;
-            if (strlen((char *)b->data) != (size_t) b->count) goto badzeros;
+            if (strlen((char *)b->data) != b->count) goto badzeros;
             return (const char *) b->data;
         }
     }
     JanetByteView view = janet_getbytes(argv, n);
     const char *cstr = (const char *)view.bytes;
-    if (strlen(cstr) != (size_t) view.len) goto badzeros;
+    if (strlen(cstr) != view.len) goto badzeros;
     return cstr;
 
 badzeros:
@@ -337,7 +337,7 @@ size_t janet_getsize(const Janet *argv, int32_t n) {
     if (!janet_checksize(x)) {
         janet_panicf("bad slot #%d, expected size, got %v", n, x);
     }
-    return (size_t) janet_unwrap_number(x);
+    return janet_unwrap_size(x);
 }
 
 ssize_t janet_getssize(const Janet *argv, int32_t n) {
@@ -345,7 +345,7 @@ ssize_t janet_getssize(const Janet *argv, int32_t n) {
     if (!janet_checkssize(x)) {
         janet_panicf("bad slot #%d, expected ssize, got %v", n, x);
     }
-    return (ssize_t) janet_unwrap_number(x);
+    return janet_unwrap_ssize(x);
 }
 
 int32_t janet_gethalfrange(const Janet *argv, int32_t n, int32_t length, const char *which) {

--- a/src/core/capi.c
+++ b/src/core/capi.c
@@ -353,7 +353,7 @@ size_t janet_gethalfrange(const Janet *argv, int32_t n, size_t length, const cha
     ssize_t not_raw = raw;
     if (not_raw < 0) not_raw += length + 1;
     if (not_raw < 0 || (size_t) not_raw > length)
-        janet_panicf("%s index %d out of range [%o,%o]", which, (int64_t) raw, -(uint64_t)length - 1, (uint64_t) length);
+        janet_panicf("%s index %d out of range [%d,%d]", which, (int64_t) raw, -(int64_t)length - 1, (int64_t) length);
     return (size_t) not_raw;
 }
 
@@ -376,7 +376,7 @@ size_t janet_getargindex(const Janet *argv, int32_t n, size_t length, const char
     ssize_t not_raw = raw;
     if (not_raw < 0) not_raw += length;
     if (not_raw < 0 || (size_t) not_raw > length)
-        janet_panicf("%s index %d out of range [%o,%o)", which, (int64_t)raw, -(uint64_t)length, (uint64_t)length);
+        janet_panicf("%s index %d out of range [%d,%d)", which, (int64_t)raw, -(int64_t)length, (int64_t)length);
     return (size_t) not_raw;
 }
 
@@ -457,13 +457,13 @@ void janet_setdyn(const char *name, Janet value) {
 uint64_t janet_getflags(const Janet *argv, int32_t n, const char *flags) {
     uint64_t ret = 0;
     const uint8_t *keyw = janet_getkeyword(argv, n);
-    int32_t klen = janet_string_length(keyw);
-    int32_t flen = (int32_t) strlen(flags);
+    size_t klen = janet_string_length(keyw);
+    size_t flen = strlen(flags);
     if (flen > 64) {
         flen = 64;
     }
-    for (int32_t j = 0; j < klen; j++) {
-        for (int32_t i = 0; i < flen; i++) {
+    for (size_t j = 0; j < klen; j++) {
+        for (size_t i = 0; i < flen; i++) {
             if (((uint8_t) flags[i]) == keyw[j]) {
                 ret |= 1ULL << i;
                 goto found;

--- a/src/core/capi.c
+++ b/src/core/capi.c
@@ -138,7 +138,7 @@ type janet_opt##name(const Janet *argv, int32_t argc, int32_t n, type dflt) { \
 }
 
 #define DEFINE_OPTLEN(name, NAME, type) \
-type janet_opt##name(const Janet *argv, int32_t argc, int32_t n, int32_t dflt_len) { \
+type janet_opt##name(const Janet *argv, int32_t argc, int32_t n, size_t dflt_len) { \
     if (n >= argc || janet_checktype(argv[n], JANET_NIL)) {\
         return janet_##name(dflt_len); \
     }\

--- a/src/core/capi.c
+++ b/src/core/capi.c
@@ -348,36 +348,36 @@ ssize_t janet_getssize(const Janet *argv, int32_t n) {
     return janet_unwrap_ssize(x);
 }
 
-int32_t janet_gethalfrange(const Janet *argv, int32_t n, int32_t length, const char *which) {
-    int32_t raw = janet_getinteger(argv, n);
-    int32_t not_raw = raw;
+size_t janet_gethalfrange(const Janet *argv, int32_t n, size_t length, const char *which) {
+    ssize_t raw = janet_getssize(argv, n);
+    ssize_t not_raw = raw;
     if (not_raw < 0) not_raw += length + 1;
-    if (not_raw < 0 || not_raw > length)
-        janet_panicf("%s index %d out of range [%d,%d]", which, (int64_t) raw, -(int64_t)length - 1, (int64_t) length);
-    return not_raw;
+    if (not_raw < 0 || (size_t) not_raw > length)
+        janet_panicf("%s index %d out of range [%o,%o]", which, (int64_t) raw, -(uint64_t)length - 1, (uint64_t) length);
+    return (size_t) not_raw;
 }
 
-int32_t janet_getstartrange(const Janet *argv, int32_t argc, int32_t n, int32_t length) {
+size_t janet_getstartrange(const Janet *argv, int32_t argc, int32_t n, size_t length) {
     if (n >= argc || janet_checktype(argv[n], JANET_NIL)) {
         return 0;
     }
     return janet_gethalfrange(argv, n, length, "start");
 }
 
-int32_t janet_getendrange(const Janet *argv, int32_t argc, int32_t n, int32_t length) {
+size_t janet_getendrange(const Janet *argv, int32_t argc, int32_t n, size_t length) {
     if (n >= argc || janet_checktype(argv[n], JANET_NIL)) {
         return length;
     }
     return janet_gethalfrange(argv, n, length, "end");
 }
 
-int32_t janet_getargindex(const Janet *argv, int32_t n, int32_t length, const char *which) {
-    int32_t raw = janet_getinteger(argv, n);
-    int32_t not_raw = raw;
+size_t janet_getargindex(const Janet *argv, int32_t n, size_t length, const char *which) {
+    ssize_t raw = janet_getssize(argv, n);
+    ssize_t not_raw = raw;
     if (not_raw < 0) not_raw += length;
-    if (not_raw < 0 || not_raw > length)
-        janet_panicf("%s index %d out of range [%d,%d)", which, (int64_t)raw, -(int64_t)length, (int64_t)length);
-    return not_raw;
+    if (not_raw < 0 || (size_t) not_raw > length)
+        janet_panicf("%s index %d out of range [%o,%o)", which, (int64_t)raw, -(uint64_t)length, (uint64_t)length);
+    return (size_t) not_raw;
 }
 
 JanetView janet_getindexed(const Janet *argv, int32_t n) {
@@ -422,7 +422,7 @@ void *janet_getabstract(const Janet *argv, int32_t n, const JanetAbstractType *a
 JanetRange janet_getslice(int32_t argc, const Janet *argv) {
     janet_arity(argc, 1, 3);
     JanetRange range;
-    int32_t length = janet_length(argv[0]);
+    size_t length = janet_length(argv[0]);
     range.start = janet_getstartrange(argv, argc, 1, length);
     range.end = janet_getendrange(argv, argc, 2, length);
     if (range.end < range.start)

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -418,12 +418,11 @@ JanetSlot janetc_gettarget(JanetFopts opts) {
 }
 
 /* Get a bunch of slots for function arguments */
-JanetSlot *janetc_toslots(JanetCompiler *c, const Janet *vals, int32_t len) {
-    int32_t i;
+JanetSlot *janetc_toslots(JanetCompiler *c, const Janet *vals, size_t len) {
     JanetSlot *ret = NULL;
     JanetFopts subopts = janetc_fopts_default(c);
     subopts.flags |= JANET_FOPTS_ACCEPT_SPLICE;
-    for (i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         janet_v_push(ret, janetc_value(subopts, vals[i]));
     }
     return ret;

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -435,9 +435,9 @@ JanetSlot *janetc_toslotskv(JanetCompiler *c, Janet ds) {
     JanetFopts subopts = janetc_fopts_default(c);
     subopts.flags |= JANET_FOPTS_ACCEPT_SPLICE;
     const JanetKV *kvs = NULL;
-    int32_t cap = 0, len = 0;
+    size_t cap = 0, len = 0;
     janet_dictionary_view(ds, &kvs, &len, &cap);
-    for (int32_t i = 0; i < cap; i++) {
+    for (size_t i = 0; i < cap; i++) {
         if (janet_checktype(kvs[i].key, JANET_NIL)) continue;
         janet_v_push(ret, janetc_value(subopts, kvs[i].key));
         janet_v_push(ret, janetc_value(subopts, kvs[i].value));

--- a/src/core/compile.h
+++ b/src/core/compile.h
@@ -232,7 +232,7 @@ void janetc_throwaway(JanetFopts opts, Janet x);
 JanetSlot janetc_gettarget(JanetFopts opts);
 
 /* Get a bunch of slots for function arguments */
-JanetSlot *janetc_toslots(JanetCompiler *c, const Janet *vals, int32_t len);
+JanetSlot *janetc_toslots(JanetCompiler *c, const Janet *vals, size_t len);
 
 /* Get a bunch of slots for function arguments */
 JanetSlot *janetc_toslotskv(JanetCompiler *c, Janet ds);

--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -718,12 +718,12 @@ JANET_CORE_FN(janet_core_memcmp,
     janet_arity(argc, 2, 5);
     JanetByteView a = janet_getbytes(argv, 0);
     JanetByteView b = janet_getbytes(argv, 1);
-    int32_t len = janet_optnat(argv, argc, 2, a.len < b.len ? a.len : b.len);
-    int32_t offset_a = janet_optnat(argv, argc, 3, 0);
-    int32_t offset_b = janet_optnat(argv, argc, 4, 0);
+    size_t len = janet_optsize(argv, argc, 2, a.len < b.len ? a.len : b.len);
+    size_t offset_a = janet_optsize(argv, argc, 3, 0);
+    size_t offset_b = janet_optsize(argv, argc, 4, 0);
     if (offset_a + len > a.len) janet_panicf("invalid offset-a: %d", offset_a);
     if (offset_b + len > b.len) janet_panicf("invalid offset-b: %d", offset_b);
-    return janet_wrap_integer(memcmp(a.bytes + offset_a, b.bytes + offset_b, (size_t) len));
+    return janet_wrap_integer(memcmp(a.bytes + offset_a, b.bytes + offset_b, len));
 }
 
 typedef struct SandboxOption {
@@ -1339,7 +1339,7 @@ JanetTable *janet_core_env(JanetTable *replacements) {
     janet_resolve(env, janet_csymbol("make-image-dict"), &midv);
     JanetTable *lid = janet_unwrap_table(lidv);
     JanetTable *mid = janet_unwrap_table(midv);
-    for (int32_t i = 0; i < lid->capacity; i++) {
+    for (size_t i = 0; i < lid->capacity; i++) {
         const JanetKV *kv = lid->data + i;
         if (!janet_checktype(kv->key, JANET_NIL)) {
             janet_table_put(mid, kv->value, kv->key);
@@ -1357,7 +1357,7 @@ JanetTable *janet_core_lookup_table(JanetTable *replacements) {
 
     /* Add replacements */
     if (replacements != NULL) {
-        for (int32_t i = 0; i < replacements->capacity; i++) {
+        for (size_t i = 0; i < replacements->capacity; i++) {
             JanetKV kv = replacements->data[i];
             if (!janet_checktype(kv.key, JANET_NIL)) {
                 janet_table_put(dict, kv.key, kv.value);

--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -92,7 +92,7 @@ static const char *janet_dyncstring(const char *name, const char *dflt) {
     }
     const uint8_t *jstr = janet_unwrap_string(x);
     const char *cstr = (const char *)jstr;
-    if (strlen(cstr) != (size_t) janet_string_length(jstr)) {
+    if (strlen(cstr) != janet_string_length(jstr)) {
         janet_panicf("string %v contains embedded 0s", x);
     }
     return cstr;

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1246,9 +1246,9 @@ static void janet_chanat_marshal(void *p, JanetMarshalContext *ctx) {
     janet_marshal_byte(ctx, channel->is_threaded);
     janet_marshal_abstract(ctx, channel);
     janet_marshal_byte(ctx, channel->closed);
-    janet_marshal_int(ctx, channel->limit);
-    int32_t count = janet_q_count(&channel->items);
-    janet_marshal_int(ctx, count);
+    janet_marshal_size(ctx, channel->limit);
+    size_t count = janet_q_count(&channel->items);
+    janet_marshal_size(ctx, count);
     JanetQueue *items = &channel->items;
     Janet *data = channel->items.data;
     if (items->head <= items->tail) {
@@ -2475,7 +2475,7 @@ void ev_callback_write(JanetFiber *fiber, JanetAsyncEvent event) {
         break;
         case JANET_ASYNC_EVENT_INIT: {
             /* Begin write */
-            int32_t len;
+            size_t len;
             const uint8_t *bytes;
             if (state->is_buffer) {
                 /* If buffer, convert to string. */

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -1011,7 +1011,7 @@ JANET_CORE_FN(cfun_channel_pop,
 
 static void chan_unlock_args(const Janet *argv, int32_t n) {
     for (int32_t i = 0; i < n; i++) {
-        int32_t len;
+        size_t len;
         const Janet *data;
         JanetChannel *chan;
         if (janet_indexed_view(argv[i], &data, &len) && len == 2) {
@@ -1036,7 +1036,7 @@ JANET_CORE_FN(cfun_channel_choice,
               "channel was closed while waiting, or that the channel was already "
               "closed.") {
     janet_arity(argc, 1, -1);
-    int32_t len;
+    size_t len;
     const Janet *data;
 
     /* Check channels for immediate reads and writes */
@@ -3185,7 +3185,7 @@ JANET_CORE_FN(janet_cfun_ev_all_tasks,
     janet_fixarity(argc, 0);
     (void) argv;
     JanetArray *array = janet_array(janet_vm.active_tasks.count);
-    for (int32_t i = 0; i < janet_vm.active_tasks.capacity; i++) {
+    for (size_t i = 0; i < janet_vm.active_tasks.capacity; i++) {
         if (!janet_checktype(janet_vm.active_tasks.data[i].key, JANET_NIL)) {
             janet_array_push(array, janet_vm.active_tasks.data[i].key);
         }

--- a/src/core/ffi.c
+++ b/src/core/ffi.c
@@ -432,7 +432,7 @@ static JanetFFIType decode_ffi_type(Janet x) {
         ret.st = janet_unwrap_abstract(x);
         return ret;
     }
-    int32_t len;
+    size_t len;
     const Janet *els;
     if (janet_indexed_view(x, &els, &len)) {
         if (janet_checktype(x, JANET_ARRAY)) {

--- a/src/core/fiber.c
+++ b/src/core/fiber.c
@@ -54,8 +54,8 @@ static JanetFiber *fiber_alloc(size_t capacity) {
     if (capacity < 32) {
         capacity = 32;
     }
-    if (capacity > JANET_INTMAX_INT64) {
-        capacity = JANET_INTMAX_INT64;
+    if (capacity > JANET_INTMAX_SIZE) {
+        capacity = JANET_INTMAX_SIZE;
     }
     fiber->capacity = capacity;
     data = janet_malloc(sizeof(Janet) * capacity);
@@ -131,7 +131,7 @@ void janet_fiber_setcapacity(JanetFiber *fiber, size_t n) {
 
 /* Grow fiber if needed */
 static void janet_fiber_grow(JanetFiber *fiber, size_t needed) {
-    size_t cap = needed > (JANET_INTMAX_INT64 / 2) ? JANET_INTMAX_INT64 : 2 * needed;
+    size_t cap = needed > (JANET_INTMAX_SIZE / 2) ? JANET_INTMAX_SIZE : 2 * needed;
     janet_fiber_setcapacity(fiber, cap);
 }
 
@@ -171,7 +171,7 @@ void janet_fiber_push3(JanetFiber *fiber, Janet x, Janet y, Janet z) {
 
 /* Push an array on the next stack frame */
 void janet_fiber_pushn(JanetFiber *fiber, const Janet *arr, int32_t n) {
-    if (fiber->stacktop > (size_t) INT32_MAX - n) janet_panic("stack overflow");
+    if (fiber->stacktop > (size_t) JANET_INTMAX_SIZE - n) janet_panic("stack overflow");
     size_t newtop = fiber->stacktop + n;
     if (newtop > fiber->capacity) {
         janet_fiber_grow(fiber, newtop);

--- a/src/core/fiber.c
+++ b/src/core/fiber.c
@@ -137,7 +137,7 @@ static void janet_fiber_grow(JanetFiber *fiber, size_t needed) {
 
 /* Push a value on the next stack frame */
 void janet_fiber_push(JanetFiber *fiber, Janet x) {
-    if (fiber->stacktop == INT32_MAX) janet_panic("stack overflow");
+    if (fiber->stacktop == JANET_INTMAX_SIZE) janet_panic("stack overflow");
     if (fiber->stacktop >= fiber->capacity) {
         janet_fiber_grow(fiber, fiber->stacktop);
     }
@@ -146,7 +146,7 @@ void janet_fiber_push(JanetFiber *fiber, Janet x) {
 
 /* Push 2 values on the next stack frame */
 void janet_fiber_push2(JanetFiber *fiber, Janet x, Janet y) {
-    if (fiber->stacktop >= INT32_MAX - 1) janet_panic("stack overflow");
+    if (fiber->stacktop >= JANET_INTMAX_SIZE - 1) janet_panic("stack overflow");
     size_t newtop = fiber->stacktop + 2;
     if (newtop > fiber->capacity) {
         janet_fiber_grow(fiber, newtop);
@@ -158,7 +158,7 @@ void janet_fiber_push2(JanetFiber *fiber, Janet x, Janet y) {
 
 /* Push 3 values on the next stack frame */
 void janet_fiber_push3(JanetFiber *fiber, Janet x, Janet y, Janet z) {
-    if (fiber->stacktop >= INT32_MAX - 2) janet_panic("stack overflow");
+    if (fiber->stacktop >= JANET_INTMAX_SIZE - 2) janet_panic("stack overflow");
     size_t newtop = fiber->stacktop + 3;
     if (newtop > fiber->capacity) {
         janet_fiber_grow(fiber, newtop);
@@ -170,8 +170,8 @@ void janet_fiber_push3(JanetFiber *fiber, Janet x, Janet y, Janet z) {
 }
 
 /* Push an array on the next stack frame */
-void janet_fiber_pushn(JanetFiber *fiber, const Janet *arr, int32_t n) {
-    if (fiber->stacktop > (size_t) JANET_INTMAX_SIZE - n) janet_panic("stack overflow");
+void janet_fiber_pushn(JanetFiber *fiber, const Janet *arr, size_t n) {
+    if (fiber->stacktop > JANET_INTMAX_SIZE - n) janet_panic("stack overflow");
     size_t newtop = fiber->stacktop + n;
     if (newtop > fiber->capacity) {
         janet_fiber_grow(fiber, newtop);

--- a/src/core/fiber.h
+++ b/src/core/fiber.h
@@ -70,11 +70,11 @@
 
 #define janet_stack_frame(s) ((JanetStackFrame *)((s) - JANET_FRAME_SIZE))
 #define janet_fiber_frame(f) janet_stack_frame((f)->data + (f)->frame)
-void janet_fiber_setcapacity(JanetFiber *fiber, size_t n);
+void janet_fiber_setcapacity(JanetFiber *fiber, int32_t n);
 void janet_fiber_push(JanetFiber *fiber, Janet x);
 void janet_fiber_push2(JanetFiber *fiber, Janet x, Janet y);
 void janet_fiber_push3(JanetFiber *fiber, Janet x, Janet y, Janet z);
-void janet_fiber_pushn(JanetFiber *fiber, const Janet *arr, size_t n);
+void janet_fiber_pushn(JanetFiber *fiber, const Janet *arr, int32_t n);
 int janet_fiber_funcframe(JanetFiber *fiber, JanetFunction *func);
 int janet_fiber_funcframe_tail(JanetFiber *fiber, JanetFunction *func);
 void janet_fiber_cframe(JanetFiber *fiber, JanetCFunction cfun);

--- a/src/core/fiber.h
+++ b/src/core/fiber.h
@@ -74,7 +74,7 @@ void janet_fiber_setcapacity(JanetFiber *fiber, size_t n);
 void janet_fiber_push(JanetFiber *fiber, Janet x);
 void janet_fiber_push2(JanetFiber *fiber, Janet x, Janet y);
 void janet_fiber_push3(JanetFiber *fiber, Janet x, Janet y, Janet z);
-void janet_fiber_pushn(JanetFiber *fiber, const Janet *arr, int32_t n);
+void janet_fiber_pushn(JanetFiber *fiber, const Janet *arr, size_t n);
 int janet_fiber_funcframe(JanetFiber *fiber, JanetFunction *func);
 int janet_fiber_funcframe_tail(JanetFiber *fiber, JanetFunction *func);
 void janet_fiber_cframe(JanetFiber *fiber, JanetCFunction cfun);

--- a/src/core/fiber.h
+++ b/src/core/fiber.h
@@ -70,7 +70,7 @@
 
 #define janet_stack_frame(s) ((JanetStackFrame *)((s) - JANET_FRAME_SIZE))
 #define janet_fiber_frame(f) janet_stack_frame((f)->data + (f)->frame)
-void janet_fiber_setcapacity(JanetFiber *fiber, int32_t n);
+void janet_fiber_setcapacity(JanetFiber *fiber, size_t n);
 void janet_fiber_push(JanetFiber *fiber, Janet x);
 void janet_fiber_push2(JanetFiber *fiber, Janet x, Janet y);
 void janet_fiber_push3(JanetFiber *fiber, Janet x, Janet y, Janet z);

--- a/src/core/gc.c
+++ b/src/core/gc.c
@@ -481,7 +481,7 @@ void janet_sweep() {
 #ifdef JANET_EV
     /* Sweep threaded abstract types for references to decrement */
     JanetKV *items = janet_vm.threaded_abstracts.data;
-    for (int32_t i = 0; i < janet_vm.threaded_abstracts.capacity; i++) {
+    for (size_t i = 0; i < janet_vm.threaded_abstracts.capacity; i++) {
         if (janet_checktype(items[i].key, JANET_ABSTRACT)) {
 
             /* If item was not visited during the mark phase, then this
@@ -665,7 +665,7 @@ int janet_gcunrootall(Janet root) {
 void janet_clear_memory(void) {
 #ifdef JANET_EV
     JanetKV *items = janet_vm.threaded_abstracts.data;
-    for (int32_t i = 0; i < janet_vm.threaded_abstracts.capacity; i++) {
+    for (size_t i = 0; i < janet_vm.threaded_abstracts.capacity; i++) {
         if (janet_checktype(items[i].key, JANET_ABSTRACT)) {
             void *abst = janet_unwrap_abstract(items[i].key);
             if (0 == janet_abstract_decref(abst)) {

--- a/src/core/gc.c
+++ b/src/core/gc.c
@@ -122,7 +122,7 @@ static void janet_mark_abstract(void *adata) {
 }
 
 /* Mark a bunch of items in memory */
-static void janet_mark_many(const Janet *values, int32_t n) {
+static void janet_mark_many(const Janet *values, size_t n) {
     if (values == NULL)
         return;
     const Janet *end = values + n;
@@ -262,7 +262,7 @@ static void janet_mark_function(JanetFunction *func) {
 }
 
 static void janet_mark_fiber(JanetFiber *fiber) {
-    int32_t i, j;
+    size_t i, j;
     JanetStackFrame *frame;
 recur:
     if (janet_gc_reachable(fiber))

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -59,8 +59,7 @@ const JanetAbstractType janet_file_type = {
 /* Check arguments to fopen */
 static int32_t checkflags(const uint8_t *str) {
     int32_t flags = 0;
-    int32_t i;
-    int32_t len = janet_string_length(str);
+    size_t len = janet_string_length(str);
     if (!len || len > 10)
         janet_panic("file mode must have a length between 1 and 10");
     switch (*str) {
@@ -80,7 +79,7 @@ static int32_t checkflags(const uint8_t *str) {
             janet_sandbox_assert(JANET_SANDBOX_FS_READ);
             break;
     }
-    for (i = 1; i < len; i++) {
+    for (size_t i = 1; i < len; i++) {
         switch (str[i]) {
             default:
                 janet_panicf("invalid flag %c, expected +, b, or n", str[i]);
@@ -489,7 +488,7 @@ static Janet cfun_io_print_impl_x(int32_t argc, Janet *argv, int newline,
         }
     }
     for (int32_t i = offset; i < argc; ++i) {
-        int32_t len;
+        size_t len;
         const uint8_t *vstr;
         if (janet_checktype(argv[i], JANET_BUFFER)) {
             JanetBuffer *b = janet_unwrap_buffer(argv[i]);

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -204,11 +204,11 @@ JANET_CORE_FN(cfun_io_fread,
     } else {
         buffer = janet_getbuffer(argv, 2);
     }
-    int32_t bufstart = buffer->count;
+    size_t bufstart = buffer->count;
     if (janet_checktype(argv[1], JANET_KEYWORD)) {
         const uint8_t *sym = janet_unwrap_keyword(argv[1]);
         if (!janet_cstrcmp(sym, "all")) {
-            int32_t sizeBefore;
+            size_t sizeBefore;
             do {
                 sizeBefore = buffer->count;
                 read_chunk(iof, buffer, 4096);

--- a/src/core/marsh.c
+++ b/src/core/marsh.c
@@ -96,7 +96,7 @@ static Janet entry_getval(Janet env_entry) {
 /* Merge values from an environment into an existing lookup table. */
 void janet_env_lookup_into(JanetTable *renv, JanetTable *env, const char *prefix, int recurse) {
     while (env) {
-        for (int32_t i = 0; i < env->capacity; i++) {
+        for (size_t i = 0; i < env->capacity; i++) {
             if (janet_checktype(env->data[i].key, JANET_SYMBOL)) {
                 if (prefix) {
                     int32_t prelen = (int32_t) strlen(prefix);
@@ -566,12 +566,11 @@ static void marshal_one(MarshalState *st, Janet x, int flags) {
             return;
         }
         case JANET_ARRAY: {
-            int32_t i;
             JanetArray *a = janet_unwrap_array(x);
             MARK_SEEN();
             pushbyte(st, LB_ARRAY);
             pushint(st, a->count);
-            for (i = 0; i < a->count; i++)
+            for (size_t i = 0; i < a->count; i++)
                 marshal_one(st, a->data[i], flags + 1);
             return;
         }
@@ -596,7 +595,7 @@ static void marshal_one(MarshalState *st, Janet x, int flags) {
             pushint(st, t->count);
             if (t->proto)
                 marshal_one(st, janet_wrap_table(t->proto), flags + 1);
-            for (int32_t i = 0; i < t->capacity; i++) {
+            for (size_t i = 0; i < t->capacity; i++) {
                 if (janet_checktype(t->data[i].key, JANET_NIL))
                     continue;
                 marshal_one(st, t->data[i].key, flags + 1);
@@ -612,7 +611,7 @@ static void marshal_one(MarshalState *st, Janet x, int flags) {
             pushint(st, count);
             if (janet_struct_proto(struct_))
                 marshal_one(st, janet_wrap_struct(janet_struct_proto(struct_)), flags + 1);
-            for (int32_t i = 0; i < janet_struct_capacity(struct_); i++) {
+            for (size_t i = 0; i < janet_struct_capacity(struct_); i++) {
                 if (janet_checktype(struct_[i].key, JANET_NIL))
                     continue;
                 marshal_one(st, struct_[i].key, flags + 1);
@@ -1094,7 +1093,7 @@ static const uint8_t *unmarshal_one_fiber(
     if (!fiber->data) {
         JANET_OUT_OF_MEMORY;
     }
-    for (int32_t i = 0; i < fiber->capacity; i++) {
+    for (size_t i = 0; i < fiber->capacity; i++) {
         fiber->data[i] = janet_wrap_nil();
     }
 

--- a/src/core/math.c
+++ b/src/core/math.c
@@ -81,9 +81,9 @@ void janet_rng_seed(JanetRNG *rng, uint32_t seed) {
     for (int i = 0; i < 16; i++) janet_rng_u32(rng);
 }
 
-void janet_rng_longseed(JanetRNG *rng, const uint8_t *bytes, int32_t len) {
+void janet_rng_longseed(JanetRNG *rng, const uint8_t *bytes, size_t len) {
     uint8_t state[16] = {0};
-    for (int32_t i = 0; i < len; i++)
+    for (size_t i = 0; i < len; i++)
         state[i & 0xF] ^= bytes[i];
     rng->a = state[0] + (state[1] << 8) + (state[2] << 16) + (state[3] << 24);
     rng->b = state[4] + (state[5] << 8) + (state[6] << 16) + (state[7] << 24);

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -325,7 +325,7 @@ static EnvBlock os_execute_env(int32_t argc, const Janet *argv) {
     memcpy(ret, temp->data, temp->count);
     return ret;
 #else
-    char **envp = janet_smalloc(sizeof(char *) * ((size_t)dict.len + 1));
+    char **envp = janet_smalloc(sizeof(char *) * (dict.len + 1));
     int32_t j = 0;
     for (size_t i = 0; i < dict.cap; i++) {
         const JanetKV *kv = dict.kvs + i;
@@ -333,18 +333,18 @@ static EnvBlock os_execute_env(int32_t argc, const Janet *argv) {
         if (!janet_checktype(kv->value, JANET_STRING)) continue;
         const uint8_t *keys = janet_unwrap_string(kv->key);
         const uint8_t *vals = janet_unwrap_string(kv->value);
-        int32_t klen = janet_string_length(keys);
-        int32_t vlen = janet_string_length(vals);
+        size_t klen = janet_string_length(keys);
+        size_t vlen = janet_string_length(vals);
         /* Check keys has no embedded 0s or =s. */
         int skip = 0;
-        for (int32_t k = 0; k < klen; k++) {
+        for (size_t k = 0; k < klen; k++) {
             if (keys[k] == '\0' || keys[k] == '=') {
                 skip = 1;
                 break;
             }
         }
         if (skip) continue;
-        char *envitem = janet_smalloc((size_t) klen + (size_t) vlen + 2);
+        char *envitem = janet_smalloc(klen + vlen + 2);
         memcpy(envitem, keys, klen);
         envitem[klen] = '=';
         memcpy(envitem + klen + 1, vals, vlen);
@@ -1246,7 +1246,7 @@ static Janet os_execute_impl(int32_t argc, Janet *argv, JanetExecuteMode mode) {
     /* Result */
     int status = 0;
 
-    const char **child_argv = janet_smalloc(sizeof(char *) * ((size_t) exargs.len + 1));
+    const char **child_argv = janet_smalloc(sizeof(char *) * (exargs.len + 1));
     for (size_t i = 0; i < exargs.len; i++)
         child_argv[i] = janet_getcstring(exargs.items, i);
     child_argv[exargs.len] = NULL;

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -309,7 +309,7 @@ static EnvBlock os_execute_env(int32_t argc, const Janet *argv) {
     JanetDictView dict = janet_getdictionary(argv, 2);
 #ifdef JANET_WINDOWS
     JanetBuffer *temp = janet_buffer(10);
-    for (int32_t i = 0; i < dict.cap; i++) {
+    for (size_t i = 0; i < dict.cap; i++) {
         const JanetKV *kv = dict.kvs + i;
         if (!janet_checktype(kv->key, JANET_STRING)) continue;
         if (!janet_checktype(kv->value, JANET_STRING)) continue;
@@ -380,7 +380,7 @@ static void os_execute_cleanup(EnvBlock envp, const char **child_argv) {
  * a single string of this format. Returns a buffer that can be cast into a c string. */
 static JanetBuffer *os_exec_escape(JanetView args) {
     JanetBuffer *b = janet_buffer(0);
-    for (int32_t i = 0; i < args.len; i++) {
+    for (size_t i = 0; i < args.len; i++) {
         const char *arg = janet_getcstring(args.items, i);
 
         /* Push leading space if not first */

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -327,7 +327,7 @@ static EnvBlock os_execute_env(int32_t argc, const Janet *argv) {
 #else
     char **envp = janet_smalloc(sizeof(char *) * ((size_t)dict.len + 1));
     int32_t j = 0;
-    for (int32_t i = 0; i < dict.cap; i++) {
+    for (size_t i = 0; i < dict.cap; i++) {
         const JanetKV *kv = dict.kvs + i;
         if (!janet_checktype(kv->key, JANET_STRING)) continue;
         if (!janet_checktype(kv->value, JANET_STRING)) continue;
@@ -1247,7 +1247,7 @@ static Janet os_execute_impl(int32_t argc, Janet *argv, JanetExecuteMode mode) {
     int status = 0;
 
     const char **child_argv = janet_smalloc(sizeof(char *) * ((size_t) exargs.len + 1));
-    for (int32_t i = 0; i < exargs.len; i++)
+    for (size_t i = 0; i < exargs.len; i++)
         child_argv[i] = janet_getcstring(exargs.items, i);
     child_argv[exargs.len] = NULL;
     /* Coerce to form that works for spawn. I'm fairly confident no implementation

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1670,9 +1670,8 @@ JANET_CORE_FN(os_cryptorand,
               "Get or append `n` bytes of good quality random data provided by the OS. Returns a new buffer or `buf`.") {
     JanetBuffer *buffer;
     janet_arity(argc, 1, 2);
-    int32_t offset;
-    int32_t n = janet_getinteger(argv, 0);
-    if (n < 0) janet_panic("expected positive integer");
+    size_t offset;
+    size_t n = janet_getsize(argv, 0);
     if (argc == 2) {
         buffer = janet_getbuffer(argv, 1);
         offset = buffer->count;

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -434,8 +434,8 @@ static int stringchar(JanetParser *p, JanetParseState *state, uint8_t c) {
 }
 
 /* Check for string equality in the buffer */
-static int check_str_const(const char *cstr, const uint8_t *str, int32_t len) {
-    int32_t index;
+static int check_str_const(const char *cstr, const uint8_t *str, size_t len) {
+    size_t index;
     for (index = 0; index < len; index++) {
         uint8_t c = str[index];
         uint8_t k = ((const uint8_t *)cstr)[index];
@@ -974,7 +974,7 @@ JANET_CORE_FN(cfun_parse_insert,
         }
     } else if (s->flags & (PFLAG_STRING | PFLAG_LONGSTRING)) {
         const uint8_t *str = janet_to_string(argv[1]);
-        int32_t slen = janet_string_length(str);
+        size_t slen = janet_string_length(str);
         size_t newcount = p->bufcount + slen;
         if (p->bufcap < newcount) {
             size_t newcap = 2 * newcount;

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -921,7 +921,7 @@ JANET_CORE_FN(cfun_parse_consume,
     JanetByteView view = janet_getbytes(argv, 1);
     if (argc == 3) {
         size_t offset = janet_getsize(argv, 2);
-        if (offset < 0 || offset > view.len)
+        if (offset > view.len)
             janet_panicf("invalid offset %d out of range [0,%d]", offset, view.len);
         view.len -= offset;
         view.bytes += offset;

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -920,13 +920,13 @@ JANET_CORE_FN(cfun_parse_consume,
     JanetParser *p = janet_getabstract(argv, 0, &janet_parser_type);
     JanetByteView view = janet_getbytes(argv, 1);
     if (argc == 3) {
-        int32_t offset = janet_getinteger(argv, 2);
+        size_t offset = janet_getsize(argv, 2);
         if (offset < 0 || offset > view.len)
             janet_panicf("invalid offset %d out of range [0,%d]", offset, view.len);
         view.len -= offset;
         view.bytes += offset;
     }
-    int32_t i;
+    size_t i;
     for (i = 0; i < view.len; i++) {
         janet_parser_consume(p, view.bytes[i]);
         switch (janet_parser_status(p)) {
@@ -934,10 +934,10 @@ JANET_CORE_FN(cfun_parse_consume,
             case JANET_PARSE_PENDING:
                 break;
             default:
-                return janet_wrap_integer(i + 1);
+                return janet_wrap_size(i + 1);
         }
     }
-    return janet_wrap_integer(i);
+    return janet_wrap_size(i);
 }
 
 JANET_CORE_FN(cfun_parse_eof,

--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -59,11 +59,11 @@ int janet_is_symbol_char(uint8_t c) {
 /* Validate some utf8. Useful for identifiers. Only validates
  * the encoding, does not check for valid code points (they
  * are less well defined than the encoding). */
-int janet_valid_utf8(const uint8_t *str, int32_t len) {
-    int32_t i = 0;
-    int32_t j;
+int janet_valid_utf8(const uint8_t *str, size_t len) {
+    size_t i = 0;
+    size_t j;
     while (i < len) {
-        int32_t nexti;
+        size_t nexti;
         uint8_t c = str[i];
 
         /* Check the number of bytes in code point */
@@ -449,14 +449,14 @@ static int check_str_const(const char *cstr, const uint8_t *str, int32_t len) {
 static int tokenchar(JanetParser *p, JanetParseState *state, uint8_t c) {
     Janet ret;
     double numval;
-    int32_t blen;
+    size_t blen;
     if (janet_is_symbol_char(c)) {
         push_buf(p, (uint8_t) c);
         if (c > 127) state->argn = 1; /* Use to indicate non ascii */
         return 1;
     }
     /* Token finished */
-    blen = (int32_t) p->bufcount;
+    blen = p->bufcount;
     int start_dig = p->buf[0] >= '0' && p->buf[0] <= '9';
     int start_num = start_dig || p->buf[0] == '-' || p->buf[0] == '+' || p->buf[0] == '.';
     if (p->buf[0] == ':') {

--- a/src/core/peg.c
+++ b/src/core/peg.c
@@ -597,7 +597,7 @@ tail:
         case RULE_ERROR: {
             int oldmode = s->mode;
             s->mode = PEG_MODE_NORMAL;
-            int32_t old_cap = s->captures->count;
+            size_t old_cap = s->captures->count;
             down1(s);
             const uint8_t *result = peg_rule(s, s->bytecode + rule[1], text);
             up1(s);
@@ -925,7 +925,7 @@ static void spec_set(Builder *b, int32_t argc, const Janet *argv) {
     Reserve r = reserve(b, 9);
     const uint8_t *str = peg_getset(b, argv[0]);
     uint32_t bitmap[8] = {0};
-    for (int32_t i = 0; i < janet_string_length(str); i++)
+    for (size_t i = 0; i < janet_string_length(str); i++)
         bitmap_set(bitmap, str[i]);
     emit_rule(r, RULE_SET, 8, bitmap);
 }
@@ -1384,7 +1384,7 @@ static uint32_t peg_compile1(Builder *b, Janet peg) {
             /* Build grammar table */
             const JanetKV *st = janet_unwrap_struct(peg);
             JanetTable *new_grammar = janet_table(2 * janet_struct_capacity(st));
-            for (int32_t i = 0; i < janet_struct_capacity(st); i++) {
+            for (size_t i = 0; i < janet_struct_capacity(st); i++) {
                 if (janet_checktype(st[i].key, JANET_KEYWORD)) {
                     janet_table_put(new_grammar, st[i].key, st[i].value);
                 }
@@ -1805,7 +1805,7 @@ JANET_CORE_FN(cfun_peg_find,
               "(peg/find peg text &opt start & args)",
               "Find first index where the peg matches in text. Returns an integer, or nil if not found.") {
     PegCall c = peg_cfun_init(argc, argv, 0);
-    for (int32_t i = c.start; i < c.bytes.len; i++) {
+    for (size_t i = c.start; i < c.bytes.len; i++) {
         peg_call_reset(&c);
         if (peg_rule(&c.s, c.s.bytecode, c.bytes.bytes + i))
             return janet_wrap_integer(i);
@@ -1818,7 +1818,7 @@ JANET_CORE_FN(cfun_peg_find_all,
               "Find all indexes where the peg matches in text. Returns an array of integers.") {
     PegCall c = peg_cfun_init(argc, argv, 0);
     JanetArray *ret = janet_array(0);
-    for (int32_t i = c.start; i < c.bytes.len; i++) {
+    for (size_t i = c.start; i < c.bytes.len; i++) {
         peg_call_reset(&c);
         if (peg_rule(&c.s, c.s.bytecode, c.bytes.bytes + i))
             janet_array_push(ret, janet_wrap_integer(i));
@@ -1829,8 +1829,8 @@ JANET_CORE_FN(cfun_peg_find_all,
 static Janet cfun_peg_replace_generic(int32_t argc, Janet *argv, int only_one) {
     PegCall c = peg_cfun_init(argc, argv, 1);
     JanetBuffer *ret = janet_buffer(0);
-    int32_t trail = 0;
-    for (int32_t i = c.start; i < c.bytes.len;) {
+    size_t trail = 0;
+    for (size_t i = c.start; i < c.bytes.len;) {
         peg_call_reset(&c);
         const uint8_t *result = peg_rule(&c.s, c.s.bytecode, c.bytes.bytes + i);
         if (NULL != result) {
@@ -1838,7 +1838,7 @@ static Janet cfun_peg_replace_generic(int32_t argc, Janet *argv, int only_one) {
                 janet_buffer_push_bytes(ret, c.bytes.bytes + trail, (i - trail));
                 trail = i;
             }
-            int32_t nexti = (int32_t)(result - c.bytes.bytes);
+            size_t nexti = (size_t)(result - c.bytes.bytes);
             JanetByteView subst = janet_text_substitution(&c.subst, c.bytes.bytes + i, nexti - i, c.s.captures);
             janet_buffer_push_bytes(ret, subst.bytes, subst.len);
             trail = nexti;

--- a/src/core/peg.c
+++ b/src/core/peg.c
@@ -423,10 +423,10 @@ tail:
             /* check number parsing */
             double x = 0.0;
             int32_t base = (int32_t) rule[2];
-            if (janet_scan_number_base(text, (int32_t)(result - text), base, &x)) return NULL;
+            if (janet_scan_number_base(text, (size_t)(result - text), base, &x)) return NULL;
             /* Specialized pushcap - avoid intermediate string creation */
             if (!s->has_backref && s->mode == PEG_MODE_ACCUMULATE) {
-                janet_buffer_push_bytes(s->scratch, text, (int32_t)(result - text));
+                janet_buffer_push_bytes(s->scratch, text, (size_t)(result - text));
             } else {
                 uint32_t tag = rule[3];
                 pushcap(s, janet_wrap_number(x), tag);

--- a/src/core/peg.c
+++ b/src/core/peg.c
@@ -65,9 +65,9 @@ typedef struct {
  * to save state at branches, and then reload
  * if one branch fails and try a new branch. */
 typedef struct {
-    int32_t cap;
-    int32_t tcap;
-    int32_t scratch;
+    size_t cap;
+    size_t tcap;
+    size_t scratch;
 } CapState;
 
 /* Save the current capture state */

--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -895,13 +895,13 @@ void janet_formatbv(JanetBuffer *b, const char *format, va_list args) {
                 case 's':
                 case 'S': {
                     const char *str = va_arg(args, const char *);
-                    int32_t len = c[-1] == 's'
-                                  ? (int32_t) strlen(str)
+                    size_t len = c[-1] == 's'
+                                  ? strlen(str)
                                   : janet_string_length((JanetString) str);
                     if (form[2] == '\0')
                         janet_buffer_push_bytes(b, (const uint8_t *) str, len);
                     else {
-                        if (len != (int32_t) strlen((const char *) str))
+                        if (len != strlen((const char *) str))
                             janet_panic("string contains zeros");
                         if (!strchr(form, '.') && len >= 100) {
                             janet_panic("no precision and string is too long to be formatted");

--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -134,9 +134,9 @@ static void string_description_b(JanetBuffer *buffer, const char *title, void *p
 #undef POINTSIZE
 }
 
-static void janet_escape_string_impl(JanetBuffer *buffer, const uint8_t *str, int32_t len) {
+static void janet_escape_string_impl(JanetBuffer *buffer, const uint8_t *str, size_t len) {
     janet_buffer_push_u8(buffer, '"');
-    for (int32_t i = 0; i < len; ++i) {
+    for (size_t i = 0; i < len; ++i) {
         uint8_t c = str[i];
         switch (c) {
             case '"':

--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -391,7 +391,7 @@ static int print_jdn_one(struct pretty *S, Janet x, int depth) {
             JanetTuple t = janet_unwrap_tuple(x);
             int isb = janet_tuple_flag(t) & JANET_TUPLE_FLAG_BRACKETCTOR;
             janet_buffer_push_u8(S->buffer, isb ? '[' : '(');
-            for (int32_t i = 0; i < janet_tuple_length(t); i++) {
+            for (size_t i = 0; i < janet_tuple_length(t); i++) {
                 if (i) janet_buffer_push_u8(S->buffer, ' ');
                 if (print_jdn_one(S, t[i], depth - 1)) return 1;
             }
@@ -402,7 +402,7 @@ static int print_jdn_one(struct pretty *S, Janet x, int depth) {
             janet_table_put(&S->seen, x, janet_wrap_true());
             JanetArray *a = janet_unwrap_array(x);
             janet_buffer_push_cstring(S->buffer, "@[");
-            for (int32_t i = 0; i < a->count; i++) {
+            for (size_t i = 0; i < a->count; i++) {
                 if (i) janet_buffer_push_u8(S->buffer, ' ');
                 if (print_jdn_one(S, a->data[i], depth - 1)) return 1;
             }
@@ -414,7 +414,7 @@ static int print_jdn_one(struct pretty *S, Janet x, int depth) {
             JanetTable *tab = janet_unwrap_table(x);
             janet_buffer_push_cstring(S->buffer, "@{");
             int isFirst = 1;
-            for (int32_t i = 0; i < tab->capacity; i++) {
+            for (size_t i = 0; i < tab->capacity; i++) {
                 const JanetKV *kv = tab->data + i;
                 if (janet_checktype(kv->key, JANET_NIL)) continue;
                 if (!isFirst) janet_buffer_push_u8(S->buffer, ' ');
@@ -430,7 +430,7 @@ static int print_jdn_one(struct pretty *S, Janet x, int depth) {
             JanetStruct st = janet_unwrap_struct(x);
             janet_buffer_push_u8(S->buffer, '{');
             int isFirst = 1;
-            for (int32_t i = 0; i < janet_struct_capacity(st); i++) {
+            for (size_t i = 0; i < janet_struct_capacity(st); i++) {
                 const JanetKV *kv = st + i;
                 if (janet_checktype(kv->key, JANET_NIL)) continue;
                 if (!isFirst) janet_buffer_push_u8(S->buffer, ' ');

--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -279,10 +279,10 @@ void janet_to_string_b(JanetBuffer *buffer, Janet x) {
 
 /* Check if a symbol or keyword contains no symbol characters */
 static int contains_bad_chars(const uint8_t *sym, int issym) {
-    int32_t len = janet_string_length(sym);
+    size_t len = janet_string_length(sym);
     if (len && issym && sym[0] >= '0' && sym[0] <= '9') return 1;
     if (!janet_valid_utf8(sym, len)) return 1;
-    for (int32_t i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         if (!janet_is_symbol_char(sym[i])) return 1;
     }
     return 0;
@@ -536,7 +536,7 @@ static void janet_pretty_one(struct pretty *S, Janet x, int is_dict_value) {
         }
         case JANET_ARRAY:
         case JANET_TUPLE: {
-            int32_t i = 0, len = 0;
+            size_t i = 0, len = 0;
             const Janet *arr = NULL;
             int isarray = janet_checktype(x, JANET_ARRAY);
             janet_indexed_view(x, &arr, &len);
@@ -587,7 +587,7 @@ static void janet_pretty_one(struct pretty *S, Janet x, int is_dict_value) {
                 if (NULL != proto) {
                     Janet name = janet_table_get(proto, janet_ckeywordv("_name"));
                     const uint8_t *n;
-                    int32_t len;
+                    size_t len;
                     if (janet_bytes_view(name, &n, &len)) {
                         if (S->flags & JANET_PRETTY_COLOR) {
                             janet_buffer_push_cstring(S->buffer, janet_class_color);
@@ -604,7 +604,7 @@ static void janet_pretty_one(struct pretty *S, Janet x, int is_dict_value) {
                 if (NULL != proto) {
                     Janet name = janet_struct_get(proto, janet_ckeywordv("_name"));
                     const uint8_t *n;
-                    int32_t len;
+                    size_t len;
                     if (janet_bytes_view(name, &n, &len)) {
                         if (S->flags & JANET_PRETTY_COLOR) {
                             janet_buffer_push_cstring(S->buffer, janet_class_color);
@@ -623,7 +623,7 @@ static void janet_pretty_one(struct pretty *S, Janet x, int is_dict_value) {
             if (S->depth == 0) {
                 janet_buffer_push_cstring(S->buffer, "...");
             } else {
-                int32_t i = 0, len = 0, cap = 0;
+                size_t i = 0, len = 0, cap = 0;
                 const JanetKV *kvs = NULL;
                 janet_dictionary_view(x, &kvs, &len, &cap);
                 if (!istable && !(S->flags & JANET_PRETTY_ONELINE) && len >= JANET_PRETTY_DICT_ONELINE)

--- a/src/core/run.c
+++ b/src/core/run.c
@@ -27,7 +27,7 @@
 #endif
 
 /* Run a string */
-int janet_dobytes(JanetTable *env, const uint8_t *bytes, int32_t len, const char *sourcePath, Janet *out) {
+int janet_dobytes(JanetTable *env, const uint8_t *bytes, size_t len, const char *sourcePath, Janet *out) {
     JanetParser parser;
     int errflags = 0, done = 0;
     int32_t index = 0;
@@ -128,7 +128,7 @@ int janet_dobytes(JanetTable *env, const uint8_t *bytes, int32_t len, const char
 }
 
 int janet_dostring(JanetTable *env, const char *str, const char *sourcePath, Janet *out) {
-    int32_t len = 0;
+    size_t len = 0;
     while (str[len]) ++len;
     return janet_dobytes(env, (const uint8_t *)str, len, sourcePath, out);
 }

--- a/src/core/run.c
+++ b/src/core/run.c
@@ -30,7 +30,7 @@
 int janet_dobytes(JanetTable *env, const uint8_t *bytes, size_t len, const char *sourcePath, Janet *out) {
     JanetParser parser;
     int errflags = 0, done = 0;
-    int32_t index = 0;
+    size_t index = 0;
     Janet ret = janet_wrap_nil();
     JanetFiber *fiber = NULL;
     const uint8_t *where = sourcePath ? janet_cstring(sourcePath) : NULL;

--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -105,7 +105,7 @@ static JanetSlot quasiquote(JanetFopts opts, Janet x, int depth, int level) {
         case JANET_TABLE:
         case JANET_STRUCT: {
             const JanetKV *kv = NULL, *kvs = NULL;
-            int32_t len, cap = 0;
+            size_t len, cap = 0;
             janet_dictionary_view(x, &kvs, &len, &cap);
             while ((kv = janet_dictionary_next(kvs, cap, kv))) {
                 JanetSlot key = quasiquote(subopts, kv->key, depth - 1, level);
@@ -156,10 +156,10 @@ static int destructure(JanetCompiler *c,
             return leaf(c, janet_unwrap_symbol(left), right, attr);
         case JANET_TUPLE:
         case JANET_ARRAY: {
-            int32_t len = 0;
+            size_t len = 0;
             const Janet *values = NULL;
             janet_indexed_view(left, &values, &len);
-            for (int32_t i = 0; i < len; i++) {
+            for (size_t i = 0; i < len; i++) {
                 JanetSlot nextright = janetc_farslot(c);
                 Janet subval = values[i];
 
@@ -170,11 +170,11 @@ static int destructure(JanetCompiler *c,
                     }
 
                     if (i + 2 < len) {
-                        int32_t num_extra = len - i - 1;
+                        size_t num_extra = len - i - 1;
                         Janet *extra = janet_tuple_begin(num_extra);
                         janet_tuple_flag(extra) |= JANET_TUPLE_FLAG_BRACKETCTOR;
 
-                        for (int32_t j = 0; j < num_extra; ++j) {
+                        for (size_t j = 0; j < num_extra; ++j) {
                             extra[j] = values[j + i + 1];
                         }
 
@@ -237,9 +237,9 @@ static int destructure(JanetCompiler *c,
         case JANET_TABLE:
         case JANET_STRUCT: {
             const JanetKV *kvs = NULL;
-            int32_t cap = 0, len = 0;
+            size_t cap = 0, len = 0;
             janet_dictionary_view(left, &kvs, &len, &cap);
-            for (int32_t i = 0; i < cap; i++) {
+            for (size_t i = 0; i < cap; i++) {
                 if (janet_checktype(kvs[i].key, JANET_NIL)) continue;
                 JanetSlot nextright = janetc_farslot(c);
                 JanetSlot k = janetc_value(janetc_fopts_default(c), kvs[i].key);
@@ -362,7 +362,7 @@ SlotHeadPair *dohead_destructure(JanetCompiler *c, SlotHeadPair *into, JanetFopt
         janet_indexed_view(lhs, &view_lhs.items, &view_lhs.len);
         janet_indexed_view(rhs, &view_rhs.items, &view_rhs.len);
         int found_amp = 0;
-        for (int32_t i = 0; i < view_lhs.len; i++) {
+        for (size_t i = 0; i < view_lhs.len; i++) {
             if (janet_symeq(view_lhs.items[i], "&")) {
                 found_amp = 1;
                 /* Good error will be generated later. */
@@ -370,7 +370,7 @@ SlotHeadPair *dohead_destructure(JanetCompiler *c, SlotHeadPair *into, JanetFopt
             }
         }
         if (!found_amp) {
-            for (int32_t i = 0; i < view_lhs.len; i++) {
+            for (size_t i = 0; i < view_lhs.len; i++) {
                 Janet sub_rhs = view_rhs.len <= i ? janet_wrap_nil() : view_rhs.items[i];
                 into = dohead_destructure(c, into, subopts, view_lhs.items[i], sub_rhs);
             }

--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -72,7 +72,7 @@ static JanetSlot quasiquote(JanetFopts opts, Janet x, int depth, int level) {
         default:
             return janetc_cslot(x);
         case JANET_TUPLE: {
-            int32_t i, len;
+            size_t i, len;
             const Janet *tup = janet_unwrap_tuple(x);
             len = janet_tuple_length(tup);
             if (len > 1 && janet_checktype(tup[0], JANET_SYMBOL)) {

--- a/src/core/specials.c
+++ b/src/core/specials.c
@@ -96,9 +96,8 @@ static JanetSlot quasiquote(JanetFopts opts, Janet x, int depth, int level) {
                             : JOP_MAKE_TUPLE);
         }
         case JANET_ARRAY: {
-            int32_t i;
             JanetArray *array = janet_unwrap_array(x);
-            for (i = 0; i < array->count; i++)
+            for (size_t i = 0; i < array->count; i++)
                 janet_v_push(slots, quasiquote(subopts, array->data[i], depth - 1, level));
             return qq_slots(opts, slots, JOP_MAKE_ARRAY);
         }

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -42,8 +42,8 @@ typedef struct JanetScratch {
 typedef struct {
     JanetGCObject *self;
     JanetGCObject *other;
-    int32_t index;
-    int32_t index2;
+    size_t index;
+    size_t index2;
 } JanetTraversalNode;
 
 typedef struct {

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -47,9 +47,9 @@ typedef struct {
 } JanetTraversalNode;
 
 typedef struct {
-    int32_t capacity;
-    int32_t head;
-    int32_t tail;
+    size_t capacity;
+    size_t head;
+    size_t tail;
     void *data;
 } JanetQueue;
 

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -205,12 +205,11 @@ JANET_CORE_FN(cfun_string_repeat,
               "Returns a string that is `n` copies of `bytes` concatenated.") {
     janet_fixarity(argc, 2);
     JanetByteView view = janet_getbytes(argv, 0);
-    int32_t rep = janet_getinteger(argv, 1);
-    if (rep < 0) janet_panic("expected non-negative number of repetitions");
+    size_t rep = janet_getsize(argv, 1);
     if (rep == 0) return janet_cstringv("");
-    int64_t mulres = (int64_t) rep * view.len;
-    if (mulres > JANET_INTMAX_INT64) janet_panic("result string is too long");
-    uint8_t *newbuf = janet_string_begin((int32_t) mulres);
+    size_t mulres = rep * view.len;
+    if (mulres > JANET_INTMAX_SIZE) janet_panic("result string is too long");
+    uint8_t *newbuf = janet_string_begin(mulres);
     uint8_t *end = newbuf + mulres;
     for (uint8_t *p = newbuf; p < end; p += view.len) {
         safe_memcpy(p, view.bytes, view.len);
@@ -506,7 +505,7 @@ JANET_CORE_FN(cfun_string_join,
     }
     /* Check args */
     size_t i;
-    int64_t finallen = 0;
+    size_t finallen = 0;
     for (i = 0; i < parts.len; i++) {
         const uint8_t *chunk;
         size_t chunklen = 0;
@@ -515,11 +514,11 @@ JANET_CORE_FN(cfun_string_join,
         }
         if (i) finallen += joiner.len;
         finallen += chunklen;
-        if (finallen > INT32_MAX)
+        if (finallen > JANET_INTMAX_SIZE)
             janet_panic("result string too long");
     }
     uint8_t *buf, *out;
-    out = buf = janet_string_begin((size_t) finallen);
+    out = buf = janet_string_begin(finallen);
     for (i = 0; i < parts.len; i++) {
         const uint8_t *chunk = NULL;
         size_t chunklen = 0;

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -94,8 +94,8 @@ const uint8_t *janet_cstring(const char *str) {
 struct kmp_state {
     int32_t i;
     int32_t j;
-    int32_t textlen;
-    int32_t patlen;
+    size_t textlen;
+    size_t patlen;
     int32_t *lookup;
     const uint8_t *text;
     const uint8_t *pat;
@@ -103,8 +103,8 @@ struct kmp_state {
 
 static void kmp_init(
     struct kmp_state *s,
-    const uint8_t *text, int32_t textlen,
-    const uint8_t *pat, int32_t patlen) {
+    const uint8_t *text, size_t textlen,
+    const uint8_t *pat, size_t patlen) {
     if (patlen == 0) {
         janet_panic("expected non-empty pattern");
     }
@@ -142,8 +142,8 @@ static void kmp_seti(struct kmp_state *state, int32_t i) {
 static int32_t kmp_next(struct kmp_state *state) {
     int32_t i = state->i;
     int32_t j = state->j;
-    int32_t textlen = state->textlen;
-    int32_t patlen = state->patlen;
+    size_t textlen = state->textlen;
+    size_t patlen = state->patlen;
     const uint8_t *text = state->text;
     const uint8_t *pat = state->pat;
     int32_t *lookup = state->lookup;
@@ -251,7 +251,7 @@ JANET_CORE_FN(cfun_string_asciilower,
     janet_fixarity(argc, 1);
     JanetByteView view = janet_getbytes(argv, 0);
     uint8_t *buf = janet_string_begin(view.len);
-    for (int32_t i = 0; i < view.len; i++) {
+    for (size_t i = 0; i < view.len; i++) {
         uint8_t c = view.bytes[i];
         if (c >= 65 && c <= 90) {
             buf[i] = c + 32;
@@ -568,21 +568,21 @@ JANET_CORE_FN(cfun_string_format,
 }
 
 static int trim_help_checkset(JanetByteView set, uint8_t x) {
-    for (int32_t j = 0; j < set.len; j++)
+    for (size_t j = 0; j < set.len; j++)
         if (set.bytes[j] == x)
             return 1;
     return 0;
 }
 
 static int32_t trim_help_leftedge(JanetByteView str, JanetByteView set) {
-    for (int32_t i = 0; i < str.len; i++)
+    for (size_t i = 0; i < str.len; i++)
         if (!trim_help_checkset(set, str.bytes[i]))
             return i;
     return str.len;
 }
 
 static int32_t trim_help_rightedge(JanetByteView str, JanetByteView set) {
-    for (int32_t i = str.len - 1; i >= 0; i--)
+    for (size_t i = str.len - 1; i >= 0; i--)
         if (!trim_help_checkset(set, str.bytes[i]))
             return i + 1;
     return 0;

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -92,8 +92,8 @@ const uint8_t *janet_cstring(const char *str) {
 /* Knuth Morris Pratt Algorithm */
 
 struct kmp_state {
-    int32_t i;
-    int32_t j;
+    size_t i;
+    size_t j;
     size_t textlen;
     size_t patlen;
     int32_t *lookup;
@@ -121,7 +121,8 @@ static void kmp_init(
     s->patlen = patlen;
     /* Init state machine */
     {
-        int32_t i, j;
+        size_t i;
+        int32_t j;
         for (i = 1, j = 0; i < patlen; i++) {
             while (j && pat[j] != pat[i]) j = lookup[j - 1];
             if (pat[j] == pat[i]) j++;
@@ -140,8 +141,8 @@ static void kmp_seti(struct kmp_state *state, int32_t i) {
 }
 
 static int32_t kmp_next(struct kmp_state *state) {
-    int32_t i = state->i;
-    int32_t j = state->j;
+    size_t i = state->i;
+    size_t j = state->j;
     size_t textlen = state->textlen;
     size_t patlen = state->patlen;
     const uint8_t *text = state->text;
@@ -270,7 +271,7 @@ JANET_CORE_FN(cfun_string_asciiupper,
     janet_fixarity(argc, 1);
     JanetByteView view = janet_getbytes(argv, 0);
     uint8_t *buf = janet_string_begin(view.len);
-    for (int32_t i = 0; i < view.len; i++) {
+    for (size_t i = 0; i < view.len; i++) {
         uint8_t c = view.bytes[i];
         if (c >= 97 && c <= 122) {
             buf[i] = c - 32;
@@ -287,7 +288,7 @@ JANET_CORE_FN(cfun_string_reverse,
     janet_fixarity(argc, 1);
     JanetByteView view = janet_getbytes(argv, 0);
     uint8_t *buf = janet_string_begin(view.len);
-    int32_t i, j;
+    size_t i, j;
     for (i = 0, j = view.len - 1; i < view.len; i++, j--) {
         buf[i] = view.bytes[j];
     }
@@ -474,13 +475,13 @@ JANET_CORE_FN(cfun_string_checkset,
     JanetByteView set = janet_getbytes(argv, 0);
     JanetByteView str = janet_getbytes(argv, 1);
     /* Populate set */
-    for (int32_t i = 0; i < set.len; i++) {
+    for (size_t i = 0; i < set.len; i++) {
         int index = set.bytes[i] >> 5;
         uint32_t mask = 1 << (set.bytes[i] & 0x1F);
         bitset[index] |= mask;
     }
     /* Check set */
-    for (int32_t i = 0; i < str.len; i++) {
+    for (size_t i = 0; i < str.len; i++) {
         int index = str.bytes[i] >> 5;
         uint32_t mask = 1 << (str.bytes[i] & 0x1F);
         if (!(bitset[index] & mask)) {

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -207,7 +207,7 @@ JANET_CORE_FN(cfun_string_repeat,
     JanetByteView view = janet_getbytes(argv, 0);
     size_t rep = janet_getsize(argv, 1);
     if (rep == 0) return janet_cstringv("");
-    size_t mulres = rep * view.len;
+    uint64_t mulres = (uint64_t) rep * view.len;
     if (mulres > JANET_INTMAX_SIZE) janet_panic("result string is too long");
     uint8_t *newbuf = janet_string_begin(mulres);
     uint8_t *end = newbuf + mulres;

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -58,8 +58,8 @@ const uint8_t *janet_string(const uint8_t *buf, size_t len) {
 
 /* Compare two strings */
 int janet_string_compare(const uint8_t *lhs, const uint8_t *rhs) {
-    int32_t xlen = janet_string_length(lhs);
-    int32_t ylen = janet_string_length(rhs);
+    size_t xlen = janet_string_length(lhs);
+    size_t ylen = janet_string_length(rhs);
     size_t len = xlen > ylen ? ylen : xlen;
     int res = memcmp(lhs, rhs, len);
     if (res) return res > 0 ? 1 : -1;
@@ -574,14 +574,14 @@ static int trim_help_checkset(JanetByteView set, uint8_t x) {
     return 0;
 }
 
-static int32_t trim_help_leftedge(JanetByteView str, JanetByteView set) {
+static size_t trim_help_leftedge(JanetByteView str, JanetByteView set) {
     for (size_t i = 0; i < str.len; i++)
         if (!trim_help_checkset(set, str.bytes[i]))
             return i;
     return str.len;
 }
 
-static int32_t trim_help_rightedge(JanetByteView str, JanetByteView set) {
+static size_t trim_help_rightedge(JanetByteView str, JanetByteView set) {
     for (size_t i = str.len - 1; i > 0; i--)
         if (!trim_help_checkset(set, str.bytes[i]))
             return i + 1;
@@ -605,8 +605,8 @@ JANET_CORE_FN(cfun_string_trim,
               "`set` is provided, consider only characters in `set` to be whitespace.") {
     JanetByteView str, set;
     trim_help_args(argc, argv, &str, &set);
-    int32_t left_edge = trim_help_leftedge(str, set);
-    int32_t right_edge = trim_help_rightedge(str, set);
+    size_t left_edge = trim_help_leftedge(str, set);
+    size_t right_edge = trim_help_rightedge(str, set);
     if (right_edge < left_edge)
         return janet_stringv(NULL, 0);
     return janet_stringv(str.bytes + left_edge, right_edge - left_edge);

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -582,9 +582,9 @@ static size_t trim_help_leftedge(JanetByteView str, JanetByteView set) {
 }
 
 static size_t trim_help_rightedge(JanetByteView str, JanetByteView set) {
-    for (size_t i = str.len - 1; i > 0; i--)
-        if (!trim_help_checkset(set, str.bytes[i]))
-            return i + 1;
+    for (size_t i = 0; i < str.len; i++)
+        if (!trim_help_checkset(set, str.bytes[str.len - i - 1]))
+            return str.len - i;
     return 0;
 }
 

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -583,7 +583,7 @@ static int32_t trim_help_leftedge(JanetByteView str, JanetByteView set) {
 }
 
 static int32_t trim_help_rightedge(JanetByteView str, JanetByteView set) {
-    for (size_t i = str.len - 1; i >= 0; i--)
+    for (size_t i = str.len - 1; i > 0; i--)
         if (!trim_help_checkset(set, str.bytes[i]))
             return i + 1;
     return 0;

--- a/src/core/strtod.c
+++ b/src/core/strtod.c
@@ -249,7 +249,7 @@ static double convert(
  * and integer, return 0. */
 int janet_scan_number_base(
     const uint8_t *str,
-    int32_t len,
+    size_t len,
     int32_t base,
     double *out) {
     const uint8_t *end = str + len;
@@ -385,7 +385,7 @@ error:
 
 int janet_scan_number(
     const uint8_t *str,
-    int32_t len,
+    size_t len,
     double *out) {
     return janet_scan_number_base(str, len, 0, out);
 }
@@ -394,7 +394,7 @@ int janet_scan_number(
 
 static int scan_uint64(
     const uint8_t *str,
-    int32_t len,
+    size_t len,
     uint64_t *out,
     int *neg) {
     const uint8_t *end = str + len;
@@ -457,7 +457,7 @@ static int scan_uint64(
     return 1;
 }
 
-int janet_scan_int64(const uint8_t *str, int32_t len, int64_t *out) {
+int janet_scan_int64(const uint8_t *str, size_t len, int64_t *out) {
     int neg;
     uint64_t bi;
     if (scan_uint64(str, len, &bi, &neg)) {
@@ -477,7 +477,7 @@ int janet_scan_int64(const uint8_t *str, int32_t len, int64_t *out) {
     return 0;
 }
 
-int janet_scan_uint64(const uint8_t *str, int32_t len, uint64_t *out) {
+int janet_scan_uint64(const uint8_t *str, size_t len, uint64_t *out) {
     int neg;
     uint64_t bi;
     if (scan_uint64(str, len, &bi, &neg)) {

--- a/src/core/struct.c
+++ b/src/core/struct.c
@@ -34,11 +34,13 @@ JanetKV *janet_struct_begin(size_t count) {
 
     uint64_t double_count =
         (count > JANET_INTMAX_SIZE / 2) ? JANET_INTMAX_SIZE : 2 * count;
-    uint64_t cap = janet_tablen(double_count);
-    size_t capacity =
-        (cap > JANET_INTMAX_SIZE) ? JANET_INTMAX_SIZE : (size_t)cap;
+    uint64_t capacity = janet_tablen(double_count);
 
-    size_t size = sizeof(JanetStructHead) + capacity * sizeof(JanetKV);
+    uint64_t part_size = capacity * sizeof(JanetKV);
+    if (part_size > JANET_INTMAX_SIZE){
+        part_size = JANET_INTMIN_SIZE;
+    }
+    size_t size = sizeof(JanetStructHead) + (uint64_t) part_size;
     JanetStructHead *head = janet_gcalloc(JANET_MEMORY_STRUCT, size);
     head->length = count;
     head->capacity = capacity;

--- a/src/core/struct.c
+++ b/src/core/struct.c
@@ -31,7 +31,12 @@
 /* Begin creation of a struct */
 JanetKV *janet_struct_begin(size_t count) {
     /* Calculate capacity as power of 2 after 2 * count. */
-    size_t capacity = janet_tablen(2 * count);
+
+    uint64_t double_count =
+        (count > JANET_INTMAX_SIZE / 2) ? JANET_INTMAX_SIZE : 2 * count;
+    uint64_t cap = janet_tablen(double_count);
+    size_t capacity =
+        (cap > JANET_INTMAX_SIZE) ? JANET_INTMAX_SIZE : (size_t)cap;
 
     size_t size = sizeof(JanetStructHead) + capacity * sizeof(JanetKV);
     JanetStructHead *head = janet_gcalloc(JANET_MEMORY_STRUCT, size);

--- a/src/core/struct.c
+++ b/src/core/struct.c
@@ -54,7 +54,7 @@ const JanetKV *janet_struct_find(const JanetKV *st, Janet key) {
     for (i = index; i < cap; i++)
         if (janet_checktype(st[i].key, JANET_NIL) || janet_equals(st[i].key, key))
             return st + i;
-    for (i = 0; i < index; i++)
+    for (i = 0; i < (size_t) index; i++)
         if (janet_checktype(st[i].key, JANET_NIL) || janet_equals(st[i].key, key))
             return st + i;
     return NULL;
@@ -77,7 +77,7 @@ void janet_struct_put_ext(JanetKV *st, Janet key, Janet value, int replace) {
     if (janet_checktype(key, JANET_NIL) || janet_checktype(value, JANET_NIL)) return;
     if (janet_checktype(key, JANET_NUMBER) && isnan(janet_unwrap_number(key))) return;
     /* Avoid extra items */
-    if (janet_struct_hash(st) == janet_struct_length(st)) return;
+    if ((size_t) janet_struct_hash(st) == janet_struct_length(st)) return;
     for (dist = 0, j = 0; j < 4; j += 2)
         for (i = bounds[j]; i < bounds[j + 1]; i++, dist++) {
             int status;
@@ -138,7 +138,7 @@ void janet_struct_put(JanetKV *st, Janet key, Janet value) {
 
 /* Finish building a struct */
 const JanetKV *janet_struct_end(JanetKV *st) {
-    if (janet_struct_hash(st) != janet_struct_length(st)) {
+    if ((size_t) janet_struct_hash(st) != janet_struct_length(st)) {
         /* Error building struct, probably duplicate values. We need to rebuild
          * the struct using only the values that went in. The second creation should always
          * succeed. */

--- a/src/core/symcache.c
+++ b/src/core/symcache.c
@@ -66,7 +66,7 @@ static const uint8_t JANET_SYMCACHE_DELETED[1] = {0};
  * where one would put it. */
 static const uint8_t **janet_symcache_findmem(
     const uint8_t *str,
-    int32_t len,
+    size_t len,
     int32_t hash,
     int *success) {
     uint32_t bounds[4];
@@ -116,10 +116,10 @@ notfound:
     janet_symcache_findmem((str), janet_string_length(str), janet_string_hash(str), (success))
 
 /* Resize the cache. */
-static void janet_cache_resize(uint32_t newCapacity) {
-    uint32_t i, oldCapacity;
+static void janet_cache_resize(size_t newCapacity) {
+    size_t i, oldCapacity;
     const uint8_t **oldCache = janet_vm.cache;
-    const uint8_t **newCache = janet_calloc(1, (size_t) newCapacity * sizeof(const uint8_t *));
+    const uint8_t **newCache = janet_calloc(1, newCapacity * sizeof(const uint8_t *));
     if (newCache == NULL) {
         JANET_OUT_OF_MEMORY;
     }

--- a/src/core/symcache.c
+++ b/src/core/symcache.c
@@ -169,14 +169,14 @@ void janet_symbol_deinit(const uint8_t *sym) {
 }
 
 /* Create a symbol from a byte string */
-const uint8_t *janet_symbol(const uint8_t *str, int32_t len) {
+const uint8_t *janet_symbol(const uint8_t *str, size_t len) {
     int32_t hash = janet_string_calchash(str, len);
     uint8_t *newstr;
     int success = 0;
     const uint8_t **bucket = janet_symcache_findmem(str, len, hash, &success);
     if (success)
         return *bucket;
-    JanetStringHead *head = janet_gcalloc(JANET_MEMORY_SYMBOL, sizeof(JanetStringHead) + (size_t) len + 1);
+    JanetStringHead *head = janet_gcalloc(JANET_MEMORY_SYMBOL, sizeof(JanetStringHead) + len + 1);
     head->hash = hash;
     head->length = len;
     newstr = (uint8_t *)(head->data);
@@ -188,7 +188,7 @@ const uint8_t *janet_symbol(const uint8_t *str, int32_t len) {
 
 /* Get a symbol from a cstring */
 const uint8_t *janet_csymbol(const char *cstr) {
-    return janet_symbol((const uint8_t *)cstr, (int32_t) strlen(cstr));
+    return janet_symbol((const uint8_t *)cstr, strlen(cstr));
 }
 
 /* Increment the gensym buffer */

--- a/src/core/table.c
+++ b/src/core/table.c
@@ -32,7 +32,7 @@
 
 static void *janet_memalloc_empty_local(size_t count) {
     size_t i;
-    void *mem = janet_smalloc((size_t) count * sizeof(JanetKV));
+    void *mem = janet_smalloc(count * sizeof(JanetKV));
     JanetKV *mmem = (JanetKV *)mem;
     for (i = 0; i < count; i++) {
         JanetKV *kv = mmem + i;

--- a/src/core/tuple.c
+++ b/src/core/tuple.c
@@ -31,8 +31,8 @@
 /* Create a new empty tuple of the given size. This will return memory
  * which should be filled with Janets. The memory will not be collected until
  * janet_tuple_end is called. */
-Janet *janet_tuple_begin(int32_t length) {
-    size_t size = sizeof(JanetTupleHead) + ((size_t) length * sizeof(Janet));
+Janet *janet_tuple_begin(size_t length) {
+    size_t size = sizeof(JanetTupleHead) + (length * sizeof(Janet));
     JanetTupleHead *head = janet_gcalloc(JANET_MEMORY_TUPLE, size);
     head->sm_line = -1;
     head->sm_column = -1;
@@ -47,7 +47,7 @@ const Janet *janet_tuple_end(Janet *tuple) {
 }
 
 /* Build a tuple with n values */
-const Janet *janet_tuple_n(const Janet *values, int32_t n) {
+const Janet *janet_tuple_n(const Janet *values, size_t n) {
     Janet *t = janet_tuple_begin(n);
     safe_memcpy(t, values, sizeof(Janet) * n);
     return janet_tuple_end(t);

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -267,8 +267,7 @@ int32_t janet_kv_calchash(const JanetKV *kvs, int32_t len) {
 
 /* Calculate next power of 2. May overflow. If n is 0,
  * will return 0. */
-int32_t janet_tablen(int32_t n) {
-    if (n < 0) return 0;
+size_t janet_tablen(size_t n) {
     n |= n >> 1;
     n |= n >> 2;
     n |= n >> 4;

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -829,12 +829,14 @@ int janet_checksize(Janet x) {
     if (!janet_checktype(x, JANET_NUMBER))
         return 0;
     double dval = janet_unwrap_number(x);
-    if (dval != (double)((size_t) dval)) return 0;
-    if (SIZE_MAX > JANET_INTMAX_INT64) {
-        return dval <= JANET_INTMAX_INT64;
-    } else {
-        return dval <= SIZE_MAX;
-    }
+    return janet_checksizerange(dval);
+}
+
+int janet_checkssize(Janet x) {
+    if (!janet_checktype(x, JANET_NUMBER))
+        return 0;
+    double dval = janet_unwrap_number(x);
+    return janet_checkssizerange(dval);
 }
 
 JanetTable *janet_get_core_table(const char *name) {

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -341,8 +341,8 @@ const JanetKV *janet_dictionary_next(const JanetKV *kvs, size_t cap, const Janet
 /* Compare a janet string with a cstring. More efficient than loading
  * c string as a janet string. */
 int janet_cstrcmp(const uint8_t *str, const char *other) {
-    int32_t len = janet_string_length(str);
-    int32_t index;
+    size_t len = janet_string_length(str);
+    size_t index;
     for (index = 0; index < len; index++) {
         uint8_t c = str[index];
         uint8_t k = ((const uint8_t *)other)[index];

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -861,7 +861,7 @@ int32_t janet_sorted_keys(const JanetKV *dict, size_t cap, int32_t *index_buffer
     for (size_t i = 1; i < next_index; i++) {
         int32_t index_to_insert = index_buffer[i];
         Janet lhs = dict[index_to_insert].key;
-        for (size_t j = i - 1; j >= 0; j--) {
+        for (size_t j = i - 1; j > 0; j--) {
             index_buffer[j + 1] = index_buffer[j];
             Janet rhs = dict[index_buffer[j]].key;
             if (janet_compare(lhs, rhs) >= 0) {

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -267,7 +267,7 @@ int32_t janet_kv_calchash(const JanetKV *kvs, size_t len) {
 
 /* Calculate next power of 2. May overflow. If n is 0,
  * will return 0. */
-size_t janet_tablen(size_t n) {
+uint64_t janet_tablen(uint64_t n) {
     n |= n >> 1;
     n |= n >> 2;
     n |= n >> 4;

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -302,7 +302,7 @@ const JanetKV *janet_dict_find(const JanetKV *buckets, size_t cap, Janet key) {
         }
     }
     /* Lower half */
-    for (i = 0; i < index; i++) {
+    for (i = 0; i < (size_t) index; i++) {
         const JanetKV *kv = buckets + i;
         if (janet_checktype(kv->key, JANET_NIL)) {
             if (janet_checktype(kv->value, JANET_NIL)) {
@@ -847,21 +847,21 @@ JanetTable *janet_get_core_table(const char *name) {
 }
 
 /* Sort keys of a dictionary type */
-int32_t janet_sorted_keys(const JanetKV *dict, int32_t cap, int32_t *index_buffer) {
+int32_t janet_sorted_keys(const JanetKV *dict, size_t cap, int32_t *index_buffer) {
 
     /* First, put populated indices into index_buffer */
-    int32_t next_index = 0;
-    for (int32_t i = 0; i < cap; i++) {
+    size_t next_index = 0;
+    for (size_t i = 0; i < cap; i++) {
         if (!janet_checktype(dict[i].key, JANET_NIL)) {
             index_buffer[next_index++] = i;
         }
     }
 
     /* Next, sort those (simple insertion sort here for now) */
-    for (int32_t i = 1; i < next_index; i++) {
+    for (size_t i = 1; i < next_index; i++) {
         int32_t index_to_insert = index_buffer[i];
         Janet lhs = dict[index_to_insert].key;
-        for (int32_t j = i - 1; j >= 0; j--) {
+        for (size_t j = i - 1; j >= 0; j--) {
             index_buffer[j + 1] = index_buffer[j];
             Janet rhs = dict[index_buffer[j]].key;
             if (janet_compare(lhs, rhs) >= 0) {

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -690,7 +690,7 @@ static JanetByteView to_byte_view(Janet value) {
 JanetByteView janet_text_substitution(
     Janet *subst,
     const uint8_t *bytes,
-    uint32_t len,
+    size_t len,
     JanetArray *extra_argv) {
     int32_t extra_argc = extra_argv == NULL ? 0 : extra_argv->count;
     JanetType type = janet_type(*subst);

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -117,7 +117,7 @@ const char *const janet_status_names[16] = {
 
 #ifndef JANET_PRF
 
-int32_t janet_string_calchash(const uint8_t *str, int32_t len) {
+int32_t janet_string_calchash(const uint8_t *str, size_t len) {
     if (NULL == str) return 5381;
     const uint8_t *end = str + len;
     uint32_t hash = 5381;
@@ -230,7 +230,7 @@ void janet_init_hash_key(uint8_t new_key[JANET_HASH_KEY_SIZE]) {
 
 /* Calculate hash for string */
 
-int32_t janet_string_calchash(const uint8_t *str, int32_t len) {
+int32_t janet_string_calchash(const uint8_t *str, size_t len) {
     uint32_t hash;
     hash = halfsiphash(str, len, hash_key);
     return (int32_t)hash;
@@ -244,7 +244,7 @@ uint32_t janet_hash_mix(uint32_t input, uint32_t more) {
 }
 
 /* Computes hash of an array of values */
-int32_t janet_array_calchash(const Janet *array, int32_t len) {
+int32_t janet_array_calchash(const Janet *array, size_t len) {
     const Janet *end = array + len;
     uint32_t hash = 33;
     while (array < end) {
@@ -254,7 +254,7 @@ int32_t janet_array_calchash(const Janet *array, int32_t len) {
 }
 
 /* Computes hash of an array of values */
-int32_t janet_kv_calchash(const JanetKV *kvs, int32_t len) {
+int32_t janet_kv_calchash(const JanetKV *kvs, size_t len) {
     const JanetKV *end = kvs + len;
     uint32_t hash = 33;
     while (kvs < end) {
@@ -284,9 +284,9 @@ void safe_memcpy(void *dest, const void *src, size_t len) {
 
 /* Helper to find a value in a Janet struct or table. Returns the bucket
  * containing the key, or the first empty bucket if there is no such key. */
-const JanetKV *janet_dict_find(const JanetKV *buckets, int32_t cap, Janet key) {
+const JanetKV *janet_dict_find(const JanetKV *buckets, size_t cap, Janet key) {
     int32_t index = janet_maphash(cap, janet_hash(key));
-    int32_t i;
+    size_t i;
     const JanetKV *first_bucket = NULL;
     /* Higher half */
     for (i = index; i < cap; i++) {
@@ -318,7 +318,7 @@ const JanetKV *janet_dict_find(const JanetKV *buckets, int32_t cap, Janet key) {
 }
 
 /* Get a value from a janet struct or table. */
-Janet janet_dictionary_get(const JanetKV *data, int32_t cap, Janet key) {
+Janet janet_dictionary_get(const JanetKV *data, size_t cap, Janet key) {
     const JanetKV *kv = janet_dict_find(data, cap, key);
     if (kv && !janet_checktype(kv->key, JANET_NIL)) {
         return kv->value;
@@ -327,7 +327,7 @@ Janet janet_dictionary_get(const JanetKV *data, int32_t cap, Janet key) {
 }
 
 /* Iterate through a struct or dictionary generically */
-const JanetKV *janet_dictionary_next(const JanetKV *kvs, int32_t cap, const JanetKV *kv) {
+const JanetKV *janet_dictionary_next(const JanetKV *kvs, size_t cap, const JanetKV *kv) {
     const JanetKV *end = kvs + cap;
     kv = (kv == NULL) ? kvs : kv + 1;
     while (kv < end) {
@@ -740,7 +740,7 @@ Janet janet_resolve_core(const char *name) {
 
 /* Read both tuples and arrays as c pointers + int32_t length. Return 1 if the
  * view can be constructed, 0 if an invalid type. */
-int janet_indexed_view(Janet seq, const Janet **data, int32_t *len) {
+int janet_indexed_view(Janet seq, const Janet **data, size_t *len) {
     if (janet_checktype(seq, JANET_ARRAY)) {
         *data = janet_unwrap_array(seq)->data;
         *len = janet_unwrap_array(seq)->count;
@@ -755,7 +755,7 @@ int janet_indexed_view(Janet seq, const Janet **data, int32_t *len) {
 
 /* Read both strings and buffer as unsigned character array + int32_t len.
  * Returns 1 if the view can be constructed and 0 if the type is invalid. */
-int janet_bytes_view(Janet str, const uint8_t **data, int32_t *len) {
+int janet_bytes_view(Janet str, const uint8_t **data, size_t *len) {
     JanetType t = janet_type(str);
     if (t == JANET_STRING || t == JANET_SYMBOL || t == JANET_KEYWORD) {
         *data = janet_unwrap_string(str);
@@ -782,7 +782,7 @@ int janet_bytes_view(Janet str, const uint8_t **data, int32_t *len) {
 /* Read both structs and tables as the entries of a hashtable with
  * identical structure. Returns 1 if the view can be constructed and
  * 0 if the type is invalid. */
-int janet_dictionary_view(Janet tab, const JanetKV **data, int32_t *len, int32_t *cap) {
+int janet_dictionary_view(Janet tab, const JanetKV **data, size_t *len, size_t *cap) {
     if (janet_checktype(tab, JANET_TABLE)) {
         *data = janet_unwrap_table(tab)->data;
         *cap = janet_unwrap_table(tab)->capacity;

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -66,18 +66,18 @@
 /* Utils */
 uint32_t janet_hash_mix(uint32_t input, uint32_t more);
 #define janet_maphash(cap, hash) ((uint32_t)(hash) & (cap - 1))
-int janet_valid_utf8(const uint8_t *str, int32_t len);
+int janet_valid_utf8(const uint8_t *str, size_t len);
 int janet_is_symbol_char(uint8_t c);
 extern const char janet_base64[65];
-int32_t janet_array_calchash(const Janet *array, int32_t len);
-int32_t janet_kv_calchash(const JanetKV *kvs, int32_t len);
-int32_t janet_string_calchash(const uint8_t *str, int32_t len);
-int32_t janet_tablen(int32_t n);
+int32_t janet_array_calchash(const Janet *array, size_t len);
+int32_t janet_kv_calchash(const JanetKV *kvs, size_t len);
+int32_t janet_string_calchash(const uint8_t *str, size_t len);
+size_t janet_tablen(size_t n);
 void safe_memcpy(void *dest, const void *src, size_t len);
 void janet_buffer_push_types(JanetBuffer *buffer, int types);
-const JanetKV *janet_dict_find(const JanetKV *buckets, int32_t cap, Janet key);
-void janet_memempty(JanetKV *mem, int32_t count);
-void *janet_memalloc_empty(int32_t count);
+const JanetKV *janet_dict_find(const JanetKV *buckets, size_t cap, Janet key);
+void janet_memempty(JanetKV *mem, size_t count);
+void *janet_memalloc_empty(size_t count);
 JanetTable *janet_get_core_table(const char *name);
 void janet_def_addflags(JanetFuncDef *def);
 const void *janet_strbinsearch(

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -96,7 +96,7 @@ JanetBinding janet_binding_from_entry(Janet entry);
 JanetByteView janet_text_substitution(
     Janet *subst,
     const uint8_t *bytes,
-    uint32_t len,
+    size_t len,
     JanetArray *extra_args);
 
 /* Registry functions */

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -72,7 +72,7 @@ extern const char janet_base64[65];
 int32_t janet_array_calchash(const Janet *array, size_t len);
 int32_t janet_kv_calchash(const JanetKV *kvs, size_t len);
 int32_t janet_string_calchash(const uint8_t *str, size_t len);
-size_t janet_tablen(size_t n);
+uint64_t janet_tablen(uint64_t n);
 void safe_memcpy(void *dest, const void *src, size_t len);
 void janet_buffer_push_types(JanetBuffer *buffer, int types);
 const JanetKV *janet_dict_find(const JanetKV *buckets, size_t cap, Janet key);

--- a/src/core/value.c
+++ b/src/core/value.c
@@ -667,7 +667,7 @@ size_t janet_length(Janet x) {
             const JanetAbstractType *type = janet_abstract_type(abst);
             if (type->length != NULL) {
                 size_t len = type->length(abst, janet_abstract_size(abst));
-                if (len > JANET_INTMAX_INT64) {
+                if (len > JANET_INTMAX_SIZE) {
                     janet_panicf("invalid integer length %u", len);
                 }
                 return len;
@@ -771,7 +771,7 @@ void janet_put(Janet ds, Janet key, Janet value) {
                          JANET_TFLAG_ARRAY | JANET_TFLAG_BUFFER | JANET_TFLAG_TABLE, ds);
         case JANET_ARRAY: {
             JanetArray *array = janet_unwrap_array(ds);
-            size_t index = getter_checksize(type, key, JANET_INTMAX_INT64 - 1);
+            size_t index = getter_checksize(type, key, JANET_INTMAX_SIZE - 1);
             if (index >= array->count) {
                 janet_array_setcount(array, index + 1);
             }
@@ -780,7 +780,7 @@ void janet_put(Janet ds, Janet key, Janet value) {
         }
         case JANET_BUFFER: {
             JanetBuffer *buffer = janet_unwrap_buffer(ds);
-            size_t index = getter_checksize(type, key, JANET_INTMAX_INT64 - 1);
+            size_t index = getter_checksize(type, key, JANET_INTMAX_SIZE - 1);
             if (!janet_checkint(value))
                 janet_panicf("can only put integers in buffers, got %v", value);
             if (index >= buffer->count) {

--- a/src/core/value.c
+++ b/src/core/value.c
@@ -439,16 +439,6 @@ int janet_compare(Janet x, Janet y) {
     return status - 2;
 }
 
-static int32_t getter_checkint(JanetType type, Janet key, int32_t max) {
-    if (!janet_checkint(key)) goto bad;
-    int32_t ret = janet_unwrap_integer(key);
-    if (ret < 0) goto bad;
-    if (ret >= max) goto bad;
-    return ret;
-bad:
-    janet_panicf("expected integer key for %s in range [0, %d), got %v", janet_type_names[type], max, key);
-}
-
 static size_t getter_checksize(JanetType type, Janet key, size_t max) {
     if (!janet_checksize(key)) goto bad;
     size_t ret = janet_unwrap_size(key);

--- a/src/core/value.c
+++ b/src/core/value.c
@@ -179,7 +179,7 @@ Janet janet_next_impl(Janet ds, Janet key, int is_interpreter) {
             } else {
                 len = janet_string_length(janet_unwrap_string(ds));
             }
-            if (i < len && i >= 0) {
+            if (i < len) {
                 return janet_wrap_size(i);
             }
             break;
@@ -530,7 +530,6 @@ Janet janet_get(Janet ds, Janet key) {
         case JANET_KEYWORD: {
             if (!janet_checksize(key)) return janet_wrap_nil();
             size_t index = janet_unwrap_size(key);
-            if (index < 0) return janet_wrap_nil();
             const uint8_t *str = janet_unwrap_string(ds);
             if (index >= janet_string_length(str)) return janet_wrap_nil();
             return janet_wrap_integer(str[index]);
@@ -549,7 +548,6 @@ Janet janet_get(Janet ds, Janet key) {
         case JANET_BUFFER: {
             if (!janet_checkint(key)) return janet_wrap_nil();
             size_t index = janet_unwrap_size(key);
-            if (index < 0) return janet_wrap_nil();
             if (t == JANET_ARRAY) {
                 JanetArray *a = janet_unwrap_array(ds);
                 if (index >= a->count) return janet_wrap_nil();
@@ -584,7 +582,6 @@ Janet janet_get(Janet ds, Janet key) {
 
 Janet janet_getindex(Janet ds, size_t index) {
     Janet value;
-    if (index < 0) janet_panic("expected non-negative index");
     switch (janet_type(ds)) {
         default:
             janet_panicf("expected %T, got %v", JANET_TFLAG_LENGTHABLE, ds);

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -997,7 +997,7 @@ static JanetSignal run_vm(JanetFiber *fiber, Janet in) {
 
     VM_OP(JOP_PUSH_ARRAY) {
         const Janet *vals;
-        int32_t len;
+        size_t len;
         if (janet_indexed_view(stack[D], &vals, &len)) {
             janet_fiber_pushn(fiber, vals, len);
         } else {

--- a/src/core/wrap.c
+++ b/src/core/wrap.c
@@ -88,6 +88,12 @@ int (janet_unwrap_boolean)(Janet x) {
 int32_t (janet_unwrap_integer)(Janet x) {
     return janet_unwrap_integer(x);
 }
+size_t (janet_unwrap_size)(Janet x) {
+    return janet_unwrap_size(x);
+}
+ssize_t (janet_unwrap_ssize)(Janet x) {
+    return janet_unwrap_ssize(x);
+}
 
 #if defined(JANET_NANBOX_32) || defined(JANET_NANBOX_64)
 Janet(janet_wrap_nil)(void) {
@@ -143,6 +149,12 @@ Janet(janet_wrap_pointer)(void *x) {
 }
 Janet(janet_wrap_integer)(int32_t x) {
     return janet_wrap_integer(x);
+}
+Janet(janet_wrap_size)(size_t x) {
+    return janet_wrap_size(x);
+}
+Janet(janet_wrap_ssize)(ssize_t x) {
+    return janet_wrap_ssize(x);
 }
 #endif
 

--- a/src/core/wrap.c
+++ b/src/core/wrap.c
@@ -160,10 +160,10 @@ Janet(janet_wrap_number)(double x) {
 
 /*****/
 
-void *janet_memalloc_empty(int32_t count) {
-    int32_t i;
-    void *mem = janet_malloc((size_t) count * sizeof(JanetKV));
-    janet_vm.next_collection += (size_t) count * sizeof(JanetKV);
+void *janet_memalloc_empty(size_t count) {
+    size_t i;
+    void *mem = janet_malloc(count * sizeof(JanetKV));
+    janet_vm.next_collection += count * sizeof(JanetKV);
     if (NULL == mem) {
         JANET_OUT_OF_MEMORY;
     }
@@ -176,8 +176,8 @@ void *janet_memalloc_empty(int32_t count) {
     return mem;
 }
 
-void janet_memempty(JanetKV *mem, int32_t count) {
-    int32_t i;
+void janet_memempty(JanetKV *mem, size_t count) {
+    size_t i;
     for (i = 0; i < count; i++) {
         mem[i].key = janet_wrap_nil();
         mem[i].value = janet_wrap_nil();

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -148,6 +148,13 @@ extern "C" {
 #define JANET_INTMIN_DOUBLE (-9007199254740992.0)
 #define JANET_INTMAX_INT64 9007199254740992
 #define JANET_INTMIN_INT64 (-9007199254740992)
+#if defined(JANET_64)
+    #define JANET_INTMAX_SIZE JANET_INTMAX_INT64
+    #define JANET_INTMIN_SIZE JANET_INTMIN_INT64
+#else
+    #define JANET_INTMAX_SIZE 4294967295
+    #define JANET_INTMIN_SIZE (-4294967295)
+#endif
 
 /* Check emscripten */
 #ifdef __EMSCRIPTEN__
@@ -371,6 +378,9 @@ typedef struct JanetOSRWLock JanetOSRWLock;
 #include <setjmp.h>
 #include <stddef.h>
 #include <stdio.h>
+
+/* signed size */
+typedef ptrdiff_t ssize_t;
 
 /* What to do when out of memory */
 #ifndef JANET_OUT_OF_MEMORY
@@ -895,16 +905,20 @@ JANET_API int janet_checkuint(Janet x);
 JANET_API int janet_checkint64(Janet x);
 JANET_API int janet_checkuint64(Janet x);
 JANET_API int janet_checksize(Janet x);
+JANET_API int janet_checkssize(Janet x);
 JANET_API JanetAbstract janet_checkabstract(Janet x, const JanetAbstractType *at);
 #define janet_checkintrange(x) ((x) >= INT32_MIN && (x) <= INT32_MAX && (x) == (int32_t)(x))
 #define janet_checkuintrange(x) ((x) >= 0 && (x) <= UINT32_MAX && (x) == (uint32_t)(x))
 #define janet_checkint64range(x) ((x) >= JANET_INTMIN_DOUBLE && (x) <= JANET_INTMAX_DOUBLE && (x) == (int64_t)(x))
 #define janet_checkuint64range(x) ((x) >= 0 && (x) <= JANET_INTMAX_DOUBLE && (x) == (uint64_t)(x))
-#define janet_checksizerange(x) ((x) >= 0 && (x) <= JANET_INTMAX_INT64 && (x) == (size_t)(x))
+#define janet_checksizerange(x) ((x) >= 0 && (x) <= JANET_INTMAX_SIZE && (x) == (size_t)(x))
+#define janet_checkssizerange(x) ((x) >= JANET_INTMIN_SIZE && (x) <= JANET_INTMAX_SIZE && (x) == (ssize_t)(x))
 #define janet_unwrap_integer(x) ((int32_t) janet_unwrap_number(x))
 #define janet_wrap_integer(x) janet_wrap_number((int32_t)(x))
 #define janet_unwrap_size(x) ((size_t) janet_unwrap_number(x))
 #define janet_wrap_size(x) janet_wrap_number((size_t)(x))
+#define janet_unwrap_ssize(x) ((ssize_t) janet_unwrap_number(x))
+#define janet_wrap_ssize(x) janet_wrap_number((ssize_t)(x))
 
 #define janet_checktypes(x, tps) ((1 << janet_type(x)) & (tps))
 
@@ -2019,6 +2033,7 @@ JANET_API int32_t janet_getinteger(const Janet *argv, int32_t n);
 JANET_API int64_t janet_getinteger64(const Janet *argv, int32_t n);
 JANET_API uint64_t janet_getuinteger64(const Janet *argv, int32_t n);
 JANET_API size_t janet_getsize(const Janet *argv, int32_t n);
+JANET_API ssize_t janet_getssize(const Janet *argv, int32_t n);
 JANET_API JanetView janet_getindexed(const Janet *argv, int32_t n);
 JANET_API JanetByteView janet_getbytes(const Janet *argv, int32_t n);
 JANET_API JanetDictView janet_getdictionary(const Janet *argv, int32_t n);
@@ -2048,6 +2063,7 @@ JANET_API int32_t janet_optnat(const Janet *argv, int32_t argc, int32_t n, int32
 JANET_API int32_t janet_optinteger(const Janet *argv, int32_t argc, int32_t n, int32_t dflt);
 JANET_API int64_t janet_optinteger64(const Janet *argv, int32_t argc, int32_t n, int64_t dflt);
 JANET_API size_t janet_optsize(const Janet *argv, int32_t argc, int32_t n, size_t dflt);
+JANET_API ssize_t janet_optssize(const Janet *argv, int32_t argc, int32_t n, ssize_t dflt);
 JANET_API JanetAbstract janet_optabstract(const Janet *argv, int32_t argc, int32_t n, const JanetAbstractType *at, JanetAbstract dflt);
 
 /* Mutable optional types specify a size default, and construct a new value if none is provided */

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -380,7 +380,11 @@ typedef struct JanetOSRWLock JanetOSRWLock;
 #include <stdio.h>
 
 /* signed size */
+#ifdef _SSIZE_T
+typedef ssize_t ssize_t;
+#else
 typedef ptrdiff_t ssize_t;
+#endif
 
 /* What to do when out of memory */
 #ifndef JANET_OUT_OF_MEMORY

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -973,8 +973,8 @@ struct JanetArray {
 /* A byte buffer type. Used as a mutable string or string builder. */
 struct JanetBuffer {
     JanetGCObject gc;
-    int32_t count;
-    int32_t capacity;
+    size_t count;
+    size_t capacity;
     uint8_t *data;
 };
 

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -143,19 +143,6 @@ extern "C" {
 #define JANET_LITTLE_ENDIAN 1
 #endif
 
-/* Limits for converting doubles to 64 bit integers */
-#define JANET_INTMAX_DOUBLE 9007199254740992.0
-#define JANET_INTMIN_DOUBLE (-9007199254740992.0)
-#define JANET_INTMAX_INT64 9007199254740992
-#define JANET_INTMIN_INT64 (-9007199254740992)
-#if defined(JANET_64)
-    #define JANET_INTMAX_SIZE JANET_INTMAX_INT64
-    #define JANET_INTMIN_SIZE JANET_INTMIN_INT64
-#else
-    #define JANET_INTMAX_SIZE 4294967295
-    #define JANET_INTMIN_SIZE (-4294967295)
-#endif
-
 /* Check emscripten */
 #ifdef __EMSCRIPTEN__
 #define JANET_NO_DYNAMIC_MODULES
@@ -378,6 +365,19 @@ typedef struct JanetOSRWLock JanetOSRWLock;
 #include <setjmp.h>
 #include <stddef.h>
 #include <stdio.h>
+
+/* Limits for converting doubles to 64 bit integers */
+#define JANET_INTMAX_DOUBLE 9007199254740992.0
+#define JANET_INTMIN_DOUBLE (-9007199254740992.0)
+#define JANET_INTMAX_INT64 9007199254740992
+#define JANET_INTMIN_INT64 (-9007199254740992)
+#if defined(JANET_64)
+    #define JANET_INTMAX_SIZE JANET_INTMAX_INT64
+    #define JANET_INTMIN_SIZE JANET_INTMIN_INT64
+#else
+    #define JANET_INTMAX_SIZE INT32_MAX
+    #define JANET_INTMIN_SIZE INT32_MIN
+#endif
 
 /* signed size */
 #ifdef _SSIZE_T

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -717,6 +717,8 @@ JANET_API JanetCFunction janet_unwrap_cfunction(Janet x);
 JANET_API int janet_unwrap_boolean(Janet x);
 JANET_API double janet_unwrap_number(Janet x);
 JANET_API int32_t janet_unwrap_integer(Janet x);
+JANET_API size_t janet_unwrap_size(Janet x);
+JANET_API ssize_t janet_unwrap_ssize(Janet x);
 
 JANET_API Janet janet_wrap_nil(void);
 JANET_API Janet janet_wrap_number(double x);
@@ -737,6 +739,8 @@ JANET_API Janet janet_wrap_table(JanetTable *x);
 JANET_API Janet janet_wrap_abstract(JanetAbstract x);
 JANET_API Janet janet_wrap_pointer(void *x);
 JANET_API Janet janet_wrap_integer(int32_t x);
+JANET_API Janet janet_wrap_size(size_t x);
+JANET_API Janet janet_wrap_ssize(ssize_t x);
 
 /***** END SECTION NON-C API *****/
 
@@ -942,11 +946,11 @@ struct JanetGCObject {
 struct JanetFiber {
     JanetGCObject gc; /* GC Object stuff */
     int32_t flags; /* More flags */
-    size_t frame; /* Index of the stack frame */
-    size_t stackstart; /* Beginning of next args */
-    size_t stacktop; /* Top of stack. Where values are pushed and popped from. */
-    size_t capacity; /* How big is the stack memory */
-    size_t maxstack; /* Arbitrary defined limit for stack overflow */
+    int32_t frame; /* Index of the stack frame */
+    int32_t stackstart; /* Beginning of next args */
+    int32_t stacktop; /* Top of stack. Where values are pushed and popped from. */
+    int32_t capacity; /* How big is the stack memory */
+    int32_t maxstack; /* Arbitrary defined limit for stack overflow */
     JanetTable *env; /* Dynamic bindings table (usually current environment). */
     Janet *data; /* Dynamically resized stack memory */
     JanetFiber *child; /* Keep linked list of fibers for restarting pending fibers */
@@ -1734,7 +1738,7 @@ JANET_API JanetTable *janet_table_clone(JanetTable *table);
 JANET_API void janet_table_clear(JanetTable *table);
 
 /* Fiber */
-JANET_API JanetFiber *janet_fiber(JanetFunction *callee, size_t capacity, int32_t argc, const Janet *argv);
+JANET_API JanetFiber *janet_fiber(JanetFunction *callee, int32_t capacity, int32_t argc, const Janet *argv);
 JANET_API JanetFiber *janet_fiber_reset(JanetFiber *fiber, JanetFunction *callee, int32_t argc, const Janet *argv);
 JANET_API JanetFiberStatus janet_fiber_status(JanetFiber *fiber);
 JANET_API int janet_fiber_can_resume(JanetFiber *fiber);

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -924,11 +924,11 @@ struct JanetGCObject {
 struct JanetFiber {
     JanetGCObject gc; /* GC Object stuff */
     int32_t flags; /* More flags */
-    int32_t frame; /* Index of the stack frame */
-    int32_t stackstart; /* Beginning of next args */
-    int32_t stacktop; /* Top of stack. Where values are pushed and popped from. */
+    size_t frame; /* Index of the stack frame */
+    size_t stackstart; /* Beginning of next args */
+    size_t stacktop; /* Top of stack. Where values are pushed and popped from. */
     size_t capacity; /* How big is the stack memory */
-    int32_t maxstack; /* Arbitrary defined limit for stack overflow */
+    size_t maxstack; /* Arbitrary defined limit for stack overflow */
     JanetTable *env; /* Dynamic bindings table (usually current environment). */
     Janet *data; /* Dynamically resized stack memory */
     JanetFiber *child; /* Keep linked list of fibers for restarting pending fibers */
@@ -1658,7 +1658,7 @@ JANET_API JanetString janet_string(const uint8_t *buf, size_t len);
 JANET_API JanetString janet_cstring(const char *cstring);
 JANET_API int janet_string_compare(JanetString lhs, JanetString rhs);
 JANET_API int janet_string_equal(JanetString lhs, JanetString rhs);
-JANET_API int janet_string_equalconst(JanetString lhs, const uint8_t *rhs, size_t rlen, size_t rhash);
+JANET_API int janet_string_equalconst(JanetString lhs, const uint8_t *rhs, size_t rlen, int32_t rhash);
 JANET_API JanetString janet_description(Janet x);
 JANET_API JanetString janet_to_string(Janet x);
 JANET_API void janet_to_string_b(JanetBuffer *buffer, Janet x);
@@ -1808,13 +1808,13 @@ JANET_API Janet janet_getindex(Janet ds, size_t index);
 JANET_API size_t janet_length(Janet x);
 JANET_API Janet janet_lengthv(Janet x);
 JANET_API void janet_put(Janet ds, Janet key, Janet value);
-JANET_API void janet_putindex(Janet ds, int32_t index, Janet value);
+JANET_API void janet_putindex(Janet ds, size_t index, Janet value);
 #define janet_flag_at(F, I) ((F) & ((1ULL) << (I)))
 JANET_API Janet janet_wrap_number_safe(double x);
 JANET_API int janet_keyeq(Janet x, const char *cstring);
 JANET_API int janet_streq(Janet x, const char *cstring);
 JANET_API int janet_symeq(Janet x, const char *cstring);
-JANET_API int32_t janet_sorted_keys(const JanetKV *dict, int32_t cap, int32_t *index_buffer);
+JANET_API int32_t janet_sorted_keys(const JanetKV *dict, size_t cap, int32_t *index_buffer);
 
 /* VM functions */
 JANET_API int janet_init(void);
@@ -2051,9 +2051,9 @@ JANET_API size_t janet_optsize(const Janet *argv, int32_t argc, int32_t n, size_
 JANET_API JanetAbstract janet_optabstract(const Janet *argv, int32_t argc, int32_t n, const JanetAbstractType *at, JanetAbstract dflt);
 
 /* Mutable optional types specify a size default, and construct a new value if none is provided */
-JANET_API JanetBuffer *janet_optbuffer(const Janet *argv, int32_t argc, int32_t n, int32_t dflt_len);
-JANET_API JanetTable *janet_opttable(const Janet *argv, int32_t argc, int32_t n, int32_t dflt_len);
-JANET_API JanetArray *janet_optarray(const Janet *argv, int32_t argc, int32_t n, int32_t dflt_len);
+JANET_API JanetBuffer *janet_optbuffer(const Janet *argv, int32_t argc, int32_t n, size_t dflt_len);
+JANET_API JanetTable *janet_opttable(const Janet *argv, int32_t argc, int32_t n, size_t dflt_len);
+JANET_API JanetArray *janet_optarray(const Janet *argv, int32_t argc, int32_t n, size_t dflt_len);
 
 JANET_API Janet janet_dyn(const char *name);
 JANET_API void janet_setdyn(const char *name, Janet value);

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -965,8 +965,8 @@ struct JanetStackFrame {
 /* A dynamic array type. */
 struct JanetArray {
     JanetGCObject gc;
-    int32_t count;
-    int32_t capacity;
+    size_t count;
+    size_t capacity;
     Janet *data;
 };
 

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1017,7 +1017,7 @@ struct JanetStructHead {
 /* Prefix for a string */
 struct JanetStringHead {
     JanetGCObject gc;
-    int32_t length;
+    size_t length;
     int32_t hash;
     const uint8_t data[];
 };
@@ -1649,13 +1649,13 @@ JANET_API JanetTuple janet_tuple_n(const Janet *values, size_t n);
 #define janet_string_head(s) ((JanetStringHead *)((char *)s - offsetof(JanetStringHead, data)))
 #define janet_string_length(s) (janet_string_head(s)->length)
 #define janet_string_hash(s) (janet_string_head(s)->hash)
-JANET_API uint8_t *janet_string_begin(int32_t length);
+JANET_API uint8_t *janet_string_begin(size_t length);
 JANET_API JanetString janet_string_end(uint8_t *str);
-JANET_API JanetString janet_string(const uint8_t *buf, int32_t len);
+JANET_API JanetString janet_string(const uint8_t *buf, size_t len);
 JANET_API JanetString janet_cstring(const char *cstring);
 JANET_API int janet_string_compare(JanetString lhs, JanetString rhs);
 JANET_API int janet_string_equal(JanetString lhs, JanetString rhs);
-JANET_API int janet_string_equalconst(JanetString lhs, const uint8_t *rhs, int32_t rlen, int32_t rhash);
+JANET_API int janet_string_equalconst(JanetString lhs, const uint8_t *rhs, size_t rlen, size_t rhash);
 JANET_API JanetString janet_description(Janet x);
 JANET_API JanetString janet_to_string(Janet x);
 JANET_API void janet_to_string_b(JanetBuffer *buffer, Janet x);

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1604,25 +1604,25 @@ JANET_API uint32_t janet_rng_u32(JanetRNG *rng);
 JANET_API double janet_rng_double(JanetRNG *rng);
 
 /* Array functions */
-JANET_API JanetArray *janet_array(int32_t capacity);
-JANET_API JanetArray *janet_array_weak(int32_t capacity);
-JANET_API JanetArray *janet_array_n(const Janet *elements, int32_t n);
-JANET_API void janet_array_ensure(JanetArray *array, int32_t capacity, int32_t growth);
-JANET_API void janet_array_setcount(JanetArray *array, int32_t count);
+JANET_API JanetArray *janet_array(size_t capacity);
+JANET_API JanetArray *janet_array_weak(size_t capacity);
+JANET_API JanetArray *janet_array_n(const Janet *elements, size_t n);
+JANET_API void janet_array_ensure(JanetArray *array, size_t capacity, size_t growth);
+JANET_API void janet_array_setcount(JanetArray *array, size_t count);
 JANET_API void janet_array_push(JanetArray *array, Janet x);
 JANET_API Janet janet_array_pop(JanetArray *array);
 JANET_API Janet janet_array_peek(JanetArray *array);
 
 /* Buffer functions */
 #define JANET_BUFFER_FLAG_NO_REALLOC 0x10000
-JANET_API JanetBuffer *janet_buffer(int32_t capacity);
-JANET_API JanetBuffer *janet_buffer_init(JanetBuffer *buffer, int32_t capacity);
-JANET_API JanetBuffer *janet_pointer_buffer_unsafe(void *memory, int32_t capacity, int32_t count);
+JANET_API JanetBuffer *janet_buffer(size_t capacity);
+JANET_API JanetBuffer *janet_buffer_init(JanetBuffer *buffer, size_t capacity);
+JANET_API JanetBuffer *janet_pointer_buffer_unsafe(void *memory, size_t capacity, size_t count);
 JANET_API void janet_buffer_deinit(JanetBuffer *buffer);
-JANET_API void janet_buffer_ensure(JanetBuffer *buffer, int32_t capacity, int32_t growth);
-JANET_API void janet_buffer_setcount(JanetBuffer *buffer, int32_t count);
-JANET_API void janet_buffer_extra(JanetBuffer *buffer, int32_t n);
-JANET_API void janet_buffer_push_bytes(JanetBuffer *buffer, const uint8_t *string, int32_t len);
+JANET_API void janet_buffer_ensure(JanetBuffer *buffer, size_t capacity, size_t growth);
+JANET_API void janet_buffer_setcount(JanetBuffer *buffer, size_t count);
+JANET_API void janet_buffer_extra(JanetBuffer *buffer, size_t n);
+JANET_API void janet_buffer_push_bytes(JanetBuffer *buffer, const uint8_t *string, size_t len);
 JANET_API void janet_buffer_push_string(JanetBuffer *buffer, JanetString string);
 JANET_API void janet_buffer_push_cstring(JanetBuffer *buffer, const char *cstring);
 JANET_API void janet_buffer_push_u8(JanetBuffer *buffer, uint8_t x);
@@ -1696,9 +1696,9 @@ JANET_API JanetTable *janet_struct_to_table(JanetStruct st);
 JANET_API const JanetKV *janet_struct_find(JanetStruct st, Janet key);
 
 /* Table functions */
-JANET_API JanetTable *janet_table(int32_t capacity);
-JANET_API JanetTable *janet_table_init(JanetTable *table, int32_t capacity);
-JANET_API JanetTable *janet_table_init_raw(JanetTable *table, int32_t capacity);
+JANET_API JanetTable *janet_table(size_t capacity);
+JANET_API JanetTable *janet_table_init(JanetTable *table, size_t capacity);
+JANET_API JanetTable *janet_table_init_raw(JanetTable *table, size_t capacity);
 JANET_API void janet_table_deinit(JanetTable *table);
 JANET_API Janet janet_table_get(JanetTable *t, Janet key);
 JANET_API Janet janet_table_get_ex(JanetTable *t, Janet key, JanetTable **which);

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -900,8 +900,11 @@ JANET_API JanetAbstract janet_checkabstract(Janet x, const JanetAbstractType *at
 #define janet_checkuintrange(x) ((x) >= 0 && (x) <= UINT32_MAX && (x) == (uint32_t)(x))
 #define janet_checkint64range(x) ((x) >= JANET_INTMIN_DOUBLE && (x) <= JANET_INTMAX_DOUBLE && (x) == (int64_t)(x))
 #define janet_checkuint64range(x) ((x) >= 0 && (x) <= JANET_INTMAX_DOUBLE && (x) == (uint64_t)(x))
+#define janet_checksizerange(x) ((x) >= 0 && (x) <= JANET_INTMAX_INT64 && (x) == (size_t)(x))
 #define janet_unwrap_integer(x) ((int32_t) janet_unwrap_number(x))
 #define janet_wrap_integer(x) janet_wrap_number((int32_t)(x))
+#define janet_unwrap_size(x) ((size_t) janet_unwrap_number(x))
+#define janet_wrap_size(x) janet_wrap_number((size_t)(x))
 
 #define janet_checktypes(x, tps) ((1 << janet_type(x)) & (tps))
 
@@ -1201,18 +1204,18 @@ struct JanetMethod {
 
 struct JanetView {
     const Janet *items;
-    int32_t len;
+    size_t len;
 };
 
 struct JanetByteView {
     const uint8_t *bytes;
-    int32_t len;
+    size_t len;
 };
 
 struct JanetDictView {
     const JanetKV *kvs;
-    int32_t len;
-    int32_t cap;
+    size_t len;
+    size_t cap;
 };
 
 struct JanetRange {
@@ -1576,17 +1579,17 @@ JANET_API JanetTable *janet_core_env(JanetTable *replacements);
 JANET_API JanetTable *janet_core_lookup_table(JanetTable *replacements);
 
 /* Execute strings */
-JANET_API int janet_dobytes(JanetTable *env, const uint8_t *bytes, int32_t len, const char *sourcePath, Janet *out);
+JANET_API int janet_dobytes(JanetTable *env, const uint8_t *bytes, size_t len, const char *sourcePath, Janet *out);
 JANET_API int janet_dostring(JanetTable *env, const char *str, const char *sourcePath, Janet *out);
 
 /* Run the entrypoint of a wrapped program */
 JANET_API int janet_loop_fiber(JanetFiber *fiber);
 
 /* Number scanning */
-JANET_API int janet_scan_number(const uint8_t *str, int32_t len, double *out);
-JANET_API int janet_scan_number_base(const uint8_t *str, int32_t len, int32_t base, double *out);
-JANET_API int janet_scan_int64(const uint8_t *str, int32_t len, int64_t *out);
-JANET_API int janet_scan_uint64(const uint8_t *str, int32_t len, uint64_t *out);
+JANET_API int janet_scan_number(const uint8_t *str, size_t len, double *out);
+JANET_API int janet_scan_number_base(const uint8_t *str, size_t len, int32_t base, double *out);
+JANET_API int janet_scan_int64(const uint8_t *str, size_t len, int64_t *out);
+JANET_API int janet_scan_uint64(const uint8_t *str, size_t len, uint64_t *out);
 
 /* Debugging */
 JANET_API void janet_debug_break(JanetFuncDef *def, int32_t pc);
@@ -1599,7 +1602,7 @@ JANET_API void janet_debug_find(
 extern JANET_API const JanetAbstractType janet_rng_type;
 JANET_API JanetRNG *janet_default_rng(void);
 JANET_API void janet_rng_seed(JanetRNG *rng, uint32_t seed);
-JANET_API void janet_rng_longseed(JanetRNG *rng, const uint8_t *bytes, int32_t len);
+JANET_API void janet_rng_longseed(JanetRNG *rng, const uint8_t *bytes, size_t len);
 JANET_API uint32_t janet_rng_u32(JanetRNG *rng);
 JANET_API double janet_rng_double(JanetRNG *rng);
 
@@ -1667,7 +1670,7 @@ JANET_API JanetBuffer *janet_formatb(JanetBuffer *bufp, const char *format, ...)
 JANET_API void janet_formatbv(JanetBuffer *bufp, const char *format, va_list args);
 
 /* Symbol functions */
-JANET_API JanetSymbol janet_symbol(const uint8_t *str, int32_t len);
+JANET_API JanetSymbol janet_symbol(const uint8_t *str, size_t len);
 JANET_API JanetSymbol janet_csymbol(const char *str);
 JANET_API JanetSymbol janet_symbol_gen(void);
 #define janet_symbolv(str, len) janet_wrap_symbol(janet_symbol((str), (len)))
@@ -1721,11 +1724,11 @@ JANET_API JanetFiber *janet_current_fiber(void);
 JANET_API JanetFiber *janet_root_fiber(void);
 
 /* Treat similar types through uniform interfaces for iteration */
-JANET_API int janet_indexed_view(Janet seq, const Janet **data, int32_t *len);
-JANET_API int janet_bytes_view(Janet str, const uint8_t **data, int32_t *len);
-JANET_API int janet_dictionary_view(Janet tab, const JanetKV **data, int32_t *len, int32_t *cap);
-JANET_API Janet janet_dictionary_get(const JanetKV *data, int32_t cap, Janet key);
-JANET_API const JanetKV *janet_dictionary_next(const JanetKV *kvs, int32_t cap, const JanetKV *kv);
+JANET_API int janet_indexed_view(Janet seq, const Janet **data, size_t *len);
+JANET_API int janet_bytes_view(Janet str, const uint8_t **data, size_t *len);
+JANET_API int janet_dictionary_view(Janet tab, const JanetKV **data, size_t *len, size_t *cap);
+JANET_API Janet janet_dictionary_get(const JanetKV *data, size_t cap, Janet key);
+JANET_API const JanetKV *janet_dictionary_next(const JanetKV *kvs, size_t cap, const JanetKV *kv);
 
 /* Abstract */
 #define janet_abstract_head(u) ((JanetAbstractHead *)((char *)u - offsetof(JanetAbstractHead, data)))
@@ -1801,8 +1804,8 @@ JANET_API int janet_cstrcmp(JanetString str, const char *other);
 JANET_API Janet janet_in(Janet ds, Janet key);
 JANET_API Janet janet_get(Janet ds, Janet key);
 JANET_API Janet janet_next(Janet ds, Janet key);
-JANET_API Janet janet_getindex(Janet ds, int32_t index);
-JANET_API int32_t janet_length(Janet x);
+JANET_API Janet janet_getindex(Janet ds, size_t index);
+JANET_API size_t janet_length(Janet x);
 JANET_API Janet janet_lengthv(Janet x);
 JANET_API void janet_put(Janet ds, Janet key, Janet value);
 JANET_API void janet_putindex(Janet ds, int32_t index, Janet value);
@@ -2171,8 +2174,8 @@ JANET_API Janet janet_wrap_s64(int64_t x);
 JANET_API Janet janet_wrap_u64(uint64_t x);
 JANET_API int64_t janet_unwrap_s64(Janet x);
 JANET_API uint64_t janet_unwrap_u64(Janet x);
-JANET_API int janet_scan_int64(const uint8_t *str, int32_t len, int64_t *out);
-JANET_API int janet_scan_uint64(const uint8_t *str, int32_t len, uint64_t *out);
+JANET_API int janet_scan_int64(const uint8_t *str, size_t len, int64_t *out);
+JANET_API int janet_scan_uint64(const uint8_t *str, size_t len, uint64_t *out);
 
 #endif
 

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -997,7 +997,7 @@ struct JanetKV {
 /* Prefix for a tuple */
 struct JanetTupleHead {
     JanetGCObject gc;
-    int32_t length;
+    size_t length;
     int32_t hash;
     int32_t sm_line;
     int32_t sm_column;
@@ -1641,9 +1641,9 @@ JANET_API void janet_buffer_push_u64(JanetBuffer *buffer, uint64_t x);
 #define janet_tuple_sm_line(t) (janet_tuple_head(t)->sm_line)
 #define janet_tuple_sm_column(t) (janet_tuple_head(t)->sm_column)
 #define janet_tuple_flag(t) (janet_tuple_head(t)->gc.flags)
-JANET_API Janet *janet_tuple_begin(int32_t length);
+JANET_API Janet *janet_tuple_begin(size_t length);
 JANET_API JanetTuple janet_tuple_end(Janet *tuple);
-JANET_API JanetTuple janet_tuple_n(const Janet *values, int32_t n);
+JANET_API JanetTuple janet_tuple_n(const Janet *values, size_t n);
 
 /* String/Symbol functions */
 #define janet_string_head(s) ((JanetStringHead *)((char *)s - offsetof(JanetStringHead, data)))

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1237,8 +1237,8 @@ struct JanetDictView {
 };
 
 struct JanetRange {
-    int32_t start;
-    int32_t end;
+    size_t start;
+    size_t end;
 };
 
 struct JanetRNG {
@@ -2043,10 +2043,10 @@ JANET_API JanetByteView janet_getbytes(const Janet *argv, int32_t n);
 JANET_API JanetDictView janet_getdictionary(const Janet *argv, int32_t n);
 JANET_API void *janet_getabstract(const Janet *argv, int32_t n, const JanetAbstractType *at);
 JANET_API JanetRange janet_getslice(int32_t argc, const Janet *argv);
-JANET_API int32_t janet_gethalfrange(const Janet *argv, int32_t n, int32_t length, const char *which);
-JANET_API int32_t janet_getstartrange(const Janet *argv, int32_t argc, int32_t n, int32_t length);
-JANET_API int32_t janet_getendrange(const Janet *argv, int32_t argc, int32_t n, int32_t length);
-JANET_API int32_t janet_getargindex(const Janet *argv, int32_t n, int32_t length, const char *which);
+JANET_API size_t janet_gethalfrange(const Janet *argv, int32_t n, size_t length, const char *which);
+JANET_API size_t janet_getstartrange(const Janet *argv, int32_t argc, int32_t n, size_t length);
+JANET_API size_t janet_getendrange(const Janet *argv, int32_t argc, int32_t n, size_t length);
+JANET_API size_t janet_getargindex(const Janet *argv, int32_t n, size_t length, const char *which);
 JANET_API uint64_t janet_getflags(const Janet *argv, int32_t n, const char *flags);
 
 /* Optionals */

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -981,9 +981,9 @@ struct JanetBuffer {
 /* A mutable associative data type. Backed by a hashtable. */
 struct JanetTable {
     JanetGCObject gc;
-    int32_t count;
-    int32_t capacity;
-    int32_t deleted;
+    size_t count;
+    size_t capacity;
+    size_t deleted;
     JanetKV *data;
     JanetTable *proto;
 };

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -924,7 +924,7 @@ struct JanetFiber {
     int32_t frame; /* Index of the stack frame */
     int32_t stackstart; /* Beginning of next args */
     int32_t stacktop; /* Top of stack. Where values are pushed and popped from. */
-    int32_t capacity; /* How big is the stack memory */
+    size_t capacity; /* How big is the stack memory */
     int32_t maxstack; /* Arbitrary defined limit for stack overflow */
     JanetTable *env; /* Dynamic bindings table (usually current environment). */
     Janet *data; /* Dynamically resized stack memory */
@@ -1686,7 +1686,7 @@ JANET_API JanetSymbol janet_symbol_gen(void);
 #define janet_struct_capacity(t) (janet_struct_head(t)->capacity)
 #define janet_struct_hash(t) (janet_struct_head(t)->hash)
 #define janet_struct_proto(t) (janet_struct_head(t)->proto)
-JANET_API JanetKV *janet_struct_begin(int32_t count);
+JANET_API JanetKV *janet_struct_begin(size_t count);
 JANET_API void janet_struct_put(JanetKV *st, Janet key, Janet value);
 JANET_API JanetStruct janet_struct_end(JanetKV *st);
 JANET_API Janet janet_struct_get(JanetStruct st, Janet key);
@@ -1713,7 +1713,7 @@ JANET_API JanetTable *janet_table_clone(JanetTable *table);
 JANET_API void janet_table_clear(JanetTable *table);
 
 /* Fiber */
-JANET_API JanetFiber *janet_fiber(JanetFunction *callee, int32_t capacity, int32_t argc, const Janet *argv);
+JANET_API JanetFiber *janet_fiber(JanetFunction *callee, size_t capacity, int32_t argc, const Janet *argv);
 JANET_API JanetFiber *janet_fiber_reset(JanetFiber *fiber, JanetFunction *callee, int32_t argc, const Janet *argv);
 JANET_API JanetFiberStatus janet_fiber_status(JanetFiber *fiber);
 JANET_API int janet_fiber_can_resume(JanetFiber *fiber);

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1007,9 +1007,9 @@ struct JanetTupleHead {
 /* Prefix for a struct */
 struct JanetStructHead {
     JanetGCObject gc;
-    int32_t length;
+    size_t length;
     int32_t hash;
-    int32_t capacity;
+    size_t capacity;
     const JanetKV *proto;
     const JanetKV data[];
 };

--- a/src/mainclient/shell.c
+++ b/src/mainclient/shell.c
@@ -626,7 +626,7 @@ static JanetByteView longest_common_prefix(void) {
         bv = gbl_matches[0];
         for (int i = 0; i < gbl_match_count; i++) {
             JanetByteView other = gbl_matches[i];
-            int32_t minlen = other.len < bv.len ? other.len : bv.len;
+            size_t minlen = other.len < bv.len ? other.len : bv.len;
             for (bv.len = 0; bv.len < minlen; bv.len++) {
                 if (bv.bytes[bv.len] != other.bytes[bv.len]) {
                     break;
@@ -691,7 +691,7 @@ static void doc_format(JanetString doc, int32_t width) {
     int32_t current = 0;
     if (maxcol > 200) maxcol = 200;
     fprintf(stderr, "    ");
-    for (int32_t i = 0; i < janet_string_length(doc); i++) {
+    for (size_t i = 0; i < janet_string_length(doc); i++) {
         uint8_t b = doc[i];
         switch (b) {
             default: {
@@ -814,13 +814,13 @@ static void kshowcomp(void) {
     check_specials(prefix);
 
     JanetByteView lcp = longest_common_prefix();
-    for (int i = prefix.len; i < lcp.len; i++) {
+    for (size_t i = prefix.len; i < lcp.len; i++) {
         insert(lcp.bytes[i], 0);
     }
 
     if (!gbl_lines_below && prefix.len != lcp.len) return;
 
-    int32_t maxlen = 0;
+    size_t maxlen = 0;
     for (int i = 0; i < gbl_match_count; i++)
         if (gbl_matches[i].len > maxlen)
             maxlen = gbl_matches[i].len;


### PR DESCRIPTION
Use `size_t` for Janet types length and capacity and the API those types use, as discussed on Zulip