### PR TITLE
file/open: check if directory

### DIFF
--- a/src/core/io.c
+++ b/src/core/io.c
@@ -167,7 +167,7 @@ JANET_CORE_FN(cfun_io_fopen,
     if (f != NULL) {
 #ifndef JANET_WINDOWS
         struct stat st;
-        fstat(f->_fileno, &st);
+        fstat(fileno(f), &st);
         if (S_ISDIR(st.st_mode)) {
             fclose(f);
             janet_panicf("cannot open directory: %s", fname);


### PR DESCRIPTION
Adds fstat directory test after fopen, which can return non-NULL when passed a directory name on Linux.

Tested on Ubuntu 22.04 (+valgrind), & Windows 10

Should close #1530 