### PR TITLE
Brief: Add Arm64 .msi support on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Alternatively, install the package directly with `pkgin install janet`.
 
 To build an `.msi` installer executable, in addition to the above steps, you will have to:
 
-5. Install, or otherwise add to your PATH the [WiX 3.11 Toolset](https://github.com/wixtoolset/wix3/releases).
+5. Install, or otherwise add to your PATH the [WiX 3.14 Toolset](https://github.com/wixtoolset/wix3/releases).
 6. Run `build_win dist`.
 
 Now you should have an `.msi`. You can run `build_win install` to install the `.msi`, or execute the file itself.

--- a/build_win.bat
+++ b/build_win.bat
@@ -91,7 +91,7 @@ exit /b 0
 
 @rem Clean build artifacts
 :CLEAN
-del *.exe *.lib *.exp
+del *.exe *.lib *.exp *.msi *.wixpdb
 rd /s /q build
 if exist dist (
     rd /s /q dist
@@ -143,7 +143,13 @@ if defined CI (
 ) else (
     set WIXBIN=
 )
-%WIXBIN%candle.exe tools\msi\janet.wxs -arch %BUILDARCH% -out build\
+
+set WIXARCH=%BUILDARCH%
+if "%WIXARCH%"=="aarch64" (
+    set WIXARCH=arm64
+)
+
+%WIXBIN%candle.exe tools\msi\janet.wxs -arch %WIXARCH% -out build\
 %WIXBIN%light.exe "-sice:ICE38" -b tools\msi -ext WixUIExtension build\janet.wixobj -out janet-%RELEASE_VERSION%-windows-%BUILDARCH%-installer.msi
 exit /b 0
 

--- a/tools/msi/janet.wxs
+++ b/tools/msi/janet.wxs
@@ -19,6 +19,11 @@
     <?define ProgramFilesFolder="ProgramFilesFolder" ?>
     <?define Win64="no" ?>
     <?define Arch="(x86)" ?>
+<?elseif $(sys.BUILDARCH)="arm64" ?>
+    <?define UpgradeCode="0bd4bab6-c838-4c2a-b9e6-56ea8064863c" ?>
+    <?define ProgramFilesFolder="ProgramFiles64Folder" ?>
+    <?define Win64="yes" ?>
+    <?define Arch="(Arm)" ?>
 <?else ?>
     <?error Unsupported value of sys.BUILDARCH=$(sys.BUILDARCH)?>
 <?endif?>


### PR DESCRIPTION
Small update to add Windows on Arm64 support. This does require changing the (os/arch) value from 'aarch64' to 'arm64' just for Windows on Arm.

Also requires the latest version 3.14 of the WiX toolset.