### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/src/boot/system_test.c
+++ b/src/boot/system_test.c
@@ -37,7 +37,7 @@ int system_test() {
 
     /* Check the version defines are self consistent */
     char version_combined[256];
-    sprintf(version_combined, "%d.%d.%d%s", JANET_VERSION_MAJOR, JANET_VERSION_MINOR, JANET_VERSION_PATCH, JANET_VERSION_EXTRA);
+    snprintf(version_combined, sizeof(version_combined), "%d.%d.%d%s", JANET_VERSION_MAJOR, JANET_VERSION_MINOR, JANET_VERSION_PATCH, JANET_VERSION_EXTRA);
     assert(!strcmp(JANET_VERSION, version_combined));
 
     /* Reflexive testing and nanbox testing */

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -2416,7 +2416,7 @@ Janet janet_ev_lasterr(void) {
                   msgbuf,
                   sizeof(msgbuf),
                   NULL);
-    if (!*msgbuf) sprintf(msgbuf, "%d", code);
+    if (!*msgbuf) snprintf(msgbuf, sizeof(msgbuf), "%d", code);
     char *c = msgbuf;
     while (*c) {
         if (*c == '\n' || *c == '\r') {

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1331,7 +1331,7 @@ static Janet os_execute_impl(int32_t argc, Janet *argv, JanetExecuteMode mode) {
                       msgbuf,
                       sizeof(msgbuf),
                       NULL);
-        if (!*msgbuf) sprintf(msgbuf, "%d", cp_error_code);
+        if (!*msgbuf) snprintf(msgbuf, sizeof(msgbuf), "%d", cp_error_code);
         char *c = msgbuf;
         while (*c) {
             if (*c == '\n' || *c == '\r') {


### PR DESCRIPTION
This PR replaces calls to `sprintf` with calls to `snprintf` instead.

None of the `sprintf` calls look problematic but since `snprintf` is used extensively in the rest of the codebase it seemed worth making these changes.