### PR TITLE
Use new GitHub action for s390x testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,16 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@master
     - name: Do Qemu build and test
-      run: |
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-        docker run --rm -v .:/janet --platform linux/s390x ubuntu bash -c "apt-get -y update && apt-get -y install git build-essential && cd /janet && make -j3 && make test"
+      uses: uraimo/run-on-arch-action@v3
+      with:
+        arch: s390x
+        distro: ubuntu_latest
+        dockerRunArgs: |
+          --volume ".:/janet"
+        install: |
+          apt-get -y update
+          apt-get -y install git build-essential
+        run: |
+          cd /janet
+          make -j3
+          make test


### PR DESCRIPTION
The GitHub workflow that Janet runs to check Janet builds on the s390x architecture has started failing intermittently. More information is [here](https://github.com/tonistiigi/binfmt/issues/215).

This PR uses the [run-on-arch-action](https://github.com/uraimo/run-on-arch-action) GitHub action by Umberto Raimondi. This is done for 3 reasons:

1. The action includes a fix that works around the problem.
2. The action simplifies the workflow's steps.
3. The action can support caching of the container.

In terms of (3), I have not enabled this because it I think it means you get a bit of an ugly listing in the GitHub project's packages (e.g. see [simdjson](https://github.com/orgs/simdjson/packages?repo_name=simdjson) for what that would look like) but perhaps that's an acceptable trade-off for the speed gain.