### PR TITLE
Do not warn when loop body is empty

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -652,7 +652,6 @@
   The `loop` macro always evaluates to nil.
   ```
   [head & body]
-  (check-empty-body body)
   (loop1 body head 0))
 
 (defmacro seq


### PR DESCRIPTION
This PR removes the warning in `loop` for an empty body.

Although it is nice to check for an empty body in `seq`, `catseq`, `tabseq`, and `generate`, in the case of `loop`, there are legitimate uses for having an empty body.

An example from the wild and some discussion can be seen [here](https://github.com/janet-lang/janet/issues/1470#issuecomment-2232688409).