### PR TITLE
Use snprintf instead of sprintf - sequel

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -2948,10 +2948,11 @@ int janet_make_pipe(JanetHandle handles[2], int mode) {
         if (!CreatePipe(handles, handles + 1, &saAttr, 0)) return -1;
         return 0;
     }
-    sprintf(PipeNameBuffer,
-            "\\\\.\\Pipe\\JanetPipeFile.%08x.%08x",
-            (unsigned int) GetCurrentProcessId(),
-            (unsigned int) InterlockedIncrement(&PipeSerialNumber));
+    snprintf(PipeNameBuffer,
+             sizeof(PipeNameBuffer),
+             "\\\\.\\Pipe\\JanetPipeFile.%08x.%08x",
+             (unsigned int) GetCurrentProcessId(),
+             (unsigned int) InterlockedIncrement(&PipeSerialNumber));
 
     /* server handle goes to subprocess */
     shandle = CreateNamedPipeA(

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -2579,7 +2579,7 @@ JANET_CORE_FN(os_dir,
     char pattern[MAX_PATH + 1];
     if (strlen(dir) > (sizeof(pattern) - 3))
         janet_panicf("path too long: %s", dir);
-    sprintf(pattern, "%s/*", dir);
+    snprintf(pattern, sizeof(pattern), "%s/*", dir);
     intptr_t res = _findfirst(pattern, &afile);
     if (-1 == res) janet_panicv(janet_cstringv(janet_strerror(errno)));
     do {


### PR DESCRIPTION
This PR replaces a few more calls to `sprintf` with calls to `snprintf` instead (like in #1711).

I missed a few before, sorry about that.

Hopefully, there are no more :sweat_smile: 