### PR TITLE
Fix fallback support in polymorphic compare

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -819,11 +819,17 @@
 
 (defmacro- do-compare
   [x y]
-  ~(if (def f (get ,x :compare))
-     (f ,x ,y)
-     (if (def f (get ,y :compare))
-       (- (f ,y ,x))
-       (cmp ,x ,y))))
+  ~(do
+     (def f (get ,x :compare))
+     (def f-res (if f (f ,x ,y)))
+     (if f-res
+       f-res
+       (do
+         (def g (get ,y :compare))
+         (def g-res (if g (- (g ,y ,x))))
+         (if g-res
+           g-res
+           (cmp ,x ,y))))))
 
 (defn compare
   ``Polymorphic compare. Returns -1, 0, 1 for x < y, x = y, x > y respectively.


### PR DESCRIPTION
This PR partially reverts a change to `(compare)` that changed the fallback behaviour.

## Background

In #1249, @primo-ppcg sped up the `(compare)` function in Janet by using a macro. However, the macro wasn't a direct translation of the previous code. The code effectively went from this:

```janet
(or
  (when-let [f (get x :compare)] (f x y))
  (when-let [f (get y :compare)] (- (f y x)))
  (cmp x y))
```

to this:

```janet
(if (def f (get x :compare))
  (f x y)
  (if (def f (get y :compare))
    (- (f y x))
    (cmp x y)))
```

In the original code, the use of `or` meant that the code would 'fall back' to the comparison function of the second operand if the comparison function of the first operand returns `nil` (with a further fallback to `(cmp)` if the second comparison function also returned `nil`). Now, as long as there is a comparison function for the first operand, that will be the result. This is inconsistent with Janet's [documentation](https://janet-lang.org/docs/comparison.html) (see 'Implementing Polymorphic Comparison').

## Implementation

I attempted to retain the use of a macro but changed the behaviour to memoize the result of each comparison function and return it if it was not `nil`. I used @primo-ppcg's test code (our numbers are run on our respective machines and are not comparable):

```janet
(use spork/test)

(def a (range 10))

(timeit-loop [:repeat 1_000_000] "control " (< ;a))
(timeit-loop [:repeat 1_000_000] "splice  " (compare< ;a))
(timeit-loop [:repeat 1_000_000] "number  " (compare< 0 1))
(timeit-loop [:repeat 1_000_000] "s64 arg0" (compare< (int/s64 0) 1))
(timeit-loop [:repeat 1_000_000] "s64 arg1" (compare< 0 (int/s64 1)))
```

to produce the following:

```text
# master:

control  0.299s, 0.2987µs/body
splice   0.502s, 0.5017µs/body
number   0.124s, 0.1239µs/body
s64 arg0 0.172s, 0.1724µs/body
s64 arg1 0.186s, 0.1859µs/body

# branch:

control  0.300s, 0.2995µs/body
splice   0.582s, 0.5819µs/body
number   0.134s, 0.1337µs/body
s64 arg0 0.177s, 0.1767µs/body
s64 arg1 0.197s, 0.1966µs/body
```

The numbers don't look too bad to me but I'll be the first to admit that I don't really understand how @primo-ppcg's code improved things so I've possibly made a mistake in my attempt to 'fix' it.