### PR TITLE
Fix docstrings for int/u64, int/s64 and int/to-number

### DIFF
--- a/src/core/inttypes.c
+++ b/src/core/inttypes.c
@@ -191,14 +191,14 @@ Janet janet_wrap_u64(uint64_t x) {
 
 JANET_CORE_FN(cfun_it_s64_new,
               "(int/s64 value)",
-              "Create a boxed signed 64 bit integer from a string value.") {
+              "Create a boxed signed 64 bit integer from a string value or a number.") {
     janet_fixarity(argc, 1);
     return janet_wrap_s64(janet_unwrap_s64(argv[0]));
 }
 
 JANET_CORE_FN(cfun_it_u64_new,
               "(int/u64 value)",
-              "Create a boxed unsigned 64 bit integer from a string value.") {
+              "Create a boxed unsigned 64 bit integer from a string value or a number.") {
     janet_fixarity(argc, 1);
     return janet_wrap_u64(janet_unwrap_u64(argv[0]));
 }

--- a/src/core/inttypes.c
+++ b/src/core/inttypes.c
@@ -205,7 +205,7 @@ JANET_CORE_FN(cfun_it_u64_new,
 
 JANET_CORE_FN(cfun_to_number,
               "(int/to-number value)",
-              "Convert an int/u64 or int/s64 to a number. Fails if the number is out of range for an int32.") {
+              "Convert an int/u64 or int/s64 to a number. Fails if the number is out of range for an int64.") {
     janet_fixarity(argc, 1);
     if (janet_type(argv[0]) == JANET_ABSTRACT) {
         void *abst = janet_unwrap_abstract(argv[0]);


### PR DESCRIPTION
All credits go to @sogaiu (see this [Zulip chat](https://janet.zulipchat.com/#narrow/channel/399615-general/topic/Advent.20of.20Code/near/493101919)).

The current doc strings for `int/u64` and `int/s64` say that these functions only support strings. But as far as I can tell from the [diff](https://github.com/janet-lang/janet/commit/bad040665fb742b1363b85e0c9f1736d43fc313c#diff-3a550951c59fd425cf0d44f6c0b3581d1e54135a7d07bb19d0e500548b99a8d1R68-R92) they always support both numbers and strings, and the test suites cover those cases. I therefore updated the docstrings to indicate that.

`int/to-number` used to only supports `int32` values but [this commit](https://github.com/janet-lang/janet/commit/75845c028364b8a25f06d620a61851cfa4505e64#diff-3a550951c59fd425cf0d44f6c0b3581d1e54135a7d07bb19d0e500548b99a8d1L217) added support for up to `JANET_INTMAX_INT64`.

This isn't the most ground breaking commit but I was certainly a bit confused about what I can do with these functions when I was dealing with `bxor`ing 64bit integers for Advent of Code.