### PR TITLE
Revert some bundle/install changes

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4373,16 +4373,20 @@
         (put man :dependencies deps)
         (put man :info info))
       (def module (get-bundle-module bundle-name))
+      (def clean (get config :clean))
+      (def check (get config :check))
       (def all-hooks (seq [[k v] :pairs module :when (symbol? k) :unless (get v :private)] (keyword k)))
       (put man :hooks all-hooks)
       (do-hook module bundle-name :dependencies man) # deprecated, use :postdeps
       (do-hook module bundle-name :postdeps man)
-      (do-hook module bundle-name :clean man)
+      (when clean
+        (do-hook module bundle-name :clean man))
       (do-hook module bundle-name :build man)
       (do-hook module bundle-name :install man)
       (if (empty? (get man :files)) (print "no files installed, is this a valid bundle?"))
       (sync-manifest man)
-      (do-hook module bundle-name :check man))
+      (when check
+        (do-hook module bundle-name :check man)))
     (print "installed " bundle-name)
     (when (get man :has-bin-script)
       (def binpath (string (dyn *syspath*) s "bin"))


### PR DESCRIPTION
This PR is an attempt to fix some breakage that seems to have been introduced in [this commit](https://github.com/janet-lang/janet/commit/6a96b615f0113a5c671fea71c2b66e89df8348dc).

The symptoms can be seen by running `spork`'s tests [1].  They go into what seems like an infinite loop:

```
~/src/spork$ janet-pm clean-all && jpm clean && jpm test
removing directory _build
Deleted build directory build
compiling deps/miniz/miniz.c to build/deps___miniz___miniz.o...
compiling src/base64.c to build/src___base64.o...
compiling src/utf8.c to build/src___utf8.o...
compiling src/json.c to build/src___json.o...
compiling src/rawterm.c to build/src___rawterm.o...
compiling src/crc.c to build/src___crc.o...
compiling src/cmath.c to build/src___cmath.o...
generating meta file build/spork/rawterm.meta.janet...
generating meta file build/spork/zip.meta.janet...
generating meta file build/spork/json.meta.janet...
generating meta file build/spork/crc.meta.janet...
generating meta file build/spork/utf8.meta.janet...
compiling src/tarray.c to build/src___tarray.o...
generating meta file build/spork/tarray.meta.janet...
compiling src/zip.c to build/src___zip.o...
generating meta file build/spork/cmath.meta.janet...
generating meta file build/spork/base64.meta.janet...
creating native module build/spork/utf8.so...
compiling src/utf8.c to build/src___utf8.static.o...
compiling src/cmath.c to build/src___cmath.static.o...
creating native module build/spork/cmath.so...
creating native module build/spork/base64.so...
compiling src/base64.c to build/src___base64.static.o...
creating native module build/spork/crc.so...
compiling src/crc.c to build/src___crc.static.o...
compiling src/rawterm.c to build/src___rawterm.static.o...
creating native module build/spork/rawterm.so...
creating native module build/spork/json.so...
compiling src/json.c to build/src___json.static.o...
creating static library build/spork/utf8.a...
compiling src/zip.c to build/src___zip.static.o...
creating static library build/spork/cmath.a...
creating static library build/spork/base64.a...
creating native module build/spork/tarray.so...
compiling src/tarray.c to build/src___tarray.static.o...
creating static library build/spork/crc.a...
creating static library build/spork/json.a...
creating static library build/spork/rawterm.a...
creating static library build/spork/tarray.a...
compiling deps/miniz/miniz.c to build/deps___miniz___miniz.static.o...
creating native module build/spork/zip.so...
creating static library build/spork/zip.a...
running test/suite-argparse.janet ...
test suite test/suite-argparse.janet finished in 0.001 seconds - 17 of 17 tests passed.
running test/suite-base64.janet ...
test suite test/suite-base64.janet finished in 0.000 seconds - 22 of 22 tests passed.
running test/suite-cc.janet ...
test suite test/suite-cc.janet finished in 0.001 seconds - 12 of 12 tests passed.
running test/suite-crc.janet ...
test suite test/suite-crc.janet finished in 0.000 seconds - 7 of 7 tests passed.
running test/suite-cron.janet ...
test suite test/suite-cron.janet finished in 0.001 seconds - 5 of 5 tests passed.
running test/suite-data.janet ...
test suite test/suite-data.janet finished in 0.003 seconds - 40 of 40 tests passed.
running test/suite-declare-cc.janet ...
test suite test/suite-declare-cc.janet finished in 0.000 seconds - 27 of 27 tests passed.
running test/suite-ev-utils.janet ...
test suite test/suite-ev-utils.janet finished in 0.000 seconds - 2 of 2 tests passed.
running test/suite-fmt.janet ...
test suite test/suite-fmt.janet finished in 0.001 seconds - 7 of 7 tests passed.
running test/suite-generators.janet ...
test suite test/suite-generators.janet finished in 0.001 seconds - 44 of 44 tests passed.
running test/suite-htmlgen.janet ...
test suite test/suite-htmlgen.janet finished in 0.000 seconds - 7 of 7 tests passed.
running test/suite-http.janet ...
test suite test/suite-http.janet finished in 0.059 seconds - 62 of 62 tests passed.
running test/suite-infix.janet ...
test suite test/suite-infix.janet finished in 0.002 seconds - 47 of 47 tests passed.
running test/suite-json.janet ...
test suite test/suite-json.janet finished in 0.002 seconds - 34 of 34 tests passed.
running test/suite-math.janet ...
test suite test/suite-math.janet finished in 0.686 seconds - 354 of 354 tests passed.
running test/suite-mdz.janet ...
test suite test/suite-mdz.janet finished in 0.000 seconds - 35 of 35 tests passed.
running test/suite-misc.janet ...
test suite test/suite-misc.janet finished in 0.003 seconds - 75 of 75 tests passed.
running test/suite-msg.janet ...
test suite test/suite-msg.janet finished in 0.000 seconds - 2 of 2 tests passed.
running test/suite-netrepl.janet ...
Starting networked repl server on 127.0.0.1, port 8000...
client test connected
test suite test/suite-netrepl.janet finished in 0.246 seconds - 14 of 14 tests passed.
closing client test
running test/suite-path.janet ...
test suite test/suite-path.janet finished in 0.002 seconds - 46 of 46 tests passed.
running test/suite-pgp.janet ...
test suite test/suite-pgp.janet finished in 0.001 seconds - 10 of 10 tests passed.
running test/suite-pm-pre-post.janet ...
test suite test/suite-argparse.janet finished in 0.001 seconds - 17 of 17 tests passed.
test suite test/suite-base64.janet finished in 0.000 seconds - 22 of 22 tests passed.
test suite test/suite-cc.janet finished in 0.001 seconds - 12 of 12 tests passed.
test suite test/suite-crc.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-cron.janet finished in 0.001 seconds - 5 of 5 tests passed.
test suite test/suite-data.janet finished in 0.002 seconds - 40 of 40 tests passed.
test suite test/suite-declare-cc.janet finished in 0.000 seconds - 27 of 27 tests passed.
test suite test/suite-ev-utils.janet finished in 0.000 seconds - 2 of 2 tests passed.
test suite test/suite-fmt.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-generators.janet finished in 0.001 seconds - 44 of 44 tests passed.
test suite test/suite-htmlgen.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-http.janet finished in 0.058 seconds - 62 of 62 tests passed.
test suite test/suite-infix.janet finished in 0.002 seconds - 47 of 47 tests passed.
test suite test/suite-json.janet finished in 0.001 seconds - 34 of 34 tests passed.
test suite test/suite-math.janet finished in 0.689 seconds - 354 of 354 tests passed.
test suite test/suite-mdz.janet finished in 0.000 seconds - 35 of 35 tests passed.
test suite test/suite-misc.janet finished in 0.003 seconds - 75 of 75 tests passed.
test suite test/suite-msg.janet finished in 0.000 seconds - 2 of 2 tests passed.
Starting networked repl server on 127.0.0.1, port 8000...
client test connected
test suite test/suite-netrepl.janet finished in 0.247 seconds - 14 of 14 tests passed.
closing client test
test suite test/suite-path.janet finished in 0.001 seconds - 46 of 46 tests passed.
test suite test/suite-pgp.janet finished in 0.001 seconds - 10 of 10 tests passed.
test suite test/suite-argparse.janet finished in 0.001 seconds - 17 of 17 tests passed.
test suite test/suite-base64.janet finished in 0.000 seconds - 22 of 22 tests passed.
test suite test/suite-cc.janet finished in 0.002 seconds - 12 of 12 tests passed.
test suite test/suite-crc.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-cron.janet finished in 0.001 seconds - 5 of 5 tests passed.
test suite test/suite-data.janet finished in 0.003 seconds - 40 of 40 tests passed.
test suite test/suite-declare-cc.janet finished in 0.000 seconds - 27 of 27 tests passed.
test suite test/suite-ev-utils.janet finished in 0.000 seconds - 2 of 2 tests passed.
test suite test/suite-fmt.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-generators.janet finished in 0.001 seconds - 44 of 44 tests passed.
test suite test/suite-htmlgen.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-http.janet finished in 0.059 seconds - 62 of 62 tests passed.
test suite test/suite-infix.janet finished in 0.002 seconds - 47 of 47 tests passed.
test suite test/suite-json.janet finished in 0.001 seconds - 34 of 34 tests passed.
test suite test/suite-math.janet finished in 0.681 seconds - 354 of 354 tests passed.
test suite test/suite-mdz.janet finished in 0.000 seconds - 35 of 35 tests passed.
test suite test/suite-misc.janet finished in 0.003 seconds - 75 of 75 tests passed.
test suite test/suite-msg.janet finished in 0.000 seconds - 2 of 2 tests passed.
Starting networked repl server on 127.0.0.1, port 8000...
client test connected
test suite test/suite-netrepl.janet finished in 0.247 seconds - 14 of 14 tests passed.
closing client test
test suite test/suite-path.janet finished in 0.001 seconds - 46 of 46 tests passed.
test suite test/suite-pgp.janet finished in 0.001 seconds - 10 of 10 tests passed.
test suite test/suite-argparse.janet finished in 0.001 seconds - 17 of 17 tests passed.
test suite test/suite-base64.janet finished in 0.000 seconds - 22 of 22 tests passed.
test suite test/suite-cc.janet finished in 0.001 seconds - 12 of 12 tests passed.
test suite test/suite-crc.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-cron.janet finished in 0.001 seconds - 5 of 5 tests passed.
test suite test/suite-data.janet finished in 0.003 seconds - 40 of 40 tests passed.
test suite test/suite-declare-cc.janet finished in 0.000 seconds - 27 of 27 tests passed.
test suite test/suite-ev-utils.janet finished in 0.000 seconds - 2 of 2 tests passed.
test suite test/suite-fmt.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-generators.janet finished in 0.001 seconds - 44 of 44 tests passed.
test suite test/suite-htmlgen.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-http.janet finished in 0.059 seconds - 62 of 62 tests passed.
test suite test/suite-infix.janet finished in 0.002 seconds - 47 of 47 tests passed.
test suite test/suite-json.janet finished in 0.001 seconds - 34 of 34 tests passed.
test suite test/suite-math.janet finished in 0.679 seconds - 354 of 354 tests passed.
test suite test/suite-mdz.janet finished in 0.000 seconds - 35 of 35 tests passed.
test suite test/suite-misc.janet finished in 0.003 seconds - 75 of 75 tests passed.
test suite test/suite-msg.janet finished in 0.000 seconds - 2 of 2 tests passed.
Starting networked repl server on 127.0.0.1, port 8000...
client test connected
test suite test/suite-netrepl.janet finished in 0.247 seconds - 14 of 14 tests passed.
closing client test
test suite test/suite-path.janet finished in 0.001 seconds - 46 of 46 tests passed.
test suite test/suite-pgp.janet finished in 0.001 seconds - 10 of 10 tests passed.
test suite test/suite-argparse.janet finished in 0.001 seconds - 17 of 17 tests passed.
test suite test/suite-base64.janet finished in 0.000 seconds - 22 of 22 tests passed.
test suite test/suite-cc.janet finished in 0.001 seconds - 12 of 12 tests passed.
test suite test/suite-crc.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-cron.janet finished in 0.001 seconds - 5 of 5 tests passed.
test suite test/suite-data.janet finished in 0.002 seconds - 40 of 40 tests passed.
test suite test/suite-declare-cc.janet finished in 0.000 seconds - 27 of 27 tests passed.
test suite test/suite-ev-utils.janet finished in 0.000 seconds - 2 of 2 tests passed.
test suite test/suite-fmt.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-generators.janet finished in 0.001 seconds - 44 of 44 tests passed.
test suite test/suite-htmlgen.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-http.janet finished in 0.057 seconds - 62 of 62 tests passed.
test suite test/suite-infix.janet finished in 0.002 seconds - 47 of 47 tests passed.
test suite test/suite-json.janet finished in 0.001 seconds - 34 of 34 tests passed.
test suite test/suite-math.janet finished in 0.685 seconds - 354 of 354 tests passed.
test suite test/suite-mdz.janet finished in 0.000 seconds - 35 of 35 tests passed.
test suite test/suite-misc.janet finished in 0.004 seconds - 75 of 75 tests passed.
test suite test/suite-msg.janet finished in 0.000 seconds - 2 of 2 tests passed.
Starting networked repl server on 127.0.0.1, port 8000...
client test connected
test suite test/suite-netrepl.janet finished in 0.246 seconds - 14 of 14 tests passed.
closing client test
test suite test/suite-path.janet finished in 0.001 seconds - 46 of 46 tests passed.
test suite test/suite-pgp.janet finished in 0.002 seconds - 10 of 10 tests passed.
test suite test/suite-argparse.janet finished in 0.001 seconds - 17 of 17 tests passed.
test suite test/suite-base64.janet finished in 0.000 seconds - 22 of 22 tests passed.
test suite test/suite-cc.janet finished in 0.001 seconds - 12 of 12 tests passed.
test suite test/suite-crc.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-cron.janet finished in 0.001 seconds - 5 of 5 tests passed.
test suite test/suite-data.janet finished in 0.003 seconds - 40 of 40 tests passed.
test suite test/suite-declare-cc.janet finished in 0.000 seconds - 27 of 27 tests passed.
test suite test/suite-ev-utils.janet finished in 0.000 seconds - 2 of 2 tests passed.
test suite test/suite-fmt.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-generators.janet finished in 0.001 seconds - 44 of 44 tests passed.
test suite test/suite-htmlgen.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-http.janet finished in 0.060 seconds - 62 of 62 tests passed.
test suite test/suite-infix.janet finished in 0.002 seconds - 47 of 47 tests passed.
test suite test/suite-json.janet finished in 0.002 seconds - 34 of 34 tests passed.
test suite test/suite-math.janet finished in 0.685 seconds - 354 of 354 tests passed.
test suite test/suite-mdz.janet finished in 0.000 seconds - 35 of 35 tests passed.
test suite test/suite-misc.janet finished in 0.003 seconds - 75 of 75 tests passed.
test suite test/suite-msg.janet finished in 0.000 seconds - 2 of 2 tests passed.
Starting networked repl server on 127.0.0.1, port 8000...
client test connected
test suite test/suite-netrepl.janet finished in 0.247 seconds - 14 of 14 tests passed.
closing client test
test suite test/suite-path.janet finished in 0.001 seconds - 46 of 46 tests passed.
test suite test/suite-pgp.janet finished in 0.001 seconds - 10 of 10 tests passed.
test suite test/suite-argparse.janet finished in 0.001 seconds - 17 of 17 tests passed.
test suite test/suite-base64.janet finished in 0.000 seconds - 22 of 22 tests passed.
test suite test/suite-cc.janet finished in 0.001 seconds - 12 of 12 tests passed.
test suite test/suite-crc.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-cron.janet finished in 0.001 seconds - 5 of 5 tests passed.
test suite test/suite-data.janet finished in 0.003 seconds - 40 of 40 tests passed.
test suite test/suite-declare-cc.janet finished in 0.000 seconds - 27 of 27 tests passed.
test suite test/suite-ev-utils.janet finished in 0.000 seconds - 2 of 2 tests passed.
test suite test/suite-fmt.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-generators.janet finished in 0.001 seconds - 44 of 44 tests passed.
test suite test/suite-htmlgen.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-http.janet finished in 0.058 seconds - 62 of 62 tests passed.
test suite test/suite-infix.janet finished in 0.002 seconds - 47 of 47 tests passed.
test suite test/suite-json.janet finished in 0.001 seconds - 34 of 34 tests passed.
test suite test/suite-math.janet finished in 0.676 seconds - 354 of 354 tests passed.
test suite test/suite-mdz.janet finished in 0.000 seconds - 35 of 35 tests passed.
test suite test/suite-misc.janet finished in 0.003 seconds - 75 of 75 tests passed.
test suite test/suite-msg.janet finished in 0.000 seconds - 2 of 2 tests passed.
Starting networked repl server on 127.0.0.1, port 8000...
client test connected
test suite test/suite-netrepl.janet finished in 0.247 seconds - 14 of 14 tests passed.
closing client test
test suite test/suite-path.janet finished in 0.002 seconds - 46 of 46 tests passed.
test suite test/suite-pgp.janet finished in 0.001 seconds - 10 of 10 tests passed.
test suite test/suite-argparse.janet finished in 0.001 seconds - 17 of 17 tests passed.
test suite test/suite-base64.janet finished in 0.000 seconds - 22 of 22 tests passed.
test suite test/suite-cc.janet finished in 0.001 seconds - 12 of 12 tests passed.
test suite test/suite-crc.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-cron.janet finished in 0.001 seconds - 5 of 5 tests passed.
test suite test/suite-data.janet finished in 0.003 seconds - 40 of 40 tests passed.
test suite test/suite-declare-cc.janet finished in 0.000 seconds - 27 of 27 tests passed.
test suite test/suite-ev-utils.janet finished in 0.000 seconds - 2 of 2 tests passed.
test suite test/suite-fmt.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-generators.janet finished in 0.001 seconds - 44 of 44 tests passed.
test suite test/suite-htmlgen.janet finished in 0.000 seconds - 7 of 7 tests passed.
test suite test/suite-http.janet finished in 0.057 seconds - 62 of 62 tests passed.
test suite test/suite-infix.janet finished in 0.002 seconds - 47 of 47 tests passed.
test suite test/suite-json.janet finished in 0.002 seconds - 34 of 34 tests passed.
...
```

I haven't quite understood what is going on, but I believe it has something to do with the `:check` hook.  Since I don't quite get it, I'm also putting back a change for handling `:clean`.

---

[1] FWIW, the `spork` in question was at [this commit](https://github.com/janet-lang/spork/commit/db09362241308bd49f3298e87bb408d0f3a51071).