### PR TITLE
Make peg-grammar available in all threads for peg/compile

### DIFF
--- a/src/core/peg.c
+++ b/src/core/peg.c
@@ -1832,6 +1832,8 @@ static JanetPeg *compile_peg(Janet x) {
         Janet default_grammarv = janet_dyn("peg-grammar");
         if (janet_checktype(default_grammarv, JANET_TABLE)) {
             builder.default_grammar = janet_unwrap_table(default_grammarv);
+        } else {
+            builder.default_grammar = janet_get_core_table("default-peg-grammar");
         }
     }
     builder.tags = janet_table(0);
@@ -1854,8 +1856,8 @@ static JanetPeg *compile_peg(Janet x) {
 JANET_CORE_FN(cfun_peg_compile,
               "(peg/compile peg)",
               "Compiles a peg source data structure into a <core/peg>. This will speed up matching "
-              "if the same peg will be used multiple times. Will also use `(dyn :peg-grammar)` to supplement "
-              "the grammar of the peg for otherwise undefined peg keywords.") {
+              "if the same peg will be used multiple times. `(dyn :peg-grammar)` replaces "
+              "`default-peg-grammar` for the grammar of the peg.") {
     janet_fixarity(argc, 1);
     JanetPeg *peg = compile_peg(argv[0]);
     return janet_wrap_abstract(peg);


### PR DESCRIPTION
It fixes https://github.com/janet-lang/janet/issues/1180.

Although I don't know how to write C, who knew the pull request is going to be easy for a person who knows almost nothing about C? Today, I'm your code monkey who types shakespeare. The code monkey God gave me an insight for this pull request.

I tested it with

```
(ev/do-thread
  (pp (peg/match '{:main ':s*} " ")))
```

which prints

```
@[" "]
```

Your code monkey also found that sogaiu replaced `default-peg-grammar` with `(dyn :peg-grammar)`. This change broke peg/compile.