### PR TITLE
Fix math/int-{max,min} docstrings

### DIFF
--- a/src/core/math.c
+++ b/src/core/math.c
@@ -441,9 +441,9 @@ void janet_lib_math(JanetTable *env) {
     JANET_CORE_DEF(env, "math/int32-max", janet_wrap_number(INT32_MAX),
                    "The maximum contiguous integer representable by a 32 bit signed integer");
     JANET_CORE_DEF(env, "math/int-min", janet_wrap_number(JANET_INTMIN_DOUBLE),
-                   "The minimum contiguous integer representable by a double (2^53)");
+                   "The minimum contiguous integer representable by a double (-(2^53))");
     JANET_CORE_DEF(env, "math/int-max", janet_wrap_number(JANET_INTMAX_DOUBLE),
-                   "The maximum contiguous integer representable by a double (-(2^53))");
+                   "The maximum contiguous integer representable by a double (2^53)");
 #ifdef NAN
     JANET_CORE_DEF(env, "math/nan", janet_wrap_number(NAN), "Not a number (IEEE-754 NaN)");
 #else


### PR DESCRIPTION
This PR is an attempt to address #1684.

For background, please see [this Zulip topic](https://janet.zulipchat.com/#narrow/channel/409517-help/topic/.E2.9C.94.20Docs.20for.20math.2Fint-.7Bmin.2Cmax.7D.20look.20wrong.2E/with/563662621).
