### PR TITLE
Add ffi/defbind-alias

### DIFF
--- a/examples/ffi/test.janet
+++ b/examples/ffi/test.janet
@@ -55,6 +55,7 @@
 (ffi/defbind sixints-fn six-ints [])
 (ffi/defbind sixints-fn-2 :int [x :int s six-ints])
 (ffi/defbind sixints-fn-3 :int [s six-ints x :int])
+(ffi/defbind-alias int-fn int-fn-aliased :int [a :int b :int])
 
 #
 # Struct reading and writing
@@ -119,6 +120,7 @@
 (tracev (return-struct 42))
 (tracev (double-lots 1 2 3 4 5 6 700 800 9 10))
 (tracev (struct-big 11 99.5))
+(tracev (int-fn-aliased 10 20))
 
 (assert (= [10 10 12 12] (split-ret-fn 10 12)))
 (assert (= [12 12 10 10] (split-flip-ret-fn 10 12)))

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3853,9 +3853,11 @@
               :lazy lazy
               :map-symbols map-symbols}))
 
-  (defmacro ffi/defbind
-    "Generate bindings for native functions in a convenient manner."
-    [name ret-type & body]
+  (defmacro ffi/defbind-alias
+    "Generate bindings for native functions in a convenient manner.
+     Similar to defbind but allows for the janet function name to be
+     different than the FFI function."
+    [name alias ret-type & body]
     (def real-ret-type (eval ret-type))
     (def meta (slice body 0 -2))
     (def arg-pairs (partition 2 (last body)))
@@ -3872,10 +3874,15 @@
     (defn make-ptr []
       (assert (ffi/lookup (if lazy (llib) lib) raw-symbol) (string "failed to find ffi symbol " raw-symbol)))
     (if lazy
-      ~(defn ,name ,;meta [,;formal-args]
+      ~(defn ,alias ,;meta [,;formal-args]
          (,ffi/call (,(delay (make-ptr))) (,(delay (make-sig))) ,;formal-args))
-      ~(defn ,name ,;meta [,;formal-args]
+      ~(defn ,alias ,;meta [,;formal-args]
          (,ffi/call ,(make-ptr) ,(make-sig) ,;formal-args)))))
+
+  (defmacro ffi/defbind
+    "Generate bindings for native functions in a convenient manner."
+    [name ret-type & body]
+    ~(ffi/defbind-alias ,name ,name ,ret-type ,;body))
 
 ###
 ###


### PR DESCRIPTION
I would like the ability to alias an FFI method in order to maintain the naming convention of the underlying shared library

As an example I would like to be able to do the following

```
(ffi/defbind-alias tb_poll_event _tb_poll_event :int [event :ptr])
(defn tb_poll_event
  []
  (def event (ffi/write tb_event (tb_event/new)))
  (_tb_poll_event event)
  (zipcoll tb_event_keys (ffi/read tb_event event)))
```

The shared library method is called tb_poll_event but it requires a janet "wrapper" because it returns a struct pointer.