### PR TITLE
Support dedenting long-strings with Windows EOLs

### DIFF
--- a/src/core/parse.c
+++ b/src/core/parse.c
@@ -363,8 +363,7 @@ static int stringend(JanetParser *p, JanetParseState *state) {
         JanetParseState top = p->states[p->statecount - 1];
         int32_t indent_col = (int32_t) top.column - 1;
         uint8_t *r = bufstart, *end = r + buflen;
-        /* Check if there are any characters before the start column -
-         * if so, do not reindent. */
+        /* Unless there are only spaces before EOLs, disable reindenting */
         int reindent = 1;
         while (reindent && (r < end)) {
             if (*r++ == '\n') {
@@ -374,34 +373,36 @@ static int stringend(JanetParser *p, JanetParseState *state) {
                         break;
                     }
                 }
+                if ((r + 1) < end && *r == '\r' && *(r + 1) == '\n') reindent = 1;
             }
         }
-        /* Now reindent if able to, otherwise just drop leading newline. */
-        if (!reindent) {
-            if (buflen > 0 && bufstart[0] == '\n') {
-                buflen--;
-                bufstart++;
-            }
-        } else {
+        /* Now reindent if able */
+        if (reindent) {
             uint8_t *w = bufstart;
             r = bufstart;
             while (r < end) {
                 if (*r == '\n') {
-                    if (r == bufstart) {
-                        /* Skip leading newline */
-                        r++;
-                    } else {
-                        *w++ = *r++;
-                    }
+                    *w++ = *r++;
                     for (int32_t j = 0; (r < end) && (*r != '\n') && (j < indent_col); j++, r++);
+                    if ((r + 1) < end && *r == '\r' && *(r + 1) == '\n') *w++ = *r++;
                 } else {
                     *w++ = *r++;
                 }
             }
             buflen = (int32_t)(w - bufstart);
         }
-        /* Check for trailing newline character so we can remove it */
-        if (buflen > 0 && bufstart[buflen - 1] == '\n') {
+        /* Check for leading EOL so we can remove it */
+        if (buflen > 1 && bufstart[0] == '\r' && bufstart[1] == '\n') { /* Windows EOL */
+            buflen = buflen - 2;
+            bufstart = bufstart + 2;
+        } else if (buflen > 0 && bufstart[0] == '\n') { /* Unix EOL */
+            buflen--;
+            bufstart++;
+        }
+        /* Check for trailing EOL so we can remove it */
+        if (buflen > 1 && bufstart[buflen - 2] == '\r' && bufstart[buflen - 1] == '\n') { /* Windows EOL */
+            buflen = buflen - 2;
+        } else if (buflen > 0 && bufstart[buflen - 1] == '\n') { /* Unix EOL */
             buflen--;
         }
     }


### PR DESCRIPTION
This PR fixes the dedenting behaviour of long-strings that use Windows EOLs (i.e. `\r\n`). It fixes #1502.

## Background

Janet supports dedenting long-strings (i.e. strings delimited by one or more `` ` `` characters). This is particularly useful for docstrings where the docstring will usually be indented to preserve visual hierarchy.

As reported by @CFiggers in #1502, this practice ‘breaks’ with files that use `\r\n` as the EOL sequence. This is because Janet’s dedenting algorithm assumes the EOL sequence will be `\n`:

https://github.com/janet-lang/janet/blob/4daecc9a4113aa0198ddf30c90e59cc256a748d1/src/core/parse.c#L361-L407

By default, Git will use `\r\n` when cloning repositories on Windows even if the files in the repository used only `\n`. Git’s behaviour can be modified but requires affirmative action from the user.

## Implementation

The dedenting algorithm in the `src/core/parse.c` file is modified to support `\r\n` as an EOL sequence. In essence, this is done by including a test after the for-loop that checks indentation. If the for-loop ended because it hit a `\r` character, `reindent` is set back to `1` (i.e. `true`) if the next character is a `\n` so that the while-loop continues.

The indenting tests that are in the test suite are expanded to ensure that long-strings that use `\r\n` as an EOL sequence work as intended.

## Notes

As noted by @sogaiu in #1302, different approaches could be taken to normalising EOL sequences. **This PR does not do this.** If the long-string contained Windows-style EOL sequences, these are preserved in the dedented output.