### PR TITLE
Add assertf and use in boot.janet. Address #1516

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -154,6 +154,11 @@
        ,v
        (,error ,(if err err (string/format "assert failure in %j" x))))))
 
+(defmacro assertf
+  "Convenience macro that combines `assert` and `string/format`."
+  [x & args]
+  ~(as-macro ,assert ,x (,string/format ,;args)))
+
 (defmacro defdyn
   ``Define an alias for a keyword that is used as a dynamic binding. The
   alias is a normal, lexically scoped binding that can be used instead of
@@ -3934,7 +3939,7 @@
     (defn make-sig []
       (ffi/signature :default real-ret-type ;computed-type-args))
     (defn make-ptr []
-      (assert (ffi/lookup (if lazy (llib) lib) raw-symbol) (string "failed to find ffi symbol " raw-symbol)))
+      (assertf (ffi/lookup (if lazy (llib) lib) raw-symbol) "failed to find ffi symbol %v" raw-symbol))
     (if lazy
       ~(defn ,alias ,;meta [,;formal-args]
          (,ffi/call (,(delay (make-ptr))) (,(delay (make-sig))) ,;formal-args))
@@ -4111,7 +4116,7 @@
     "Get the manifest for a give installed bundle"
     [bundle-name]
     (def name (get-manifest-filename bundle-name))
-    (assert (fexists name) (string "no bundle " bundle-name " found"))
+    (assertf (fexists name) "no bundle %v found" bundle-name)
     (parse (slurp name)))
 
   (defn- get-bundle-module
@@ -4254,11 +4259,9 @@
       (def missing (seq [d :in deps :when (not (bundle/installed? d))] (string d)))
       (when (next missing) (errorf "missing dependencies %s" (string/join missing ", "))))
     (def bundle-name (get config :name default-bundle-name))
-    (assert bundle-name (errorf "unable to infer bundle name for %v, use :name argument" path))
-    (assert (not (string/check-set "\\/" bundle-name))
-            (string "bundle name "
-                    bundle-name
-                    " cannot contain path separators"))
+    (assertf bundle-name "unable to infer bundle name for %v, use :name argument" path)
+    (assertf (not (string/check-set "\\/" bundle-name))
+             "bundle name %v cannot contain path separators" bundle-name)
     (assert (next bundle-name) "cannot use empty bundle-name")
     (assert (not (fexists (get-manifest-filename bundle-name)))
             "bundle is already installed")
@@ -4310,7 +4313,7 @@
     (var i 0)
     (def man (bundle/manifest bundle-name))
     (def files (get man :files @[]))
-    (assert (os/mkdir dest-dir) (string "could not create directory " dest-dir " (or it already exists)"))
+    (assertf (os/mkdir dest-dir) "could not create directory %v (or it already exists)" dest-dir)
     (def s (sep))
     (os/mkdir (string dest-dir s "bundle"))
     (def install-hook (string dest-dir s "bundle" s "init.janet"))

--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -986,4 +986,14 @@
 (assert (deep= (get (dyn 'a) :source-form) source))
 (setdyn *debug* nil)
 
+# issue #1516
+(assert (assertf true) "assertf 1 argument")
+(assert (assertf true "fun message") "assertf 2 arguments")
+(assert (assertf true "%s message" "mystery") "assertf 3 arguments")
+(assert (assertf (not nil) "%s message" "ordinary") "assertf not nil")
+(assert-error "assertf error 1" (assertf false))
+(assert-error "assertf error 2" (assertf false "fun message"))
+(assert-error "assertf error 3" (assertf false "%s message" "mystery"))
+(assert-error "assertf error 4" (assertf nil "%s %s" "alice" "bob"))
+
 (end-suite)


### PR DESCRIPTION
This is an attempt to address #1516 by adding `assertf` (borrowed from @ianthehenry) to `boot.janet`.

The PR also includes attempts to apply `assertf` within `boot.janet`.  I've used `%v` in some places but I'm not sure if that was appropriate.

Also, there was one bit of code that used `errorf` (may be as a short-cut?):

```janet
(assert bundle-name (errorf "unable to infer bundle name for %v, use :name argument" path))
```

this was replaced with:

```janet
(assertf bundle-name "unable to infer bundle name for %v, use :name argument" path)
```

I hope that was appropriate (^^;

For background, please see the [Zulip discussion](https://janet.zulipchat.com/#narrow/channel/399615-general/topic/assertf.3F/near/479218350) and the corresponding [issue](https://github.com/janet-lang/janet/issues/1516).
