### PR TITLE
add (til) PEG special

### DIFF
--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -2180,6 +2180,7 @@ typedef enum {
     RULE_UNREF,        /* [rule, tag] */
     RULE_CAPTURE_NUM,  /* [rule, tag] */
     RULE_SUB,          /* [rule, rule] */
+    RULE_TIL,          /* [rule, rule] */
     RULE_SPLIT,        /* [rule, rule] */
     RULE_NTH,          /* [nth, rule, tag] */
     RULE_ONLY_TAGS,    /* [rule] */

--- a/test/suite-peg.janet
+++ b/test/suite-peg.janet
@@ -713,6 +713,41 @@
   "abcdef"
   @[])
 
+(test "til: basic matching"
+  ~(til "d" "abc")
+  "abcdef"
+  @[])
+
+(test "til: second pattern can't see past the first occurrence of first pattern"
+  ~(til "d" (* "abc" -1))
+  "abcdef"
+  @[])
+
+(test "til: fails if first pattern fails"
+  ~(til "x" "abc")
+  "abcdef"
+  nil)
+
+(test "til: fails if second pattern fails"
+  ~(til "abc" "x")
+  "abcdef"
+  nil)
+
+(test "til: discards captures from initial pattern"
+  ~(til '"d" '"abc")
+  "abcdef"
+  @["abc"])
+
+(test "til: positions inside second match are still relative to the entire input"
+  ~(* "one\ntw" (til 0 (* ($) (line) (column))))
+  "one\ntwo\nthree\n"
+  @[6 2 3])
+
+(test "til: advances to the end of the first pattern's first occurrence"
+  ~(* (til "d" "ab") "e")
+  "abcdef"
+  @[])
+
 (test "split: basic functionality"
   ~(split "," '1)
   "a,b,c"


### PR DESCRIPTION
This is... maybe not a real pull request; this is an idea with an implementation and some tests. But it's an idea that adds a bit of complexity to the PEG engine and is maybe not worth it.

I often want to write a PEG somewhere in between `to` and `thru`, usually while parsing something like `key=value`: capture everything up to `=`, skip over the `=`, and then match everything after. This is a little clumsy right now:

```
(* '(to "=") "=" '(to -1))
```

Because you have to repeat the separator (and even though this doesn't actually matter in any case where I've done this, it's a little sad that you evaluate the separator PEG one more time than is necessary).

So `(til)` is a special that makes this easy to write. It captures like `(to)`, but advances like `(thru)`.

And this is... weird. Nowhere else is there a PEG that captures and advances differently -- captures are defined by how they advance the input. Until now. So this PR adds complexity to PEG rules, as each PEG rule can basically return two things now: how far to advance, and how far to capture (if currently capturing).

I'm mostly hesitant about this because it's not 100% obvious how each other PEG special should interact with `(til)`. I made judgment calls that I think are reasonable but I could see a case for e.g. either of these behaviors:

```
(check-deep ~''(til "=") "key=value" @["key" "key"])
(check-deep ~''(til "=") "key=value" @["key" "key="])
```

(I chose the latter because it's slightly simpler to implement and this will never come up in practice, but I feel slightly weird about it.)

I think this test summarizes `(til)` best:

```
(check-deep ~(* '(to "=") '(to -1)) "key=value" @["key" "=value"])
(check-deep ~(* '(til "=") '(til -1)) "key=value" @["key" "value"])
(check-deep ~(* '(thru "=") '(thru -1)) "key=value" @["key=" "value"])
```