### PR TITLE
Update `bundle/` functions

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4387,6 +4387,9 @@
     (when (get man :has-bin)
       (def binpath (string (dyn *syspath*) s "bin"))
       (eprintf "executable files have been installed to %s" binpath))
+    (when (get man :has-man)
+      (def manpath (string (dyn *syspath*) s "man"))
+      (eprintf "man pages have been installed to %s" manpath))
     bundle-name)
 
   (defn- bundle/pack
@@ -4514,8 +4517,8 @@
       (errorf "bad path %s - file is a %s" src mode)))
 
   (defn bundle/add-bin
-    ``Add a file to the bin subdirectory of the current syspath. Files will be
-    set to be executable.``
+    ``Add a file to the bin subdirectory of the current syspath. By default,
+    files will be set to be executable.``
     [manifest src &opt filename chmod-mode]
     (def s (sep))
     (default filename (last (string/split s src)))
@@ -4524,6 +4527,18 @@
     (put manifest :has-bin-script true) # deprecated, use :has-bin
     (put manifest :has-bin true)
     (bundle/add-file manifest src (string "bin" s filename) chmod-mode))
+
+  (defn bundle/add-manpage
+    ``Add a file to the man subdirectory of the current syspath. Files are
+    copied inside a directory `mansec`. By default, `mansec` is "man1".``
+    [manifest src &opt mansec]
+    (def s (sep))
+    (default mansec "man1")
+    (def filename (last (string/split s src)))
+    (os/mkdir (string (dyn *syspath*) s "man"))
+    (os/mkdir (string (dyn *syspath*) s "man" s mansec))
+    (put manifest :has-man true)
+    (bundle/add-file manifest src (string "man" s mansec s filename)))
 
   (defn bundle/update-all
     "Reinstall all bundles."

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4326,7 +4326,7 @@
   (defn bundle/install
     ``Install a bundle from the local filesystem. The name of the bundle is
     the value mapped to :name in either `config` or the info file. There are
-    5 hooks called during installation (dependencies, clean, build, install and
+    5 hooks called during installation (postdeps, clean, build, install and
     check). A user can register a hook by defining a function with the same name
     in the bundle script.``
     [path &keys config]
@@ -4375,7 +4375,8 @@
       (def module (get-bundle-module bundle-name))
       (def all-hooks (seq [[k v] :pairs module :when (symbol? k) :unless (get v :private)] (keyword k)))
       (put man :hooks all-hooks)
-      (do-hook module bundle-name :dependencies man)
+      (do-hook module bundle-name :dependencies man) # deprecated, use :postdeps
+      (do-hook module bundle-name :postdeps man)
       (do-hook module bundle-name :clean man)
       (do-hook module bundle-name :build man)
       (do-hook module bundle-name :install man)

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4384,9 +4384,9 @@
       (sync-manifest man)
       (do-hook module bundle-name :check man))
     (print "installed " bundle-name)
-    (when (get man :has-bin-script)
+    (when (get man :has-bin)
       (def binpath (string (dyn *syspath*) s "bin"))
-      (eprintf "executable scripts have been installed to %s" binpath))
+      (eprintf "executable files have been installed to %s" binpath))
     bundle-name)
 
   (defn- bundle/pack
@@ -4514,14 +4514,15 @@
       (errorf "bad path %s - file is a %s" src mode)))
 
   (defn bundle/add-bin
-    ``Add a script to the bin subdirectory of the current syspath. Scripts will
-    be set to be executable.``
+    ``Add a file to the bin subdirectory of the current syspath. Files will be
+    set to be executable.``
     [manifest src &opt filename chmod-mode]
     (def s (sep))
     (default filename (last (string/split s src)))
     (default chmod-mode 8r755)
     (os/mkdir (string (dyn *syspath*) s "bin"))
-    (put manifest :has-bin-script true)
+    (put manifest :has-bin-script true) # deprecated, use :has-bin
+    (put manifest :has-bin true)
     (bundle/add-file manifest src (string "bin" s filename) chmod-mode))
 
   (defn bundle/update-all


### PR DESCRIPTION
This PR updates the `bundle/` functions. It does four things:

1. tidies up docstrings
2. changes a hook name from `:dependencies` to `:postdeps`
3. changes `:has-bin-script` to `:has-bin`
4. add a `bundle/add-manpage` function

The changes are in four separate commits so that they can be cherry-picked if one or more of them are undesirable.

I think the changes are mostly self-explanatory but the reason to change `:has-bin-script` to `:has-bin` is because the file that is added to the binpath is not necessarily a binscript. Or at least, I can’t see any reason why it is necessarily a binscript (in [Predoc](https://github.com/pyrmont/predoc), I add a file using `bundle/add-bin` and it is a compiled file).