### PR TITLE
Remove janet_lib_ffi() dependency on JANET_EV

### DIFF
--- a/src/core/util.h
+++ b/src/core/util.h
@@ -205,9 +205,9 @@ int janet_make_pipe(JanetHandle handles[2], int mode);
 #ifdef JANET_FILEWATCH
 void janet_lib_filewatch(JanetTable *env);
 #endif
+#endif
 #ifdef JANET_FFI
 void janet_lib_ffi(JanetTable *env);
-#endif
 #endif
 
 #endif


### PR DESCRIPTION
This PR addresses https://github.com/janet-lang/janet/issues/1571 by making the `janet_lib_ffi()` prototype declaration independent of `JANET_EV` being defined. 

This ensures that Janet can be compiled with a configuration which defines `JANET_NO_EV` but not `JANET_NO_FFI`.