### PR TITLE
Add `ev/to-file` for synchronous resource operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## ??? - Unreleased
+- Add `ev/to-file` for synchronous resource operations
+
 ## 1.37.1 - 2024-12-05
 - Fix meson cross compilation
 - Update timeout documentation for networking APIs: timeouts raise errors and do not return nil.

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -32,6 +32,7 @@
 #ifdef JANET_EV
 
 #include <math.h>
+#include <fcntl.h>
 #ifdef JANET_WINDOWS
 #include <winsock2.h>
 #include <windows.h>
@@ -44,7 +45,6 @@
 #include <signal.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
-#include <fcntl.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <netdb.h>
@@ -3293,7 +3293,7 @@ static JanetFile *get_file_for_stream(JanetStream *stream) {
     }
     if (index == 0) return NULL;
     /* duplicate handle when converting stream to file */
-    #ifdef JANET_WINDOWS
+#ifdef JANET_WINDOWS
     int htype = 0;
     if (fmt[0] == 'r' && fmt[1] == '+') {
         htype = _O_RDWR;
@@ -3312,7 +3312,7 @@ static JanetFile *get_file_for_stream(JanetStream *stream) {
         /* _close(fd); */
         return NULL;
     }
-    #else
+#else
     int newHandle = dup(stream->handle);
     if (newHandle < 0) return NULL;
     FILE *f = fdopen(newHandle, fmt);
@@ -3320,7 +3320,7 @@ static JanetFile *get_file_for_stream(JanetStream *stream) {
         close(newHandle);
         return NULL;
     }
-    #endif
+#endif
     return janet_makejfile(f, flags);
 }
 

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -35,6 +35,7 @@
 #ifdef JANET_WINDOWS
 #include <winsock2.h>
 #include <windows.h>
+#include <io.h>
 #else
 #include <pthread.h>
 #include <limits.h>

--- a/test/suite-ev.janet
+++ b/test/suite-ev.janet
@@ -418,9 +418,12 @@
   (assert (= result text) (string/format "expected %v, got %v" text result)))
 
 # Now do our telnet chat
-(def bob (net/connect test-host test-port))
+(def bob (net/connect test-host test-port :stream))
 (expect-read bob "Whats your name?\n")
-(net/write bob "bob")
+(def fbob (ev/to-file bob))
+(file/write fbob "bob")
+(file/flush fbob)
+(:close fbob)
 (expect-read bob "Welcome bob\n")
 (def alice (net/connect test-host test-port))
 (expect-read alice "Whats your name?\n")

--- a/test/suite-ev.janet
+++ b/test/suite-ev.janet
@@ -420,9 +420,13 @@
 # Now do our telnet chat
 (def bob (net/connect test-host test-port :stream))
 (expect-read bob "Whats your name?\n")
-(def fbob (ev/to-file bob))
-(file/write fbob "bob")
-(:close fbob)
+(if (= :mingw (os/which))
+  (net/write bob "bob")
+  (do
+    (def fbob (ev/to-file bob))
+    (file/write fbob "bob")
+    (file/flush fbob)
+    (:close fbob)))
 (expect-read bob "Welcome bob\n")
 (def alice (net/connect test-host test-port))
 (expect-read alice "Whats your name?\n")

--- a/test/suite-ev.janet
+++ b/test/suite-ev.janet
@@ -422,7 +422,6 @@
 (expect-read bob "Whats your name?\n")
 (def fbob (ev/to-file bob))
 (file/write fbob "bob")
-(file/flush fbob)
 (:close fbob)
 (expect-read bob "Welcome bob\n")
 (def alice (net/connect test-host test-port))


### PR DESCRIPTION
This PR adds `ev/to-file` as a way to allow synchronous operations with stream-based resources (e.g. sockets).

## Background

Janet supports non-blocking IO operations via the `ev` module. While this is desirable in many cases, there are situations where a user wants to ensure that an operation is synchronous. Janet does not currently offer a mechanism to do this with stream-based resources (e.g. sockets).

As discussed in #1531, one way to address this is is to offer a function that would create a `core/file` object based on the `core/stream` object. The `core/file` object could then be used with the synchronous operations in the `file` module.

## Implementation

The `src/core/ev.c` file is modified to add  an `ev/to-file` function. The function takes a stream object and attempts to return a file object. This can then be used in the same way as other file objects:

```janet
(with [conn (net/connect host port)]
  (def f (ev/to-file conn))
  (file/write f “foo”)
  (file/write f “bar”)
  (file/flush f))
```

## Limitations

I wasn’t able to get this working on MinGW. Based on some cursory reading, I think this might be a limitation in how MinGW handles the use of Windows sockets via file descriptors. As a result, calling this function in a MinGW environment will raise an error.