### PR TITLE
Fix buffer push uint max

### DIFF
--- a/src/core/buffer.c
+++ b/src/core/buffer.c
@@ -375,7 +375,7 @@ JANET_CORE_FN(cfun_buffer_push_uint16,
         uint16_t data;
         uint8_t bytes[2];
     } u;
-    u.data = (uint16_t) janet_getinteger(argv, 2);
+    u.data = (uint16_t) janet_getuinteger(argv, 2);
     if (reverse) {
         uint8_t temp = u.bytes[1];
         u.bytes[1] = u.bytes[0];
@@ -396,7 +396,7 @@ JANET_CORE_FN(cfun_buffer_push_uint32,
         uint32_t data;
         uint8_t bytes[4];
     } u;
-    u.data = (uint32_t) janet_getinteger(argv, 2);
+    u.data = janet_getuinteger(argv, 2);
     if (reverse)
         reverse_u32(u.bytes);
     janet_buffer_push_u32(buffer, *(uint32_t *) u.bytes);
@@ -414,7 +414,7 @@ JANET_CORE_FN(cfun_buffer_push_uint64,
         uint64_t data;
         uint8_t bytes[8];
     } u;
-    u.data = (uint64_t) janet_getuinteger64(argv, 2);
+    u.data = janet_getuinteger64(argv, 2);
     if (reverse)
         reverse_u64(u.bytes);
     janet_buffer_push_u64(buffer, *(uint64_t *) u.bytes);

--- a/src/core/capi.c
+++ b/src/core/capi.c
@@ -303,9 +303,9 @@ int32_t janet_getinteger(const Janet *argv, int32_t n) {
 uint32_t janet_getuinteger(const Janet *argv, int32_t n) {
     Janet x = argv[n];
     if (!janet_checkuint(x)) {
-        janet_panicf("bad slot #%d, expected 32 bit signed integer, got %v", n, x);
+        janet_panicf("bad slot #%d, expected 32 bit unsigned integer, got %v", n, x);
     }
-    return janet_unwrap_integer(x);
+    return (uint32_t) janet_unwrap_number(x);
 }
 
 int64_t janet_getinteger64(const Janet *argv, int32_t n) {

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -2021,6 +2021,7 @@ JANET_API void *janet_getpointer(const Janet *argv, int32_t n);
 JANET_API int32_t janet_getnat(const Janet *argv, int32_t n);
 JANET_API int32_t janet_getinteger(const Janet *argv, int32_t n);
 JANET_API int64_t janet_getinteger64(const Janet *argv, int32_t n);
+JANET_API uint32_t janet_getuinteger(const Janet *argv, int32_t n);
 JANET_API uint64_t janet_getuinteger64(const Janet *argv, int32_t n);
 JANET_API size_t janet_getsize(const Janet *argv, int32_t n);
 JANET_API JanetView janet_getindexed(const Janet *argv, int32_t n);

--- a/test/suite-buffer.janet
+++ b/test/suite-buffer.janet
@@ -85,9 +85,9 @@
 (buffer/push-uint16 buffer-uint16-le :le 0x0102)
 (assert (= "\x02\x01" (string buffer-uint16-le)) "buffer/push-uint16 little endian")
 
-(def buffer-uint16-negative @"")
-(buffer/push-uint16 buffer-uint16-negative :be -1)
-(assert (= "\xff\xff" (string buffer-uint16-negative)) "buffer/push-uint16 negative")
+(def buffer-uint16-max @"")
+(buffer/push-uint16 buffer-uint16-max :be 0xFFFF)
+(assert (= "\xff\xff" (string buffer-uint16-max)) "buffer/push-uint16 max")
 
 (def buffer-uint32-be @"")
 (buffer/push-uint32 buffer-uint32-be :be 0x01020304)
@@ -97,9 +97,9 @@
 (buffer/push-uint32 buffer-uint32-le :le 0x01020304)
 (assert (= "\x04\x03\x02\x01" (string buffer-uint32-le)) "buffer/push-uint32 little endian")
 
-(def buffer-uint32-negative @"")
-(buffer/push-uint32 buffer-uint32-negative :be -1)
-(assert (= "\xff\xff\xff\xff" (string buffer-uint32-negative)) "buffer/push-uint32 negative")
+(def buffer-uint32-max @"")
+(buffer/push-uint32 buffer-uint32-max :be 0xFFFFFFFF)
+(assert (= "\xff\xff\xff\xff" (string buffer-uint32-max)) "buffer/push-uint32 max")
 
 (def buffer-float32-be @"")
 (buffer/push-float32 buffer-float32-be :be 1.234)


### PR DESCRIPTION
I was using the newer `buffer/push-uint[16|32|64]` functions and ran up against issues with upper limits.

```
error: bad slot #2, expected 32 bit signed integer, got 3927367768
  in buffer/push-uint32 [src/core/buffer.c] on line 388
```

This fixes the issue. I think it is fair that negative numbers here raise bad slot errors so I modified those tests to test the upper bounds instead.

Well, `buffer/push-uint16` anything `0xFFFF <= x <= 0xFFFFFFF` will push `"\xff\xff"` without error until it exceeds `uint32_t`. We could add a similar `janet_getuinteger16`, `janet_checkuint16` , and `janet_checkuint16range` if that's an issue. Might look better to rename the 32-bit functions for consistency as well in that case so I thought I'd get feedback first if this is enough or what path we should take.