### PR TITLE
Hide JanetMarshalContext implementation details

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -433,7 +433,7 @@ static int janet_stream_getter(void *p, Janet key, Janet *out) {
 
 static void janet_stream_marshal(void *p, JanetMarshalContext *ctx) {
     JanetStream *s = p;
-    if (!(ctx->flags & JANET_MARSHAL_UNSAFE)) {
+    if (!(janet_marshal_flags(ctx) & JANET_MARSHAL_UNSAFE)) {
         janet_panic("can only marshal stream with unsafe flag");
     }
     janet_marshal_abstract(ctx, p);
@@ -467,7 +467,7 @@ static void janet_stream_marshal(void *p, JanetMarshalContext *ctx) {
 }
 
 static void *janet_stream_unmarshal(JanetMarshalContext *ctx) {
-    if (!(ctx->flags & JANET_MARSHAL_UNSAFE)) {
+    if (!(janet_unmarshal_flags(ctx) & JANET_MARSHAL_UNSAFE)) {
         janet_panic("can only unmarshal stream with unsafe flag");
     }
     JanetStream *p = janet_unmarshal_abstract(ctx, sizeof(JanetStream));

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -411,7 +411,7 @@ static Janet io_file_next(void *p, Janet key) {
 
 static void io_file_marshal(void *p, JanetMarshalContext *ctx) {
     JanetFile *iof = (JanetFile *)p;
-    if (ctx->flags & JANET_MARSHAL_UNSAFE) {
+    if (janet_marshal_flags(ctx) & JANET_MARSHAL_UNSAFE) {
         janet_marshal_abstract(ctx, p);
         int fno = -1;
 #ifdef JANET_WINDOWS
@@ -436,7 +436,7 @@ static void io_file_marshal(void *p, JanetMarshalContext *ctx) {
 }
 
 static void *io_file_unmarshal(JanetMarshalContext *ctx) {
-    if (ctx->flags & JANET_MARSHAL_UNSAFE) {
+    if (janet_unmarshal_flags(ctx) & JANET_MARSHAL_UNSAFE) {
         JanetFile *iof = janet_unmarshal_abstract(ctx, sizeof(JanetFile));
         int32_t fd = janet_unmarshal_int(ctx);
         int32_t flags = janet_unmarshal_int(ctx);

--- a/src/core/marsh.c
+++ b/src/core/marsh.c
@@ -30,6 +30,14 @@
 #include "util.h"
 #endif
 
+struct JanetMarshalContext {
+    void *m_state;
+    void *u_state;
+    int flags;
+    const uint8_t *data;
+    const JanetAbstractType *at;
+};
+
 typedef struct {
     JanetBuffer *buf;
     JanetTable seen;
@@ -431,6 +439,10 @@ void janet_marshal_abstract(JanetMarshalContext *ctx, void *abstract) {
     MarshalState *st = (MarshalState *)(ctx->m_state);
     Janet x = janet_wrap_abstract(abstract);
     MARK_SEEN();
+}
+
+int janet_marshal_flags(JanetMarshalContext *ctx) {
+    return ctx->flags;
 }
 
 static void marshal_one_abstract(MarshalState *st, Janet x, int flags) {
@@ -1299,6 +1311,10 @@ void *janet_unmarshal_abstract_threaded(JanetMarshalContext *ctx, size_t size) {
     (void) size;
     janet_panic("threaded abstracts not supported");
 #endif
+}
+
+int janet_unmarshal_flags(JanetMarshalContext *ctx) {
+    return ctx->flags;
 }
 
 static const uint8_t *unmarshal_one_abstract(UnmarshalState *st, const uint8_t *data, Janet *out, int flags) {

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -1202,13 +1202,7 @@ struct JanetParser {
 };
 
 /* A context for marshaling and unmarshaling abstract types */
-typedef struct {
-    void *m_state;
-    void *u_state;
-    int flags;
-    const uint8_t *data;
-    const JanetAbstractType *at;
-} JanetMarshalContext;
+typedef struct JanetMarshalContext JanetMarshalContext;
 
 /* Defines an abstract type. Use a const pointer to one of these structures
  * when creating abstract types. The memory for this pointer should not be free
@@ -2285,6 +2279,7 @@ JANET_API void janet_marshal_byte(JanetMarshalContext *ctx, uint8_t value);
 JANET_API void janet_marshal_bytes(JanetMarshalContext *ctx, const uint8_t *bytes, size_t len);
 JANET_API void janet_marshal_janet(JanetMarshalContext *ctx, Janet x);
 JANET_API void janet_marshal_abstract(JanetMarshalContext *ctx, JanetAbstract abstract);
+JANET_API int janet_marshal_flags(JanetMarshalContext *ctx);
 
 JANET_API void janet_unmarshal_ensure(JanetMarshalContext *ctx, size_t size);
 JANET_API size_t janet_unmarshal_size(JanetMarshalContext *ctx);
@@ -2297,6 +2292,7 @@ JANET_API Janet janet_unmarshal_janet(JanetMarshalContext *ctx);
 JANET_API JanetAbstract janet_unmarshal_abstract(JanetMarshalContext *ctx, size_t size);
 JANET_API JanetAbstract janet_unmarshal_abstract_threaded(JanetMarshalContext *ctx, size_t size);
 JANET_API void janet_unmarshal_abstract_reuse(JanetMarshalContext *ctx, void *p);
+JANET_API int janet_unmarshal_flags(JanetMarshalContext *ctx);
 
 JANET_API void janet_register_abstract_type(const JanetAbstractType *at);
 JANET_API const JanetAbstractType *janet_get_abstract_type(Janet key);


### PR DESCRIPTION
This hides JanetMarshalContext behind an opaque pointer, and splits it into two separate Context type for marshal and unmarshal.

The motivation was my confusion while working with this type because the same context type was used for both marshal/unmarshal context, despite containing almost nothing in common, and you cannot certainly use a context that was created for marshal operation for unmarshalling.

This will break current users with compile errors due to the different pointer type on the vtable now, but the ABI should remain the same with the pointer argument.

---

I hope this is not a very controversal change :D I noticed this when trying to stub out the implementation in my Zig port, so thought I would try to also upstream this while I can