### PR TITLE
Remove unused def

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4055,7 +4055,6 @@
   Other arguments to `flycheck` are the same as `dofile`. Returns nil.
   ```
   [path &keys kwargs]
-  (def mc @{})
   (def new-env (make-env (get kwargs :env)))
   (put new-env *flychecking* true)
   (put new-env *module-cache* @{})


### PR DESCRIPTION
This PR is a suggestion to remove an apparently unused [local `def` in `boot.janet`](https://github.com/janet-lang/janet/blob/master/src/boot/boot.janet#L4058):

```janet
(defn flycheck
  # docstring elided
  [path &keys kwargs]
  (def mc @{})        # <-- this def
  (def new-env (make-env (get kwargs :env)))
```


It looks like it might have shown up in the recent refactoring of flycheck machinery in [this commit](https://github.com/janet-lang/janet/commit/1ff26d702a665d7c66774e635b685345e46a8064).