### PR TITLE
Put `<janet.h>` include behind guard

### DIFF
--- a/src/core/state.h
+++ b/src/core/state.h
@@ -26,6 +26,7 @@
 #ifndef JANET_AMALG
 #include <janet.h>
 #endif
+
 #include <stdint.h>
 
 #ifdef JANET_EV


### PR DESCRIPTION
For the Janet amalgamation to work properly, `include <janet.h>` needs to put behind a guard. This is done in all the header files except `src/core/state.h`. This fixes that mistake.