### PR TITLE
Add LoongArch64 support

### DIFF
--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -112,7 +112,8 @@ extern "C" {
     || defined(__s390x__) /* S390 64-bit (BE) */ \
     || (defined(__ppc64__) || defined(__PPC64__)) \
     || defined(__aarch64__) /* ARM 64-bit */ \
-    || (defined(__riscv) && (__riscv_xlen == 64)) /* RISC-V 64-bit */
+    || (defined(__riscv) && (__riscv_xlen == 64)) /* RISC-V 64-bit */ \
+    || defined(__loongarch64) /* LoongArch64 64-bit */
 #define JANET_64 1
 #else
 #define JANET_32 1


### PR DESCRIPTION
Tests all passed on my loongarch64 pc. You can also test on [gcc farm].(https://portal.cfarm.net/machines/list/)

```
$ meson test --print-errorlogs --no-rebuild -C output
 1/28 test/suite-array.janet            OK              0.02s
 2/28 test/suite-asm.janet              OK              0.01s
 3/28 test/suite-capi.janet             OK              0.02s
 4/28 test/suite-cfuns.janet            OK              0.01s
 5/28 test/suite-buffer.janet           OK              0.02s
 6/28 test/suite-compile.janet          OK              0.02s
 7/28 test/suite-debug.janet            OK              0.02s
 8/28 test/suite-corelib.janet          OK              0.02s
 9/28 test/suite-ffi.janet              OK              0.02s
10/28 test/suite-io.janet               OK              0.02s
11/28 test/suite-marsh.janet            OK              0.02s
12/28 test/suite-boot.janet             OK              0.05s
13/28 test/suite-inttypes.janet         OK              0.03s
14/28 test/suite-parse.janet            OK              0.01s
15/28 test/suite-pp.janet               OK              0.01s
16/28 test/suite-specials.janet         OK              0.01s
17/28 test/suite-strtod.janet           OK              0.01s
18/28 test/suite-string.janet           OK              0.02s
19/28 test/suite-peg.janet              OK              0.03s
20/28 test/suite-struct.janet           OK              0.01s
21/28 test/suite-symcache.janet         OK              0.02s
22/28 test/suite-table.janet            OK              0.01s
23/28 test/suite-value.janet            OK              0.01s
24/28 test/suite-vm.janet               OK              0.01s
25/28 test/suite-unknown.janet          OK              0.02s
26/28 test/suite-math.janet             OK              0.07s
27/28 test/suite-os.janet               OK              0.08s
28/28 test/suite-ev.janet               OK              0.31s

Ok:                 28  
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   

Full log written to /tmp/janet/output/meson-logs/testlog.txt
```