### PR TITLE
Update to macos-14 in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, macos-13 ]
+        os: [ ubuntu-latest, macos-latest, macos-14 ]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master


### PR DESCRIPTION
This PR is an attempt to update the macos runner as the macos-13 one appears to be retired.

The PR is similar to https://github.com/janet-lang/spork/pull/258.

Please see [here](https://github.com/janet-lang/spork/pull/256#issuecomment-3549850191) for background.

For this repository, [this](https://github.com/janet-lang/janet/actions/runs/20152361677/job/57847760774?pr=1681) is where we encountered an issue.