### PR TITLE
Remove unused var pstatus

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2665,7 +2665,6 @@
 
       (do
         (var pindex 0)
-        (var pstatus nil)
         (def len (length buf))
         (when (= len 0)
           (:eof p)


### PR DESCRIPTION
It looks like the [var `pstatus` in `boot.janet`](https://github.com/janet-lang/janet/blob/2bceba4a7a2706cef8ef26e8071660fc2cd5829a/src/boot/boot.janet#L2668) has not really been in use for some time.

At least as far back as [this version (2019-01) of boot.janet](https://github.com/janet-lang/janet/blob/c76f4e89d8b912809431049c24dc267b66c9fd29/src/core/core.janet#L1470), `pstatus` doesn't seem to be doing anything essential.

This PR is a suggestion to remove it.
