### PR TITLE
Fix mapcat and keep docstrings

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1103,8 +1103,9 @@
   and use `array/concat` to concatenate the results, but only if
   no `inds` are provided. Multiple data structures can be handled
   if each `inds` is a data structure and `f` is a function of
-  arity one more than the number of `inds`. The resulting array
-  has a length that is the shortest of `ind` and each of `inds`.
+  arity one more than the number of `inds`. Note that `f` is only
+  applied to values at indeces up to the largest index of the
+  shortest of `ind` and each of `inds`.
   ```
   [f ind & inds]
   (def res @[])
@@ -1143,8 +1144,8 @@
   structure `ind`, but only if no `inds` are provided. Multiple
   data structures can be handled if each `inds` is a data
   structure and `pred` is a function of arity one more than the
-  number of `inds`. The resulting array has a length that is the
-  shortest of `ind` and each of `inds`.
+  number of `inds`. The resulting array has a length that is no
+  longer than the shortest of `ind` and each of `inds`.
   ```
   [pred ind & inds]
   (def res @[])


### PR DESCRIPTION
Sorry, I think I messed up the `mapcat` and `keep` docstrings in https://github.com/janet-lang/janet/pull/1578.

---

For `mapcat` the docstring said:

```
The resulting array has a length that is the shortest
of `ind` and each of `inds`.
```

This is not correct, as shown by this example:

```janet
(mapcat |(tuple ;$&) [:a :b] [:x :y :z] [0 1])
# =>
@[:a :x 0 :b :y 1]
```

This PR suggests instead the text:

```
Note that `f` is only applied to values at indeces up
to the largest index of the shortest of `ind` and each
of `inds`.
```

---

For `keep`, the docstring said:

```
The resulting array has a length that is the shortest of
`ind` and each of `inds`.
```

This is not necessarily correct, as shown by this example:

```janet
(keep |(when (pos? (+ ;$&)) $0) [1 2 3] [-1 1 1])
# =>
@[2 3]
```

This PR suggests instead the text:

```
The resulting array has a length that is no longer than
the shortest of `ind` and each of `inds`.
```

---

Hopefully, the above suggestions correct the errors.

(Sorry about the mess up with https://github.com/janet-lang/janet/pull/1580 as well.)