### PR TITLE
Clarify :fresh usage in import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased - ???
+- Raise helpful errors for incorrect arguments to `import`.
 - Allow configuring `JANET_THREAD_LOCAL` during builds to allow multi-threading on unknown compilers.
 - Make `ffi/write` append to a buffer instead of insert at 0 by default.
 - Add `os/getpid` to get the current process id.

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3185,8 +3185,13 @@
   value to bypass the module cache. Use `:only [foo bar baz]` to only import
   select bindings into the current environment.``
   [path & args]
+  (assertf (even? (length args)) "args should have even length: %n" args)
   (def ps (partition 2 args))
-  (def argm (mapcat (fn [[k v]] [k (case k :as (string v) :only ~(quote ,v) v)]) ps))
+  (def argm
+    (mapcat (fn [[k v]]
+              (assertf (keyword? k) "expected keyword, got %s: %n" (type k) k)
+              [k (case k :as (string v) :only ~(quote ,v) v)])
+            ps))
   (tuple import* (string path) ;argm))
 
 (defmacro use

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3181,9 +3181,9 @@
   use the name of the module as a prefix. One can also use "`:export true`"
   to re-export the imported symbols. If "`:exit true`" is given as an argument,
   any errors encountered at the top level in the module will cause `(os/exit 1)`
-  to be called. Dynamic bindings will NOT be imported. Use :fresh to bypass the
-  module cache. Use `:only [foo bar baz]` to only import select bindings into the
-  current environment.``
+  to be called. Dynamic bindings will NOT be imported. Use :fresh with a truthy
+  value to bypass the module cache. Use `:only [foo bar baz]` to only import
+  select bindings into the current environment.``
   [path & args]
   (def ps (partition 2 args))
   (def argm (mapcat (fn [[k v]] [k (case k :as (string v) :only ~(quote ,v) v)]) ps))

--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -865,6 +865,13 @@
 (assert (deep= ~(,import* "a" :as "b" :fresh maybe)
                (macex '(import a :as b :fresh maybe))) "import macro 2")
 
+# 2af3f21d
+(assert-error "import macro 2" (macex '(import a :fresh)))
+(assert-error "import macro 3" (macex '(import a :as b :fresh)))
+(assert-error "import macro 4" (macex '(import b "notakeyword" value)))
+(assert (deep= ~(,import* "a" :fresh nil)
+               (macex '(import a :fresh nil))) "import macro 5")
+
 # #477 walk preserving bracket type
 # 0a1d902f4
 (assert (= :brackets (tuple/type (postwalk identity '[])))


### PR DESCRIPTION
This confused me a lot, because I kept calling `(import ./mymodule :fresh)` and it wouldn't reload anything.