### PR TITLE
illumos support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ SPORK_TAG?=master
 HAS_SHARED?=1
 DEBUGGER=gdb
 SONAME_SETTER=-Wl,-soname,
+STRIPFLAGS=-x -S
 
 # For cross compilation
 HOSTCC?=$(CC)
@@ -80,6 +81,12 @@ ifeq ($(UNAME), Darwin)
 	LDCONFIG:=true
 else ifeq ($(UNAME), Linux)
 	CLIBS:=$(CLIBS) -lrt -ldl
+else ifeq ($(UNAME), SunOS)
+	BUILD_CFLAGS+=-D__EXTENSIONS__ -DJANET_NO_NANBOX
+	BOOT_CFLAGS+=-D__EXTENSIONS__ -DJANET_NO_NANBOX
+	CLIBS:=-lsocket -lm
+	STRIPFLAGS=-x
+	LDCONFIG:=false
 endif
 
 # For other unix likes, add flags here!
@@ -289,7 +296,7 @@ build/janet-%.tar.gz: $(JANET_TARGET) \
 	README.md build/c/janet.c build/c/shell.c
 	mkdir -p build/$(JANET_DIST_DIR)/bin
 	cp $(JANET_TARGET) build/$(JANET_DIST_DIR)/bin/
-	strip -x -S 'build/$(JANET_DIST_DIR)/bin/janet'
+	strip $(STRIPFLAGS) 'build/$(JANET_DIST_DIR)/bin/janet'
 	mkdir -p build/$(JANET_DIST_DIR)/include
 	cp build/janet.h build/$(JANET_DIST_DIR)/include/
 	mkdir -p build/$(JANET_DIST_DIR)/lib/
@@ -336,7 +343,7 @@ build/janet.pc: $(JANET_TARGET)
 install: $(JANET_TARGET) $(JANET_LIBRARY) $(JANET_STATIC_LIBRARY) build/janet.pc build/janet.h
 	mkdir -p '$(DESTDIR)$(BINDIR)'
 	cp $(JANET_TARGET) '$(DESTDIR)$(BINDIR)/janet'
-	strip -x -S '$(DESTDIR)$(BINDIR)/janet'
+	strip $(STRIPFLAGS) '$(DESTDIR)$(BINDIR)/janet'
 	mkdir -p '$(DESTDIR)$(INCLUDEDIR)/janet'
 	cp -r build/janet.h '$(DESTDIR)$(INCLUDEDIR)/janet'
 	ln -sf ./janet/janet.h '$(DESTDIR)$(INCLUDEDIR)/janet.h'

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ gmake install-jpm-git
 NetBSD build instructions are the same as the FreeBSD build instructions.
 Alternatively, install the package directly with `pkgin install janet`.
 
+### illumos
+
+Building on illumos is exactly the same as building on FreeBSD.
+
 ### Windows
 
 1. Install [Visual Studio](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=15#) or [Visual Studio Build Tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15#).

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -173,6 +173,8 @@ JANET_CORE_FN(os_which,
     return janet_ckeywordv("dragonfly");
 #elif defined(JANET_BSD)
     return janet_ckeywordv("bsd");
+#elif defined(JANET_ILLUMOS)
+    return janet_ckeywordv("illumos");
 #else
     return janet_ckeywordv("posix");
 #endif
@@ -309,6 +311,13 @@ JANET_CORE_FN(os_cpu_count,
     int result = 0;
     size_t len = sizeof(int);
     if (-1 == sysctl(name, 2, &result, &len, NULL, 0)) {
+        return dflt;
+    }
+    return janet_wrap_integer(result);
+#elif defined(JANET_ILLUMOS)
+    (void) dflt;
+    long result = sysconf(_SC_NPROCESSORS_CONF);
+    if (result < 0) {
         return dflt;
     }
     return janet_wrap_integer(result);

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -77,6 +77,11 @@ extern "C" {
 #define JANET_CYGWIN 1
 #endif
 
+/* Check for Illumos */
+#if defined(__illumos__)
+#define JANET_ILLUMOS 1
+#endif
+
 /* Check Unix */
 #if defined(_AIX) \
     || defined(__APPLE__) /* Darwin */ \
@@ -162,7 +167,7 @@ extern "C" {
 #endif
 
 /* Check sun */
-#ifdef __sun
+#if defined(__sun) && !defined(JANET_ILLUMOS)
 #define JANET_NO_UTC_MKTIME
 #endif
 


### PR DESCRIPTION
This change makes Janet build cleanly on illumos. (Specifically, OmniOS: I have not tried it on other distributions.)

- Fixes build problems.
- Makes `(os/cpu-count)` work.
- Makes all tests pass.
- Makes `(os/which)` return `:illumos`.
- Patches the `Makefile` to not call `strip` with `-S` on illumos
 
I used gcc-14.2.0 on OmniOS-r151054.

I have successfully used this port for some time now. I am able to use JPM, Spork etc, and build native binaries successfully.

If this patch is accepted, I will be happy to provide illumos patches for JPM and Spork.

### Build/Install Output
<details>
<summary>expand</summary>

```
$ gmake install
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/abstract.boot.o -c src/core/abstract.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/array.boot.o -c src/core/array.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/asm.boot.o -c src/core/asm.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/buffer.boot.o -c src/core/buffer.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/bytecode.boot.o -c src/core/bytecode.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/capi.boot.o -c src/core/capi.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/cfuns.boot.o -c src/core/cfuns.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/compile.boot.o -c src/core/compile.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/corelib.boot.o -c src/core/corelib.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/debug.boot.o -c src/core/debug.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/emit.boot.o -c src/core/emit.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/ev.boot.o -c src/core/ev.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/ffi.boot.o -c src/core/ffi.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/fiber.boot.o -c src/core/fiber.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/filewatch.boot.o -c src/core/filewatch.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/gc.boot.o -c src/core/gc.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/inttypes.boot.o -c src/core/inttypes.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/io.boot.o -c src/core/io.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/marsh.boot.o -c src/core/marsh.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/math.boot.o -c src/core/math.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/net.boot.o -c src/core/net.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/os.boot.o -c src/core/os.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/parse.boot.o -c src/core/parse.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/peg.boot.o -c src/core/peg.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/pp.boot.o -c src/core/pp.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/regalloc.boot.o -c src/core/regalloc.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/run.boot.o -c src/core/run.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/specials.boot.o -c src/core/specials.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/state.boot.o -c src/core/state.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/string.boot.o -c src/core/string.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/strtod.boot.o -c src/core/strtod.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/struct.boot.o -c src/core/struct.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/symcache.boot.o -c src/core/symcache.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/table.boot.o -c src/core/table.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/tuple.boot.o -c src/core/tuple.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/util.boot.o -c src/core/util.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/value.boot.o -c src/core/value.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/vector.boot.o -c src/core/vector.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/vm.boot.o -c src/core/vm.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/core/wrap.boot.o -c src/core/wrap.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/boot/array_test.boot.o -c src/boot/array_test.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/boot/boot.boot.o -c src/boot/boot.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/boot/buffer_test.boot.o -c src/boot/buffer_test.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/boot/number_test.boot.o -c src/boot/number_test.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/boot/system_test.boot.o -c src/boot/system_test.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/boot/table_test.boot.o -c src/boot/table_test.c
gcc -DJANET_BOOTSTRAP -DJANET_BUILD="\"deede6ba\"" -O0 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -g -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/janet_boot build/core/abstract.boot.o build/core/array.boot.o build/core/asm.boot.o build/core/buffer.boot.o build/core/bytecode.boot.o build/core/capi.boot.o build/core/cfuns.boot.o build/core/compile.boot.o build/core/corelib.boot.o build/core/debug.boot.o build/core/emit.boot.o build/core/ev.boot.o build/core/ffi.boot.o build/core/fiber.boot.o build/core/filewatch.boot.o build/core/gc.boot.o build/core/inttypes.boot.o build/core/io.boot.o build/core/marsh.boot.o build/core/math.boot.o build/core/net.boot.o build/core/os.boot.o build/core/parse.boot.o build/core/peg.boot.o build/core/pp.boot.o build/core/regalloc.boot.o build/core/run.boot.o build/core/specials.boot.o build/core/state.boot.o build/core/string.boot.o build/core/strtod.boot.o build/core/struct.boot.o build/core/symcache.boot.o build/core/table.boot.o build/core/tuple.boot.o build/core/util.boot.o build/core/value.boot.o build/core/vector.boot.o build/core/vm.boot.o build/core/wrap.boot.o build/boot/array_test.boot.o build/boot/boot.boot.o build/boot/buffer_test.boot.o build/boot/number_test.boot.o build/boot/system_test.boot.o build/boot/table_test.boot.o -lsocket -lm
build/janet_boot . JANET_PATH '/usr/local/lib/janet' > build/c/janet.c
cksum build/c/janet.c
2010291979 3242568 build/c/janet.c
gcc -std=c99 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -D__EXTENSIONS__ -DJANET_NO_NANBOX -c build/c/janet.c -o build/janet.o
cp src/mainclient/shell.c build/c/shell.c
gcc -std=c99 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -D__EXTENSIONS__ -DJANET_NO_NANBOX -c build/c/shell.c -o build/shell.o
gcc -rdynamic -std=c99 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -D__EXTENSIONS__ -DJANET_NO_NANBOX -o build/janet build/janet.o build/shell.o -lsocket -lm
gcc -rdynamic -std=c99 -std=c99 -Wall -Wextra -Isrc/include -Isrc/conf -fvisibility=hidden -fPIC -D__EXTENSIONS__ -DJANET_NO_NANBOX -Wl,-soname,libjanet.so.1.38 -shared -o build/libjanet.so build/janet.o build/shell.o -lsocket -lm
ar rcs build/libjanet.a build/janet.o build/shell.o
./build/janet tools/patch-header.janet src/include/janet.h src/conf/janetconf.h build/janet.h
echo 'prefix=/usr/local' > build/janet.pc
echo 'exec_prefix=${prefix}' >> build/janet.pc
echo 'includedir=/usr/local/include/janet' >> build/janet.pc
echo 'libdir=/usr/local/lib' >> build/janet.pc
echo "" >> build/janet.pc
echo "Name: janet" >> build/janet.pc
echo "Url: https://janet-lang.org" >> build/janet.pc
echo "Description: Library for the Janet programming language." >> build/janet.pc
build/janet -e '(print "Version: " janet/version)' >> build/janet.pc
echo 'Cflags: -I${includedir}' >> build/janet.pc
echo 'Libs: -L${libdir} -ljanet' >> build/janet.pc
echo 'Libs.private: -lsocket -lm' >> build/janet.pc
mkdir -p '/usr/local/bin'
cp build/janet '/usr/local/bin/janet'
strip -x '/usr/local/bin/janet'
mkdir -p '/usr/local/include/janet'
cp -r build/janet.h '/usr/local/include/janet'
ln -sf ./janet/janet.h '/usr/local/include/janet.h'
mkdir -p '/usr/local/lib/janet'
mkdir -p '/usr/local/lib'
if test SunOS = Darwin ; then \
        cp build/libjanet.so '/usr/local/lib/libjanet.1.38.0.dylib' ; \
        ln -sf libjanet.so.1.38 '/usr/local/lib/libjanet.dylib' ; \
        ln -sf libjanet.1.38.0.dylib /usr/local/lib/libjanet.so.1.38 ; \
else \
        cp build/libjanet.so '/usr/local/lib/libjanet.so.1.38.0' ; \
        ln -sf libjanet.so.1.38 '/usr/local/lib/libjanet.so' ; \
        ln -sf libjanet.so.1.38.0 /usr/local/lib/libjanet.so.1.38 ; \
fi
cp build/libjanet.a '/usr/local/lib/libjanet.a'
mkdir -p '/usr/local/share/man/man1/'
cp janet.1 '/usr/local/share/man/man1/'
mkdir -p '/usr/local/lib/pkgconfig'
cp build/janet.pc '/usr/local/lib/pkgconfig/janet.pc'
cp 'build/janet.lib' '/usr/local/lib' || echo 'no import lib to install (mingw only)'
cp: cannot access build/janet.lib
no import lib to install (mingw only)
cp 'build/libjanet.lib' '/usr/local/lib' || echo 'no import lib to install (mingw only)'
cp: cannot access build/libjanet.lib
no import lib to install (mingw only)
[ -z '' ] && false || echo "You can ignore this error for non-Linux systems or local installs"
You can ignore this error for non-Linux systems or local installs
rm build/janet.pc
```
</details>

### Test Output
<details>
<summary>expand</summary>

```
$ gmake test
for f in test/suite*.janet; do  ./build/janet "$f" || exit; done
Starting suite test/suite-array.janet...
Finished suite test/suite-array.janet in 0.002 seconds - 29 of 29 tests passed (0 skipped).
Starting suite test/suite-asm.janet...
Finished suite test/suite-asm.janet in 0.009 seconds - 5 of 5 tests passed (0 skipped).
Starting suite test/suite-boot.janet...
Finished suite test/suite-boot.janet in 0.060 seconds - 1539 of 1539 tests passed (0 skipped).
Starting suite test/suite-buffer.janet...
Finished suite test/suite-buffer.janet in 0.003 seconds - 57 of 57 tests passed (0 skipped).
Starting suite test/suite-bundle.janet...
Finished suite test/suite-bundle.janet in 0.016 seconds - 30 of 30 tests passed (0 skipped).
Starting suite test/suite-capi.janet...
Finished suite test/suite-capi.janet in 0.001 seconds - 9 of 9 tests passed (0 skipped).
Starting suite test/suite-cfuns.janet...
Finished suite test/suite-cfuns.janet in 0.000 seconds - 2 of 2 tests passed (0 skipped).
Starting suite test/suite-compile.janet...
Finished suite test/suite-compile.janet in 0.001 seconds - 10 of 10 tests passed (0 skipped).
Starting suite test/suite-corelib.janet...
Finished suite test/suite-corelib.janet in 0.006 seconds - 93 of 93 tests passed (0 skipped).
Starting suite test/suite-debug.janet...
Finished suite test/suite-debug.janet in 0.000 seconds - 1 of 1 tests passed (0 skipped).
Starting suite test/suite-ev.janet...
Finished suite test/suite-ev.janet in 1.017 seconds - 716 of 716 tests passed (0 skipped).
Starting suite test/suite-ffi.janet...
Finished suite test/suite-ffi.janet in 0.003 seconds - 11 of 11 tests passed (0 skipped).
Starting suite test/suite-filewatch.janet...
Finished suite test/suite-filewatch.janet in 0.000 seconds - 1 of 1 tests passed (0 skipped).
Starting suite test/suite-inttypes.janet...
Finished suite test/suite-inttypes.janet in 0.013 seconds - 379 of 379 tests passed (0 skipped).
Starting suite test/suite-io.janet...
Finished suite test/suite-io.janet in 0.001 seconds - 11 of 11 tests passed (0 skipped).
Starting suite test/suite-marsh.janet...
Finished suite test/suite-marsh.janet in 0.010 seconds - 69 of 69 tests passed (0 skipped).
Starting suite test/suite-math.janet...
Finished suite test/suite-math.janet in 0.053 seconds - 157 of 157 tests passed (0 skipped).
Starting suite test/suite-os.janet...
Finished suite test/suite-os.janet in 0.121 seconds - 38 of 38 tests passed (0 skipped).
Starting suite test/suite-parse.janet...
Finished suite test/suite-parse.janet in 0.004 seconds - 60 of 60 tests passed (0 skipped).
Starting suite test/suite-peg.janet...
Finished suite test/suite-peg.janet in 0.017 seconds - 242 of 242 tests passed (0 skipped).
Starting suite test/suite-pp.janet...
Finished suite test/suite-pp.janet in 0.001 seconds - 12 of 12 tests passed (0 skipped).
Starting suite test/suite-specials.janet...
Finished suite test/suite-specials.janet in 0.003 seconds - 56 of 56 tests passed (0 skipped).
Starting suite test/suite-string.janet...
Finished suite test/suite-string.janet in 0.003 seconds - 68 of 68 tests passed (0 skipped).
Starting suite test/suite-strtod.janet...
Finished suite test/suite-strtod.janet in 0.000 seconds - 3 of 3 tests passed (0 skipped).
Starting suite test/suite-struct.janet...
Finished suite test/suite-struct.janet in 0.002 seconds - 32 of 32 tests passed (0 skipped).
Starting suite test/suite-symcache.janet...
Finished suite test/suite-symcache.janet in 0.001 seconds - 4 of 4 tests passed (0 skipped).
Starting suite test/suite-table.janet...
Finished suite test/suite-table.janet in 0.001 seconds - 15 of 15 tests passed (0 skipped).
Starting suite test/suite-tuple.janet...
Finished suite test/suite-tuple.janet in 0.000 seconds - 4 of 4 tests passed (0 skipped).
Starting suite test/suite-unknown.janet...
Finished suite test/suite-unknown.janet in 0.006 seconds - 67 of 67 tests passed (0 skipped).
Starting suite test/suite-value.janet...
Finished suite test/suite-value.janet in 0.001 seconds - 23 of 23 tests passed (0 skipped).
Starting suite test/suite-vm.janet...
Finished suite test/suite-vm.janet in 0.002 seconds - 36 of 36 tests passed (0 skipped).
for f in examples/*.janet; do  ./build/janet -k "$f"; done
```
</details>

### OS Support in REPL

```
$ janet
Janet 1.38.0-deede6ba illumos/x64/gcc - '(doc)' for help
repl:1:> (os/cpu-count)
4
repl:2:> (os/which)
:illumos
repl:3:>
```