### PR TITLE
Fix mapcat docstring

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1103,8 +1103,9 @@
   and use `array/concat` to concatenate the results, but only if
   no `inds` are provided. Multiple data structures can be handled
   if each `inds` is a data structure and `f` is a function of
-  arity one more than the number of `inds`. The resulting array
-  has a length that is the shortest of `ind` and each of `inds`.
+  arity one more than the number of `inds`. Note that `f` is only
+  applied to values at indeces up to the largest index of the
+  shortest of `ind` and each of `inds`.
   ```
   [f ind & inds]
   (def res @[])


### PR DESCRIPTION
Sorry, I think I messed up the `mapcat` docstring.

The version that was merged recently says:

```
The resulting array has a length that is the shortest
of `ind` and each of `inds`.
```

but this doesn't necessarily hold, e.g.

```janet
(mapcat |(tuple ;$&) [:a :b] [:x :y :z] [0 1])
# =>
@[:a :x 0 :b :y 1]
```

I've substituted the following sentence in this PR:

```
Note that `f` is only applied to values at indeces up
to the largest index of the shortest of `ind` and each
of `inds`.
```

Hopefully this is more correct (^^;

