### PR TITLE
Improve messages on errors when loading the bundle script

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4224,7 +4224,13 @@
         (put new-env :bundle-dir (bundle-dir bundle-name)) # get the syspath right
         (try
           (require (string "@syspath/bundle/" bundle-name))
-          ([_] (error "bundle must contain bundle.janet or bundle/init.janet"))))))
+          ([e f]
+           (def pfx "could not find module @syspath/bundle/")
+           (def msg (if (and (string? e)
+                             (string/has-prefix? pfx e))
+                      "bundle must contain bundle.janet or bundle/init.janet"
+                      e))
+           (propagate msg f))))))
 
   (defn- do-hook
     [module bundle-name hook & args]


### PR DESCRIPTION
After seeing the report in janet-lang/spork#257, I realised that catching all errors when loading the bundle script can obscure errors other than the one that prompted #1660. This PR rewrites the error message only if the bundle script cannot be found but otherwise propagates the error to the caller.

This fixes #1671.