### PR TITLE
Add some detail to signal docstring

### DIFF
--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -700,7 +700,15 @@ JANET_CORE_FN(janet_core_is_lengthable,
 
 JANET_CORE_FN(janet_core_signal,
               "(signal what x)",
-              "Raise a signal with payload x. ") {
+              "Raise a signal with payload x. `what` can be an integer\n"
+              "from 0 through 7 indicating user(0-7), or one of:\n\n"
+              "* :ok\n"
+              "* :error\n"
+              "* :debug\n"
+              "* :yield\n"
+              "* :user(0-7)\n"
+              "* :interrupt\n"
+              "* :await") {
     janet_arity(argc, 1, 2);
     Janet payload = argc == 2 ? argv[1] : janet_wrap_nil();
     if (janet_checkint(argv[0])) {

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -79,6 +79,7 @@ const char *const janet_type_names[16] = {
     "pointer"
 };
 
+/* Docstring for signal lists these */
 const char *const janet_signal_names[14] = {
     "ok",
     "error",
@@ -96,6 +97,7 @@ const char *const janet_signal_names[14] = {
     "await"
 };
 
+/* Docstring for fiber/status lists these */
 const char *const janet_status_names[16] = {
     "dead",
     "error",


### PR DESCRIPTION
This PR is part of the effort to address [this issue](https://github.com/janet-lang/janet-lang.org/issues/232).  The other part of the effort has been submitted in [this PR](https://github.com/janet-lang/janet-lang.org/pull/236).

This PR is mostly about adding some detail to `signal`'s docstring.

As a related set of changes, there are a couple of "reminders" that have been added to `util.c` (before `janet_signal_names` and `janet_status_names`) to help keep things in sync in the event of changes.