### PR TITLE
Tweak apply and short-fn docstrings

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2345,17 +2345,11 @@
 
 (defmacro short-fn
   ```
-  Shorthand for `fn`. Arguments are given as `$n`, where `n` is the 0-indexed
-  argument of the function. `$` is also an alias for the first (index 0) argument.
-  The `$&` symbol will make the anonymous function variadic if it appears in the
-  body of the function, and can be combined with positional arguments.
-
-  Example usage:
-
-      (short-fn (+ $ $)) # A function that doubles its arguments.
-      (short-fn (string $0 $1)) # accepting multiple args.
-      |(+ $ $) # use pipe reader macro for terse function literals.
-      |(+ $&)  # variadic functions
+  Shorthand for `fn`. Arguments are given as `$n`, where `n` is the
+  0-indexed argument of the function. `$` is also an alias for the
+  first (index 0) argument. The `$&` symbol will make the anonymous
+  function variadic if it appears in the body of the function, and
+  can be combined with positional arguments.
   ```
   [arg &opt name]
   (var max-param-seen -1)

--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -1002,12 +1002,11 @@ static void make_apply(JanetTable *env) {
     janet_quick_asm(env, JANET_FUN_APPLY | JANET_FUNCDEF_FLAG_VARARG,
                     "apply", 1, 1, INT32_MAX, 6, apply_asm, sizeof(apply_asm),
                     JDOC("(apply f & args)\n\n"
-         "Applies a function to a variable number of arguments. Each element in args "
-         "is used as an argument to f, except the last element in args, which is expected to "
-         "be an array-like. Each element in this last argument is then also pushed as an argument to "
-         "f. For example:\n\n"
-         "\t(apply + 1000 (range 10))\n\n"
-         "sums the first 10 integers and 1000."));
+         "Applies a function f to a variable number of arguments. Each "
+         "element in args is used as an argument to f, except the last "
+         "element in args, which is expected to be an array or a tuple. "
+         "Each element in this last argument is then also pushed as an "
+         "argument to f."));
 }
 
 static const uint32_t error_asm[] = {


### PR DESCRIPTION
This PR suggests tweaking the docstrings for `apply` and `short-fn`.

The changes are mostly about removing the contained examples, though there is also a slight clarification about the `& args` portion of `apply` as well.

During the [2025 Janetuary Community Project](https://janet.zulipchat.com/#narrow/channel/399615-general/topic/Janetuary.20Community.20Project.3A.20Write.20API.20examples), a number of us studied and added some examples to the janet-lang.org repository.

We scanned through the existing docstrings and found that there were only four [1] that contained examples.  `apply` already had examples at janet-lang.org and we added comparable ones for `short-fn`.  It seems redundant and inconsistent [2] to keep the examples in the docstrings so this PR is a proposal to remove them.

---

On a side note, the remaining two items we found examples for in docstrings were:

* `debug/break`
* `fiber/new`

Assuming this PR (or something similar) is accepted, once appropriate examples have been added to janet-lang.org for the remaining two, we're thinking to do similarly for them too.

---

[1] It's possible we missed some, but it seems unlikely there are too many more.

[2] The inconsistency also manifests visually at the Core API page (and may be some would think it doesn't look that nice):

![short-fn-on-core-api-page](https://github.com/user-attachments/assets/96a66a60-6d4b-4ba6-aa42-c07b09653d94)
