### PR TITLE
Fix absence of pthread_cancel in Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 - Make `ffi/write` append to a buffer instead of insert at 0 by default.
 - Add `os/getpid` to get the current process id.
 - Add `:out` option to `os/spawn` to be able to redirect stderr to stdout with pipes.
+  Add `interrupt?` argument to `ev/deadline` to use VM interruptions.
 
 ## 1.38.0 - 2025-03-18
 - Add `bundle/replace`

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -67,6 +67,11 @@ extern "C" {
 #define JANET_LINUX 1
 #endif
 
+/* Check for Android */
+#ifdef __ANDROID__
+#define JANET_ANDROID 1
+#endif
+
 /* Check for Cygwin */
 #if defined(__CYGWIN__)
 #define JANET_CYGWIN 1


### PR DESCRIPTION
This PR fixes a build error on Android because `pthread_cancel` is [not implemented](https://android.googlesource.com/platform/bionic/+/refs/heads/main/docs/status.md#posix) in Bionic, the library Google uses for Android that implements parts of C like `pthread` (thanks to @sogaiu for bringing this to my attention). This PR uses signals for Android as a workaround.