### PR TITLE
Use `CLOCKS_PER_SEC` instead of `CLOCKS_PER_SECOND`

### DIFF
--- a/src/core/util.c
+++ b/src/core/util.c
@@ -950,8 +950,8 @@ int janet_gettime(struct timespec *spec, enum JanetTimeSource source) {
     }
     if (source == JANET_TIME_CPUTIME) {
         clock_t tmp = clock();
-        spec->tv_sec = tmp / CLOCKS_PER_SECOND;
-        spec->tv_nsec = ((tmp - (spec->tv_sec * CLOCKS_PER_SECOND)) * 1000000000) / CLOCKS_PER_SECOND;
+        spec->tv_sec = tmp / CLOCKS_PER_SEC;
+        spec->tv_nsec = ((tmp - (spec->tv_sec * CLOCKS_PER_SEC)) * 1000000000) / CLOCKS_PER_SEC;
     }
     return 0;
 }


### PR DESCRIPTION
The POSIX standard defines that `clock(3)` returns a `clock_t` as a number of clock ticks in `CLOCKS_PER_SEC` and not `CLOCKS_PER_SECOND`, [source](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html).