### PR TITLE
Replace gitter badge with zulip one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Join the chat](https://badges.gitter.im/janet-language/community.svg)](https://gitter.im/janet-language/community)
+[![Join the chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://janet.zulipchat.com)
 &nbsp;
 [![builds.sr.ht status](https://builds.sr.ht/~bakpakin/janet/commits/master/freebsd.yml.svg)](https://builds.sr.ht/~bakpakin/janet/commits/master/freebsd.yml?)
 [![builds.sr.ht status](https://builds.sr.ht/~bakpakin/janet/commits/master/openbsd.yml.svg)](https://builds.sr.ht/~bakpakin/janet/commits/master/openbsd.yml?)


### PR DESCRIPTION
As the website top page is encouraging Zulip, this PR is a suggestion to sync the chat badge in the README.

The link was determined via [these instructions](https://zulip.com/help/linking-to-zulip).