### PR TITLE
Use strnlen when checking for null byte

### DIFF
--- a/src/core/pp.c
+++ b/src/core/pp.c
@@ -1066,7 +1066,7 @@ void janet_buffer_format(
                     if (form[2] == '\0')
                         janet_buffer_push_bytes(b, s, l);
                     else {
-                        if (l != (int32_t) strlen((const char *) s))
+                        if (l != (int32_t) strnlen((const char *) s, l))
                             janet_panic("string contains zeros");
                         if (!strchr(form, '.') && l >= 100) {
                             janet_panic("no precision and string is too long to be formatted");


### PR DESCRIPTION
Buffers are not always null-terminated, so using `strlen` here could cause reads past the end of the buffer and cause Janet to incorrectly report that the string contains zeros because the lengths don't match.

There may be other instances to fix, but this fixes #1600.