### PR TITLE
fix janet_string_equalconst

### DIFF
--- a/src/core/string.c
+++ b/src/core/string.c
@@ -71,10 +71,10 @@ int janet_string_compare(const uint8_t *lhs, const uint8_t *rhs) {
 int janet_string_equalconst(const uint8_t *lhs, const uint8_t *rhs, int32_t rlen, int32_t rhash) {
     int32_t lhash = janet_string_hash(lhs);
     int32_t llen = janet_string_length(lhs);
-    if (lhs == rhs)
-        return 1;
     if (lhash != rhash || llen != rlen)
         return 0;
+    if (lhs == rhs)
+        return 1;
     return !memcmp(lhs, rhs, rlen);
 }
 


### PR DESCRIPTION
Check string length before pointer equality, so that a string is not considered equal to a prefix slice of itself.

I ran into this with a pretty gnarly bug where e.g. `(symbol/slice 'abcdefg 0 3)` returned `'abcdefg` when the symcache was filled *just so* -- they hash differently, but if you get unlucky enough and there's a hash collision, the resolution runs `janet_string_equalconst` and erroneously says "oh yeah we found it" because `cfun_symbol_slice` just changes the `len`.