### PR TITLE
Apply :flycheck on def as well

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4110,8 +4110,17 @@
     true))
 
 (defn- is-safe-def [thunk source env where]
-  (if (no-side-effects (last source))
-    (thunk)))
+  (if-let [ve (get env (source 1))
+           fc (get ve :flycheck)]
+    (cond
+      # Sometimes safe form
+      (function? fc)
+      (fc thunk source env where)
+      # Always safe form
+      fc
+      (thunk))
+    (if (no-side-effects (last source))
+      (thunk))))
 
 (defn- flycheck-importer
   [thunk source env where]


### PR DESCRIPTION
This is actually motivated by the investigation on https://github.com/janet-lang/spork/pull/264.

With this change, we could also allow user to do something like this:

```
(def v :flycheck (maybe-side-effect-func ...))
```

If they believe `maybe-side-effect-func` won't cause any harm during flycheck.
