### PR TITLE
Prefix bin+sep to add-bin dest argument

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4387,10 +4387,10 @@
     `Shorthand for adding scripts during an install. Scripts will be installed to
     (string (dyn *syspath*) "/bin") by default and will be set to be executable.`
     [manifest src &opt dest chmod-mode]
-    (default dest (string "bin" (sep) (->> src (string/split "/") last)))
+    (default dest (last (string/split "/" src)))
     (default chmod-mode 8r755)
     (os/mkdir (string (dyn *syspath*) (sep) "bin"))
-    (bundle/add-file manifest src dest chmod-mode))
+    (bundle/add-file manifest src (string "bin" (sep) dest) chmod-mode))
 
   (defn bundle/update-all
     "Reinstall all bundles"


### PR DESCRIPTION
This PR is an attempt to address #1484.

With this change, one should be able to use `bundle/add-bin` like this:

```janet
(bundle/add-bin manifest
               "git-some-janets.janet"
               # dest argument
               "git-some-janets")
```

instead of having to express the same intent like this:

```janet
(bundle/add-bin manifest
                "git-some-janets.janet"
                # dest argument
                "bin/git-some-janets")
```

That is, if the optional `dest` argument is specified to `bundle/add-bin`, it will have `bin` and an appropriate separator prefixed to it before being passed to `install/add-file`.

I tested the new version with `spork` and one of my own repositories and it seems to work.
