### PR TITLE
Tweak a docstring and a comment

### DIFF
--- a/src/core/fiber.c
+++ b/src/core/fiber.c
@@ -592,8 +592,8 @@ JANET_CORE_FN(cfun_fiber_status,
               "* :user(0-7) - the fiber is suspended by a user signal\n"
               "* :interrupted - the fiber was interrupted\n"
               "* :suspended - the fiber is waiting to be resumed by the scheduler\n"
-              "* :alive - the fiber is currently running and cannot be resumed\n"
-              "* :new - the fiber has just been created and not yet run") {
+              "* :new - the fiber has just been created and not yet run\n"
+              "* :alive - the fiber is currently running and cannot be resumed") {
     janet_fixarity(argc, 1);
     JanetFiber *fiber = janet_getfiber(argv, 0);
     uint32_t s = janet_fiber_status(fiber);

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -268,7 +268,7 @@ int32_t janet_kv_calchash(const JanetKV *kvs, int32_t len) {
     return (int32_t) hash;
 }
 
-/* Calculate next power of 2. May overflow. If n is 0,
+/* Calculate next power of 2. May overflow. If n < 0,
  * will return 0. */
 int32_t janet_tablen(int32_t n) {
     if (n < 0) return 0;


### PR DESCRIPTION
This PR contains a couple of minor tweaks.

The docstring was tweaked so that the order of the keywords matches that of [what's currently in `util.c`](https://github.com/janet-lang/janet/blob/2602bec0176504e05c956a8ac7675067acd8c231/src/core/util.c#L100-L118) and the comment was a minor modification to the condition for when 0 is returned.