### PR TITLE
Cast arguments to `int32_t` before passing to `janet_formatb` with `%d` format specifier

### DIFF
--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -231,7 +231,7 @@ static void delim_error(JanetParser *parser, size_t stack_index, char c, const c
                 janet_buffer_push_u8(buffer, '`');
             }
         }
-        janet_formatb(buffer, " opened at line %d, column %d", s->line, s->column);
+        janet_formatb(buffer, " opened at line %d, column %d", (int32_t) s->line, (int32_t) s->column);
     }
     parser->error = (const char *) janet_string(buffer->data, buffer->count);
     parser->flag |= JANET_PARSER_GENERATED_ERROR;


### PR DESCRIPTION
`s->line` and `s->column` in `delim_error` are `size_t`, which is typically 64-bit, but `va_arg` in `janet_formatbv` reads `int32_t` for `%d`.