### PR TITLE
Expand scope of code that works with `ev/deadline`

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -3133,7 +3133,7 @@ JANET_CORE_FN(cfun_ev_deadline,
               "After `sec` seconds, the event loop will attempt cancellation of `tocancel` if the "
               "`tocheck` fiber is resumable. `sec` is a number that can have a fractional part. "
               "`tocancel` defaults to `(fiber/root)`, but if specified, must be a task (root "
-              "fiber). `tocheck` defaults to `(fiber/current)`, but if specified, must be a fiber."
+              "fiber). `tocheck` defaults to `(fiber/current)`, but if specified, must be a fiber. "
               "Returns `tocancel` immediately. If `interrupt?` is set to true, will create a "
               "background thread to interrupt the VM if the timeout expires.") {
     janet_arity(argc, 1, 4);

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -798,14 +798,14 @@ static JanetSignal run_vm(JanetFiber *fiber, Janet in) {
     vm_pcnext();
 
     VM_OP(JOP_JUMP)
-    pc += DS;
     vm_maybe_auto_suspend(DS <= 0);
+    pc += DS;
     vm_next();
 
     VM_OP(JOP_JUMP_IF)
     if (janet_truthy(stack[A])) {
-        pc += ES;
         vm_maybe_auto_suspend(ES <= 0);
+        pc += ES;
     } else {
         pc++;
     }
@@ -815,15 +815,15 @@ static JanetSignal run_vm(JanetFiber *fiber, Janet in) {
     if (janet_truthy(stack[A])) {
         pc++;
     } else {
-        pc += ES;
         vm_maybe_auto_suspend(ES <= 0);
+        pc += ES;
     }
     vm_next();
 
     VM_OP(JOP_JUMP_IF_NIL)
     if (janet_checktype(stack[A], JANET_NIL)) {
-        pc += ES;
         vm_maybe_auto_suspend(ES <= 0);
+        pc += ES;
     } else {
         pc++;
     }
@@ -833,8 +833,8 @@ static JanetSignal run_vm(JanetFiber *fiber, Janet in) {
     if (janet_checktype(stack[A], JANET_NIL)) {
         pc++;
     } else {
-        pc += ES;
         vm_maybe_auto_suspend(ES <= 0);
+        pc += ES;
     }
     vm_next();
 


### PR DESCRIPTION
This PR expands the scope of Janet code that can be run with deadlines. It does this by using a background thread to monitor the deadline which interrupts the VM if the deadline expires.

## Background

Janet supports applying timeouts to fibers using `ev/deadline`:

```
cfunction
src/core/ev.c on line 3088, column 1

(ev/deadline sec &opt tocancel tocheck)

Schedules the event loop to try to cancel the tocancel task as with
ev/cancel. After sec seconds, the event loop will attempt
cancellation of tocancel if the tocheck fiber is resumable. sec is
a number that can have a fractional part. tocancel defaults to
(fiber/root), but if specified, must be a task (root fiber).
tocheck defaults to (fiber/current), but if specified, should be a
fiber. Returns tocancel immediately.
```

The `ev/with-deadline` macro presents this to the user in a convenient way:

```
macro
boot.janet on line 3821, column 3

(ev/with-deadline sec & body)

Create a fiber to execute body, schedule the event loop to cancel
the task (root fiber) associated with body's fiber, and start
body's fiber by resuming it.

The event loop will try to cancel the root fiber if body's fiber
has not completed after at least sec seconds.

sec is a number that can have a fractional part.
```

This can be used like this:

```janet
(def ch (ev/chan 1))
(ev/with-deadline 1 (ev/take chan))
# err> error: deadline expired
# err>  in ev/take [src/core/ev.c] on line 1047
# err>  in coro [repl] on line 2, column 21
# err>  in thunk [repl] (tail call) on line 2, column 1
```

Behind the scenes, `ev/deadline` adds a timeout to the event loop’s scheduler. When a fiber yields, the scheduler checks to see if any timeouts have expired before it resumes the next scheduled fiber. If a timeout has expired, the scheduler cancels the relevant fiber.

This implementation means that the scheduler can only cancel fibers when the active fiber yields. If the fiber never yields, it cannot be cancelled. This means that the following won’t work as the user might expect:

```janet
(ev/with-deadline 1 (forever (print "All work and no play makes Jack a dull boy."))
# out> All work and no play makes Jack a dull boy.
# out> All work and no play makes Jack a dull boy.
# out> All work and no play makes Jack a dull boy.
# <...>
```

This will continue printing forever despite what a user might expect. It would be preferable from a Principle of Least Surprise perspective if this worked differently.

## Implementation
 
This PR adds a new argument to `ev/deadline`:

```janet
(ev/deadline sec &opt tocancel tocheck intr?)
```

If a user sets `intr?` to true, the implementing C function sets up a background thread. If the timeout expires, the background thread calls `janet_interpreter_interrupt()`. This atomically increments `auto_suspend` in the Janet VM which in turn causes the VM to yield back to the scheduler. This gives the scheduler a chance to check the timeouts at which point the `tocancel` fiber is cancelled.

This PR does not modify the `ev/with-deadline` macro but if we wrote our own to use the new argument to `ev/deadline`:

```janet
(defmacro with-interrupt
  [sec & body]
  (with-syms [f]
    ~(let [,f (coro ,;body)]
       (,ev/deadline ,sec nil ,f true)
       (,resume ,f))))
```

Then we can now set a deadline for the following:

```janet
(ev/with-deadline 1 (forever (print "All work and no play makes Jack a dull boy."))
# out> All work and no play makes Jack a dull boy.
# out> All work and no play makes Jack a dull boy.
# out> All work and no play makes Jack a dull boy.
# <...>
# out> All work and no play makes Jack a dull boy.
# err> error: deadline expired
# err>  in coro [repl] on line 9, column 19
# err>  in thunk [repl] (tail call) on line 9, column 1
```

## Limitations

This still doesn’t work as might be expected:

```janet
(with-interrupt 1 (os/sleep 2))
# => nil
```

The reason is that the VM is paused while it waits for the C function `os_sleep` to return and interrupting the VM cannot cause the C function to ‘stop’. This could be addressed by having C functions called in background threads but that is considered out of scope for this PR.

## Note

In the course of developing this PR, a bug was (possibly) discovered in `vm.c`:

https://github.com/janet-lang/janet/blob/a456c67a7bbc51d30c08c261a05797b5267667fd/src/core/vm.c#L800-L803

Presumably this is meant to call the `vm_maybe_auto_suspend` macro if the jump is for a loop (where `DS` would be negative because we are jumping back to ‘earlier’ in the bytecode). However, `DS` is itself a macro that is calculated based on the value of `pc`:

https://github.com/janet-lang/janet/blob/a456c67a7bbc51d30c08c261a05797b5267667fd/src/core/vm.c#L50

So by checking `DS` _after_ we have modified `pc` we are not checking the value of the `DS` payload provided with the `JOP_JUMP` instruction but instead checking the payload of the next instruction (which may not even use the `DD DD DD` payload scheme).

This PR corrects the bug by checking `vm_maybe_auto_suspend` before `pc` is modified.