### PR TITLE
Document how to set local timezone for os/date and os/strftime.

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1893,9 +1893,8 @@ static struct tm *time_to_tm(const Janet *argv, int32_t argc, int32_t n, struct 
 JANET_CORE_FN(os_date,
               "(os/date &opt time local)",
               "Returns the given time as a date struct, or the current time if `time` is not given. "
-              "Returns a struct with following key values. Note that all numbers are 0-indexed. "
               "Date is given in UTC unless `local` is truthy, in which case the date is formatted for "
-              "the local timezone.\n\n"
+              "the local timezone. Returns a struct with following key values. Note that all numbers are 0-indexed.\n\n"
               "* :seconds - number of seconds [0-61]\n\n"
               "* :minutes - number of minutes [0-59]\n\n"
               "* :hours - number of hours [0-23]\n\n"
@@ -1904,7 +1903,9 @@ JANET_CORE_FN(os_date,
               "* :year - years since year 0 (e.g. 2019)\n\n"
               "* :week-day - day of the week [0-6]\n\n"
               "* :year-day - day of the year [0-365]\n\n"
-              "* :dst - if Day Light Savings is in effect") {
+              "* :dst - if Day Light Savings is in effect\n\n"
+              "You can set local timezone by setting TZ environment variable. "
+              "See tzset(<time.h>) or _tzset(<time.h>) for further details.") {
     janet_arity(argc, 0, 2);
     (void) argv;
     struct tm t_infos;
@@ -1929,7 +1930,8 @@ JANET_CORE_FN(os_strftime,
               "Format the given time as a string, or the current time if `time` is not given. "
               "The time is formatted according to the same rules as the ISO C89 function strftime(). "
               "The time is formatted in UTC unless `local` is truthy, in which case the date is formatted for "
-              "the local timezone.") {
+              "the local timezone. You can set local timezone by setting TZ environment variable. "
+              "See tzset(<time.h>) or _tzset(<time.h>) for further details.") {
     janet_arity(argc, 1, 3);
     const char *fmt = janet_getcstring(argv, 0);
     /* ANSI X3.159-1989, section 4.12.3.5 "The strftime function" */


### PR DESCRIPTION
It turns out that localtime_s for windows and localtime_r for POSIX-compatible operating systems support TZ environment variable for setting local timezone.

It closes https://github.com/janet-lang/janet/issues/986