### PR TITLE
Add default output path for --compile (-c)

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4475,7 +4475,13 @@
      "c" (fn c-switch [i &]
            (def path (in args (+ i 1)))
            (def e (dofile path))
-           (spit (in args (+ i 2)) (make-image e))
+           (def output-path
+             (if (< (+ i 2) (length args))
+               (in args (+ i 2))
+               (string
+                 (if (string/has-suffix? ".janet" path) (string/slice path 0 -7) path)
+                 ".jimage")))
+           (spit output-path (make-image e))
            (set no-file false)
            3)
      "-" (fn [&] (set handleopts false) 1)


### PR DESCRIPTION
Changes behavior of `-c` flag such that:
* `janet -c foo.janet` writes to `foo.jimage`
* `janet -c foo` writes to `foo.jimage`

Previously these would cause a confusing error due to out of bounds access to the args array (see #1451).

The default is only used if there are no more arguments after the input file – I didn't add any special handling for edge cases like `janet -c foo.janet -h` (which uses '-h' as the output file).

closes #1451