### PR TITLE
Add `splice` peg special

### DIFF
--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -2204,6 +2204,7 @@ typedef enum {
     RULE_NTH,          /* [nth, rule, tag] */
     RULE_ONLY_TAGS,    /* [rule] */
     RULE_MATCHSPLICE,  /* [rule, constant, tag] */
+    RULE_SPLICE,       /* [rule, tag] */
 } JanetPegOpcode;
 
 typedef struct {

--- a/test/suite-peg.janet
+++ b/test/suite-peg.janet
@@ -845,4 +845,14 @@
       "abc"
       @[["b" "b" "b"]])
 
+(test "splice 1"
+      ~(splice (cmt (* 1 1 '1) ,|[$ $]))
+      "xyz"
+      @["z" "z"])
+
+(test "splice 2"
+      ~(group ;(cmt (* 1 1 '1) ,|[$ $]))
+      "xyz"
+      @[@["z" "z"]])
+
 (end-suite)


### PR DESCRIPTION
This PR is related to #1674 -- it may need more work [1].

Note that `cms` has already been added to address #1674 in f79e4d6249ecc25f460204f2bc509dd1ad9713f5.

The background is that although `cms` addressed the original situation (and can be applied to more situations), there was some discussion on Zulip that perhaps a `splice` peg special might be another way to address the issue.

See [this comment](https://github.com/janet-lang/janet/issues/1674#issuecomment-3600085538) and the following links for related discussions:

* [ianthehenry comments](https://janet.zulipchat.com/#narrow/channel/409517-help/topic/.E2.9C.94.20Splicing.20PEG.20Match-time.20Captures.3F/near/560950711)
    > This seems like a very reasonable thing to add to the PEG evaluator -- splice is currently unused and it seems like it should work like this
* [oofoe comment 1](https://janet.zulipchat.com/#narrow/channel/409517-help/topic/.E2.9C.94.20Splicing.20PEG.20Match-time.20Captures.3F/near/561069469)
    > is there any call for a generic splice operator (it appears that cms is function call only)?
* [oofoe comment 2](https://janet.zulipchat.com/#narrow/channel/409517-help/topic/.E2.9C.94.20Splicing.20PEG.20Match-time.20Captures.3F/near/561157135)
    > Sure, but then (cms ... ,identity) then becomes an idiom, instead of an explicit affordance. Also an atomic splice operator could be used generically for anything, e.g. ... ;(group ...) ... as well as ... ;(cmt ... ,fnord) ...? (I realize that ; might interfere with other operations, please substitute whatever as appropriate.)

---

[1] ...or possibly there's something inherently problematic about it.