### PR TITLE
Fix comment about syspath

### DIFF
--- a/build_win.bat
+++ b/build_win.bat
@@ -49,7 +49,7 @@ for %%f in (src\boot\*.c) do (
 )
 %JANET_LINK% /out:build\janet_boot.exe build\boot\*.obj
 @if errorlevel 1 goto :BUILDFAIL
-@rem note that there is no default sysroot being baked in
+@rem note that there is no default syspath being baked in
 build\janet_boot . > build\c\janet.c
 @if errorlevel 1 goto :BUILDFAIL
 


### PR DESCRIPTION
Sorry, I made a typo in #1640.

Instead of `syspath`, the word `sysroot` was used instead.

This PR is an attempt to fix the corresponding comment.