### PR TITLE
Tweak some fiber-related docstrings

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3865,13 +3865,16 @@
   (defn ev/call
     ```
     Call a function asynchronously.
-    Returns a fiber that is scheduled to run the function.
+    Returns a task fiber that is scheduled to run the function.
     ```
     [f & args]
     (ev/go (fn :call [&] (f ;args))))
 
   (defmacro ev/spawn
-    "Run some code in a new fiber. This is shorthand for `(ev/go (fn [] ;body))`."
+    ``
+    Run some code in a new task fiber. This is shorthand for
+    `(ev/go (fn [] ;body))`."
+    ``
     [& body]
     ~(,ev/go (fn :spawn [&] ,;body)))
 
@@ -3965,8 +3968,9 @@
 
   (defmacro ev/gather
     ``
-    Run a number of fibers in parallel and resume the current fiber after they complete.
-    Returns the gathered results in an array.
+    Run a number of fibers in parallel (created from `bodies`) and resume the
+    current fiber after they complete. Returns the gathered results in an
+    array.
     ``
     [& bodies]
     ~(,ev/go-gather ,(seq [body :in bodies] ~(fn :ev/gather [] ,body)))))

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -3007,12 +3007,14 @@ error:
 
 JANET_CORE_FN(cfun_ev_go,
               "(ev/go fiber-or-fun &opt value supervisor)",
-              "Put a fiber on the event loop to be resumed later. If a function is used, it is wrapped "
-              "with `fiber/new` first. "
-              "Optionally pass a value to resume with, otherwise resumes with nil. Returns the fiber. "
-              "An optional `core/channel` can be provided as a supervisor. When various "
-              "events occur in the newly scheduled fiber, an event will be pushed to the supervisor. "
-              "If not provided, the new fiber will inherit the current supervisor.") {
+              "Put a fiber on the event loop to be resumed later. If a "
+              "function is used, it is wrapped with `fiber/new` first. "
+              "Returns a task fiber. Optionally pass a value to resume "
+              "with, otherwise resumes with nil. An optional `core/channel` "
+              "can be provided as a supervisor. When various events occur "
+              "in the newly scheduled fiber, an event will be pushed to the "
+              "supervisor. If not provided, the new fiber will inherit the "
+              "current supervisor.") {
     janet_arity(argc, 1, 3);
     Janet value = argc >= 2 ? argv[1] : janet_wrap_nil();
     void *supervisor = janet_optabstract(argv, argc, 2, &janet_channel_type, janet_vm.root_fiber->supervisor_channel);
@@ -3324,7 +3326,8 @@ JANET_CORE_FN(cfun_ev_deadline,
 
 JANET_CORE_FN(cfun_ev_cancel,
               "(ev/cancel fiber err)",
-              "Cancel a suspended fiber in the event loop. Differs from cancel in that it returns the canceled fiber immediately.") {
+              "Cancel a suspended task fiber in the event loop. Differs from "
+              "`cancel` in that it returns the canceled fiber immediately.") {
     janet_fixarity(argc, 2);
     JanetFiber *fiber = janet_getfiber(argv, 0);
     Janet err = argv[1];
@@ -3557,7 +3560,7 @@ JANET_CORE_FN(janet_cfun_to_file,
 
 JANET_CORE_FN(janet_cfun_ev_all_tasks,
               "(ev/all-tasks)",
-              "Get an array of all active fibers that are being used by the scheduler.") {
+              "Get an array of all active task fibers that are being used by the scheduler.") {
     janet_fixarity(argc, 0);
     (void) argv;
     JanetArray *array = janet_array(janet_vm.active_tasks.count);

--- a/src/core/fiber.c
+++ b/src/core/fiber.c
@@ -610,8 +610,9 @@ JANET_CORE_FN(cfun_fiber_current,
 
 JANET_CORE_FN(cfun_fiber_root,
               "(fiber/root)",
-              "Returns the current root fiber. The root fiber is the oldest ancestor "
-              "that does not have a parent.") {
+              "Returns the current root fiber. The root fiber is the oldest "
+              "ancestor that does not have a parent. Note that a root fiber "
+              "is also a task fiber.") {
     (void) argv;
     janet_fixarity(argc, 0);
     return janet_wrap_fiber(janet_vm.root_fiber);


### PR DESCRIPTION
This PR suggests some changes to some docstrings that mention fibers and/or tasks.

While investigating `ev/cancel` via [this Zulip topic](https://janet.zulipchat.com/#narrow/channel/409517-help/topic/How.20do.20I.20cancel.20a.20fiber.20that's.20being.20resumed.20by.20a.20task.3F/with/570685332), it seemed that the docstring for `ev/cancel` might be adjusted a bit to match the modified behavior hinted at [here](https://github.com/janet-lang/janet/issues/1707#issuecomment-3814766305).

The examination process suggested that possibly some other fiber / task-related docstrings might be changed a bit as well.

The functions / macros in question include:

* `ev/all-tasks`
* `ev/call`
* `ev/cancel`
* `ev/gather`
* `ev/go`
* `ev/spawn`
* `fiber/root`

Except for those of `ev/gather`, the changes are about mentioning tasks more explicitly.