### PR TITLE
Fix: Correctly flag UDP streams in net/connect #1620

### DIFF
--- a/src/core/net.c
+++ b/src/core/net.c
@@ -547,7 +547,9 @@ JANET_CORE_FN(cfun_net_connect,
     }
 
     /* Wrap socket in abstract type JanetStream */
-    JanetStream *stream = make_stream(sock, JANET_STREAM_READABLE | JANET_STREAM_WRITABLE);
+    uint32_t udp_flag = 0;
+    if (socktype == SOCK_DGRAM) udp_flag = JANET_STREAM_UDPSERVER;
+    JanetStream *stream = make_stream(sock, JANET_STREAM_READABLE | JANET_STREAM_WRITABLE | udp_flag);
 
     /* Set up the socket for non-blocking IO before connecting */
     janet_net_socknoblock(sock);


### PR DESCRIPTION
This change adds the `JANET_STREAM_UDPSERVER` flag to `:datagram` streams created by `net/connect`.
Previously, these streams were missing the flag, causing functions like `net/send-to` to fail with a "bad stream" error.

Thank you.
