### PR TITLE
Move other unreleased change out of v1.35.2 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ All notable changes to this project will be documented in this file.
 - Fix marshalling weak tables and weak arrays.
 - Expose C functions for constructing weak tables in janet.h
 - Add `bundle/add-bin` to make installing scripts easier. This also establishes a packaging convention for it.
+- Let range take non-integer values.
 
 ## 1.35.2 - 2024-06-16
-- Let range take non-integer values.
 - Fix some documentation typos.
 - Allow using `:only` in import without quoting.
 


### PR DESCRIPTION
There were two changes that were identified as being in the wrong place in the changelog in #1491. This fixes the other one.