### PR TITLE
Improve windows-related docs and notes

### DIFF
--- a/build_win.bat
+++ b/build_win.bat
@@ -49,6 +49,7 @@ for %%f in (src\boot\*.c) do (
 )
 %JANET_LINK% /out:build\janet_boot.exe build\boot\*.obj
 @if errorlevel 1 goto :BUILDFAIL
+@rem note that there is no default sysroot being baked in
 build\janet_boot . > build\c\janet.c
 @if errorlevel 1 goto :BUILDFAIL
 

--- a/janet.1
+++ b/janet.1
@@ -214,7 +214,7 @@ Don't execute a script, only compile it to check for errors. Useful for linting 
 .BR \-m\ syspath
 Set the dynamic binding :syspath to the string syspath so that Janet will load system modules
 from a directory different than the default. The default is set when Janet is built, and defaults to
-/usr/local/lib/janet on Linux/Posix, and C:/Janet/Library on Windows. This option supersedes JANET_PATH.
+/usr/local/lib/janet on Linux/Posix. On Windows, there is no default value. This option supersedes JANET_PATH.
 
 .TP
 .BR \-c\ source\ output
@@ -255,8 +255,7 @@ and then arguments to the script.
 .RS
 The location to look for Janet libraries. This is the only environment variable Janet needs to
 find native and source code modules. If no JANET_PATH is set, Janet will look in
-the default location set at compile time. This should be a list of as well as a colon
-separate list of such directories.
+the default location set at compile time. This should be a colon-separated list of directory names on Linux/Posix, and a semicolon-separated list on Windows. Note that a typical setup (i.e. not NixOS / Guix) will only use a single directory.
 .RE
 
 .B JANET_PROFILE

--- a/tools/msi/janet.wxs
+++ b/tools/msi/janet.wxs
@@ -37,6 +37,12 @@
 			 Version="$(var.Version)"
 			 Manufacturer="$(var.Manufacturer)"
 			 UpgradeCode="$(var.UpgradeCode)">
+       <!--
+         perUser means destination will be under user's %AppData% directory,
+         not Program Files or similar.
+
+         see: https://learn.microsoft.com/en-us/windows/win32/msi/installation-context
+       -->
         <Package Compressed="yes"
 				 InstallScope="perUser"
 				 Manufacturer="$(var.Manufacturer)"


### PR DESCRIPTION
This PR is an attempt to improve some of the Windows-related documentation as well as comments in some related files.

The main user-visible bit is a suggestion to change the man page which currently mentions:

```
-m syspath
       Set the dynamic binding :syspath to the string syspath  so  that
       Janet  will  load system modules from a directory different than
       the default. The default is set when Janet  is  built,  and
       defaults to /usr/local/lib/janet on Linux/Posix, and
       C:/Janet/Library on Windows. This option supersedes JANET_PATH.
```

AFAIU, unlike for non-Windows [1], [on Windows, there is no default value baked in to `janet.exe`](https://github.com/janet-lang/janet/blob/8e7b1e9ce0d866ac1b7d6765171c49dd7afe26ad/build_win.bat#L52)[2].

The proposed new text is:

```
-m syspath
       Set the dynamic binding :syspath to the string syspath so that
       Janet will load system modules from a directory different than
       the default. The default is set when Janet is built, and 
       defaults to /usr/local/lib/janet on Linux/Posix. On Windows,
       there is no default value. This option supersedes JANET_PATH.
```

Note that, if one installs from the official (or locally-built) `.msi`, "arrangements are made" (TM) so that `JANET_PATH` is set to some location under `%APPDATA%` [3].  Thus, subsequent typical invocations of `janet.exe` (e.g. those made via new command prompts) will have `JANET_PATH` set and consequently `(dyn :syspath)` will likely yield a non-nil string path.

---

While I was at it, I also tweaked the man page bit about `JANET_PATH` to have:

> If no JANET_PATH is set, Janet will look in the default location set at compile time. This should be a colon-separated list of directory names on Linux/Posix, and a semicolon-separated list on Windows. Note that a typical setup (i.e. not NixOS / Guix) will only use a single directory.

---

[1] See [here](https://github.com/janet-lang/janet/blob/8e7b1e9ce0d866ac1b7d6765171c49dd7afe26ad/Makefile#L208) and [here](https://github.com/janet-lang/janet/blob/8e7b1e9ce0d866ac1b7d6765171c49dd7afe26ad/Makefile#L43).

[2] This was also verified by manually building `janet.exe` from source on Windows and checking `(dyn :syspath)` (which returned `nil`) on a system that didn't have Janet installed via a typical `.msi`.

[3] A comment was added to `tools/msi/janet.wxs` to this effect.