### PR TITLE
Add ctrl + left/right arrow support to the REPL

### DIFF
--- a/src/mainclient/shell.c
+++ b/src/mainclient/shell.c
@@ -867,7 +867,7 @@ static int line() {
     if (write_console((char *) gbl_prompt, gbl_plen) == -1) return -1;
     for (;;) {
         char c;
-        char seq[3];
+        char seq[5];
 
         int rc;
         do {
@@ -990,6 +990,20 @@ static int line() {
                                     break;
                                 default:
                                     break;
+                            }
+                        } else if (seq[2] == ';') {
+                            if (read_console(seq + 3, 2) == -1) break;
+                            if (seq[3] == '5') {
+                                switch (seq[4]) {
+                                    case 'C': /* ctrl-right */
+                                        krightw();
+                                        break;
+                                    case 'D': /* ctrl-left */
+                                        kleftw();
+                                        break;
+                                    default:
+                                        break;
+                                }
                             }
                         }
                     } else if (seq[0] == 'O') {


### PR DESCRIPTION
Hi! Made a small patch for a recurring annoyance I had with the REPL. Only tested on Linux w/ WezTerm & Konsole but should work on any modern terminal

Thank you for making/maintaining such a nice programming language :)

---

Commit Description:

>Ctrl + left/right arrow would simply input "5D"/"5C" into the REPL which was useless and confusing
>
>With this change, it instead goes to the previous/next word which is usually expected in readline-like interfaces