### PR TITLE
Check dependencies after running `:dependencies` hook

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4341,9 +4341,6 @@
         (def info (-> infofile-dest slurp parse))
         (def deps (seq [d :in (get info :dependencies @[])]
                    (string (if (dictionary? d) (get d :name) d))))
-        (def missing (filter (complement bundle/installed?) deps))
-        (when (next missing)
-          (error (string "missing dependencies " (string/join missing ", "))))
         (put man :dependencies deps)
         (put man :info info))
       (def clean (get config :clean))
@@ -4352,6 +4349,9 @@
       (def all-hooks (seq [[k v] :pairs module :when (symbol? k) :unless (get v :private)] (keyword k)))
       (put man :hooks all-hooks)
       (do-hook module bundle-name :dependencies man)
+      (def missing (filter (complement bundle/installed?) (get man :dependencies [])))
+      (when (next missing)
+        (error (string "missing dependencies " (string/join missing ", "))))
       (when clean
         (do-hook module bundle-name :clean man))
       (do-hook module bundle-name :build man)


### PR DESCRIPTION
This PR moves the dependency checking that occurs in `bundle/install`. Rather than have the dependency check occur before calling the `:dependencies` hook, this PR puts the hook first.

## Background

Janet includes a `bundle/install` function that can be used to install code _bundles_ (i.e. packages). This function runs a number of hooks, including `:dependencies`. A user is able to register a function to the hook by providing a function with the same name in the bundle script.

## Implementation

This PR moves the dependency checks to a later stage in `bundle/install` after any dependencies have been installed.

## Limitations

I confess the decision to have the `:dependencies` hook called after checking the dependencies have been installed is confusing to me. I am not sure if there is a side to this decision that I am missing.