### PR TITLE
Update Makefile and meson to build with msys2 gcc and clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ LDFLAGS?=-rdynamic
 LIBJANET_LDFLAGS?=$(LD_FLAGS)
 RUN:=$(RUN)
 
+
 COMMON_CFLAGS:=-std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC
 BOOT_CFLAGS:=-DJANET_BOOTSTRAP -DJANET_BUILD=$(JANET_BUILD) -O0 $(COMMON_CFLAGS) -g
 BUILD_CFLAGS:=$(CFLAGS) $(COMMON_CFLAGS)
@@ -94,12 +95,18 @@ endif
 endif
 
 # Mingw
+MINGW_COMPILER=
 ifeq ($(findstring MINGW,$(UNAME)), MINGW)
+	MINGW_COMPILER=gcc
 	CLIBS:=-lws2_32 -lpsapi -lwsock32
 	LDFLAGS:=-Wl,--out-implib,$(JANET_IMPORT_LIB)
 	LIBJANET_LDFLAGS:=-Wl,--out-implib,$(JANET_LIBRARY_IMPORT_LIB)
 	JANET_TARGET:=$(JANET_TARGET).exe
 	JANET_BOOT:=$(JANET_BOOT).exe
+	COMPILER_VERSION:=$(shell $(CC) --version)
+	ifeq ($(findstring clang,$(COMPILER_VERSION)), clang)
+		MINGW_COMPILER=clang
+	endif
 endif
 
 
@@ -209,6 +216,11 @@ ifeq ($(UNAME), Darwin)
 SONAME=libjanet.1.37.dylib
 else
 SONAME=libjanet.so.1.37
+endif
+
+ifeq ($(MINGW_COMPILER), clang)
+	SONAME=
+	SONAME_SETTER=
 endif
 
 build/c/shell.c: src/mainclient/shell.c

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,15 @@ native_thread_dep = dependency('threads', native : true)
 # Deps
 m_dep = cc.find_library('m', required : false)
 dl_dep = cc.find_library('dl', required : false)
+
+# for MINGW/MSYS2
+native_ws2_dep = native_cc.find_library('ws2_32', required: false)
+native_psapi_dep = native_cc.find_library('psapi', required: false)
+native_wsock_dep = native_cc.find_library('wsock32', required: false)
+ws2_dep = cc.find_library('ws2_32', required: false)
+psapi_dep = cc.find_library('psapi', required: false)
+wsock_dep = cc.find_library('wsock32', required: false)
+
 android_spawn_dep = cc.find_library('android-spawn', required : false)
 thread_dep = dependency('threads')
 
@@ -173,8 +182,8 @@ mainclient_src = [
   'src/mainclient/shell.c'
 ]
 
-janet_dependencies = [m_dep, dl_dep, android_spawn_dep]
-janet_native_dependencies = [native_m_dep, native_dl_dep, native_android_spawn_dep]
+janet_dependencies = [m_dep, dl_dep, android_spawn_dep, ws2_dep, psapi_dep, wsock_dep]
+janet_native_dependencies = [native_m_dep, native_dl_dep, native_android_spawn_dep, native_ws2_dep, native_psapi_dep, native_wsock_dep]
 if not get_option('single_threaded')
   janet_dependencies += thread_dep
   janet_native_dependencies += native_thread_dep


### PR DESCRIPTION
This updates the Makefile and meson.build to allow building with both gcc and clang on MSYS2/x86_64 and clang on MSYS2/ARM64.

