### PR TITLE
Keep dobytes' error string

### DIFF
--- a/src/core/run.c
+++ b/src/core/run.c
@@ -122,7 +122,8 @@ int janet_dobytes(JanetTable *env, const uint8_t *bytes, int32_t len, const char
         janet_loop();
         if (fiber) {
             janet_gcunroot(janet_wrap_fiber(fiber));
-            ret = fiber->last_value;
+            if (!errflags)
+                ret = fiber->last_value;
         }
     }
 #endif


### PR DESCRIPTION
The reason for failure would be more useful than the most recently evaluated value.