### PR TITLE
Expand scope of code that works with `ev/deadline` again

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -662,8 +662,7 @@ static void janet_timeout_cb(JanetEVGenericMessage msg) {
 #ifdef JANET_WINDOWS
 static DWORD WINAPI janet_timeout_body(LPVOID ptr) {
     JanetThreadedTimeout *tto = (JanetThreadedTimeout *)ptr;
-    double sec = (tto->sec > 0) ? tto->sec : 0;
-    SleepEx((DWORD)(sec * 1000), TRUE);
+    SleepEx((DWORD)(tto->sec * 1000), TRUE);
     if (janet_fiber_can_resume(tto->fiber)) {
         janet_interpreter_interrupt(tto->vm);
         JanetEVGenericMessage msg = {0};
@@ -3176,6 +3175,7 @@ JANET_CORE_FN(cfun_ev_deadline,
               "background thread to try to interrupt the VM if the timeout expires.") {
     janet_arity(argc, 1, 4);
     double sec = janet_getnumber(argv, 0);
+    sec = (sec < 0) ? 0 : sec;
     JanetFiber *tocancel = janet_optfiber(argv, argc, 1, janet_vm.root_fiber);
     JanetFiber *tocheck = janet_optfiber(argv, argc, 2, janet_vm.fiber);
     int use_interrupt = janet_optboolean(argv, argc, 3, 0);

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -661,28 +661,30 @@ static void janet_timeout_cb(JanetEVGenericMessage msg) {
 
 #ifdef JANET_WINDOWS
 static DWORD WINAPI janet_timeout_body(LPVOID ptr) {
-    JanetThreadedTimeout *tto = (JanetThreadedTimeout *)ptr;
-    SleepEx((DWORD)(tto->sec * 1000), TRUE);
-    if (janet_fiber_can_resume(tto->fiber)) {
-        janet_interpreter_interrupt(tto->vm);
+    JanetThreadedTimeout tto = *(JanetThreadedTimeout *)ptr;
+    janet_free(ptr);
+    SleepEx((DWORD)(tto.sec * 1000), TRUE);
+    if (janet_fiber_can_resume(tto.fiber)) {
+        janet_interpreter_interrupt(tto.vm);
         JanetEVGenericMessage msg = {0};
-        janet_ev_post_event(tto->vm, janet_timeout_cb, msg);
+        janet_ev_post_event(tto.vm, janet_timeout_cb, msg);
     }
     return 0;
 }
 #else
 static void *janet_timeout_body(void *ptr) {
-    JanetThreadedTimeout *tto = (JanetThreadedTimeout *)ptr;
+    JanetThreadedTimeout tto = *(JanetThreadedTimeout *)ptr;
+    janet_free(ptr);
     struct timespec ts;
-    ts.tv_sec = (time_t) tto->sec;
-    ts.tv_nsec = (tto->sec <= UINT32_MAX)
-                 ? (long)((tto->sec - ((uint32_t)tto->sec)) * 1000000000)
+    ts.tv_sec = (time_t) tto.sec;
+    ts.tv_nsec = (tto.sec <= UINT32_MAX)
+                 ? (long)((tto.sec - ((uint32_t)tto.sec)) * 1000000000)
                  : 0;
     nanosleep(&ts, &ts);
-    if (janet_fiber_can_resume(tto->fiber)) {
-        janet_interpreter_interrupt(tto->vm);
+    if (janet_fiber_can_resume(tto.fiber)) {
+        janet_interpreter_interrupt(tto.vm);
         JanetEVGenericMessage msg = {0};
-        janet_ev_post_event(tto->vm, janet_timeout_cb, msg);
+        janet_ev_post_event(tto.vm, janet_timeout_cb, msg);
     }
     return NULL;
 }

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -59,6 +59,12 @@ typedef struct {
     JanetFiber *curr_fiber;
     uint32_t sched_id;
     int is_error;
+    int has_worker;
+#ifdef JANET_WINDOWS
+    HANDLE worker;
+#else
+    pthread_t worker;
+#endif
 } JanetTimeout;
 
 /* Registry table for C functions - contains metadata that can

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -27,7 +27,9 @@
 #include <stdint.h>
 
 #ifdef JANET_EV
-#ifndef JANET_WINDOWS
+#ifdef JANET_WINDOWS
+#include <windows.h>
+#else
 #include <pthread.h>
 #endif
 #endif

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -55,6 +55,7 @@ typedef struct {
     void *data;
 } JanetQueue;
 
+#ifdef JANET_EV
 typedef struct {
     JanetTimestamp when;
     JanetFiber *fiber;
@@ -68,6 +69,7 @@ typedef struct {
     pthread_t worker;
 #endif
 } JanetTimeout;
+#endif
 
 /* Registry table for C functions - contains metadata that can
  * be looked up by cfunction pointer. All strings here are pointing to

--- a/test/suite-ev.janet
+++ b/test/suite-ev.janet
@@ -550,4 +550,8 @@
   (ev/sleep 0.15)
   (assert (not terminated-normally) "early termination failure 3"))
 
+(let [f (coro (forever :foo))]
+  (ev/deadline 0.01 nil f true)
+  (assert-error "deadline expired" (resume f)))
+
 (end-suite)


### PR DESCRIPTION
This PR carries on from #1566. The background, implementation and limitations are largely the same as set out in that PR.

The key difference is that the background thread is now sent to sleep for the amount of the timeout (previously, the thread used `sleep(0)`). To avoid a scenario where the fiber being monitored has finished running but the background thread remains asleep (which would prevent the process from terminating), the thread is now cancelled. This is achieved on POSIX by using `nanosleep` (which creates a ['cancellation point'](https://www.man7.org/linux/man-pages/man3/pthread_cancel.3.html) for `pthread_cancel`) and on Windows by using `SleepEx` (which permits an [asynchronous procedure call](https://learn.microsoft.com/en-us/windows/win32/sync/asynchronous-procedure-calls) to be made using `QueueUserAPC`).

A test is also added to demonstrate usage.

## Note

The `JanetTimeout` struct is only used when the `JANET_EV` macro is defined but was always being declared in `state.h`. This PR puts the declaration inside a preprocessor directive. This is similar to how `<pthread.h>` is only included if the `JANET_EV` macro is defined.