### PR TITLE
Clarify installation info a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,10 @@ Emacs, and Atom each have syntax packages for the Janet language, though.
 
 ## Installation
 
-See the [Introduction](https://janet-lang.org/docs/index.html) for more details. If you just want
-to try out the language, you don't need to install anything. You can also move the `janet` executable wherever you want on your system and run it.
+If you just want to try out the language, you don't need to install anything.
+In this case you can also move the `janet` executable wherever you want on
+your system and run it.  However, for a fuller setup, please see the
+[Introduction](https://janet-lang.org/docs/index.html) for more details.
 
 ## Usage
 


### PR DESCRIPTION
The current installation info in the README was found to be unclear on the topic of under what circumstances the `janet` executable can be moved to various locations and still have a functioning arrangement.

See [here](https://janet.zulipchat.com/#narrow/channel/409517-help/topic/Problems.20with.20.22installing.22.20Janet.20binary.20package.20in.20.2Fopt/near/478878844) for some discussion.

This PR is an attempt to make it clearer that moving the executable might only work out for "trying things out without installing" (hinting that in a more "full" setup -- e.g. involving `jpm`, `spork`, etc. -- things might be different).