### PR TITLE
Support :has-exe as well

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4388,7 +4388,9 @@
       (when check
         (do-hook module bundle-name :check man)))
     (print "installed " bundle-name)
-    (when (get man :has-bin-script)
+    (when (or (get man :has-exe)
+              # remove eventually
+              (get man :has-bin-script))
       (def binpath (string (dyn *syspath*) s "bin"))
       (eprintf "executable files have been installed to %s" binpath))
     (when (get man :has-man)
@@ -4528,7 +4530,8 @@
     (default filename (last (string/split s src)))
     (default chmod-mode 8r755)
     (os/mkdir (string (dyn *syspath*) s "bin"))
-    (put manifest :has-bin-script true)
+    (put manifest :has-exe true)
+    (put manifest :has-bin-script true) # remove eventually
     (bundle/add-file manifest src (string "bin" s filename) chmod-mode))
 
   (defn bundle/add-manpage


### PR DESCRIPTION
This is a companion change to [spork's #252](https://github.com/janet-lang/spork/pull/252) to address [spork's #247](https://github.com/janet-lang/spork/issues/247) and a bit of #1648.

Please see [spork's #247](https://github.com/janet-lang/spork/issues/247) for details.

As implemented, `:has-been-script` didn't quite mean what was intended.  The intent of `:has-exe` is to improve on the current `:has-been-script` behavior (in spork) but also to act as an eventual replacement.

To prevent breakage, both `:has-bin-script` and `:has-exe` should be supported for a while in both spork and janet.  Eventually `:has-bin-script` can be retired.

I hope some folks will try this and [the companion change](https://github.com/janet-lang/spork/pull/252) 🙏