### PR TITLE
Update Docker command to use `--platform` flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install gcc-arm-linux-gnueabi qemu-user
       - name: Compile the project
-        run: make RUN="qemu-arm -L /usr/arm-linux-gnueabi/" CC=arm-linux-gnueabi-gcc LD=arm-linux-gnueabi-gcc 
+        run: make RUN="qemu-arm -L /usr/arm-linux-gnueabi/" CC=arm-linux-gnueabi-gcc LD=arm-linux-gnueabi-gcc
       - name: Test the project
         run: make RUN="qemu-arm -L /usr/arm-linux-gnueabi/" SUBRUN="qemu-arm -L /usr/arm-linux-gnueabi/" test VERBOSE=1
 
@@ -132,4 +132,4 @@ jobs:
     - name: Do Qemu build and test
       run: |
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-        docker run --rm -v .:/janet s390x/ubuntu bash -c "apt-get -y update && apt-get -y install git build-essential && cd /janet && make -j3 && make test"
+        docker run --rm -v .:/janet --platform linux/s390x ubuntu bash -c "apt-get -y update && apt-get -y install git build-essential && cd /janet && make -j3 && make test"


### PR DESCRIPTION
Beginning with ad77bc391cb59e11deb116acd04eac04272839dd, the following error began occurring in GitHub's test runner when testing with the s390x/ubuntu Docker image:

```
docker: no matching manifest for linux/amd64 in the manifest list entries.
```

This may be because s390x/ubuntu images have become an image index and so require a platform specification (see https://github.com/nodejs/docker-node/issues/2110#issuecomment-2187459985).

This PR adds the `--platform` flag to the relevant Docker command in the GitHub workflow file to fix this problem.