### PR TITLE
Fix `LDFLAGS` Usage in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ HOSTAR?=$(AR)
 # Symbols are (optionally) removed later, keep -g as default!
 CFLAGS?=-O2 -g
 LDFLAGS?=-rdynamic
-LIBJANET_LDFLAGS?=$(LD_FLAGS)
+LIBJANET_LDFLAGS?=$(LDFLAGS)
 RUN:=$(RUN)
 
 


### PR DESCRIPTION
This PR fixes what appears to be a typo `LDFLAGS` written with an additional `_` in the Makefile for setting the default linker flags for `libjanet`.