### PR TITLE
Remove unix domain socket after test

### DIFF
--- a/test/suite-ev.janet
+++ b/test/suite-ev.janet
@@ -501,8 +501,10 @@
 # soreuseport on unix domain sockets
 (compwhen (or (= :macos (os/which)) (= :linux (os/which)))
   (assert-no-error "unix-domain socket reuseaddr"
-                   (let [s (net/listen :unix "./unix-domain-socket" :stream)]
-                     (:close s))))
+                   (let [uds-path "./unix-domain-socket"]
+                     (defer (os/rm uds-path)
+                       (let [s (net/listen :unix uds-path :stream)]
+                         (:close s))))))
 
 # net/accept-loop level triggering
 (gccollect)


### PR DESCRIPTION
This PR is a suggestion to remove `unix-domain-socket` near the end of the test involving it.