### PR TITLE
Fix stale fiber stack pointers across realloc

### DIFF
--- a/src/core/fiber.c
+++ b/src/core/fiber.c
@@ -346,9 +346,6 @@ int janet_fiber_funcframe_tail(JanetFiber *fiber, JanetFunction *func) {
 #endif
     }
 
-    Janet *stack = fiber->data + fiber->frame;
-    Janet *args = fiber->data + fiber->stackstart;
-
     /* Detach old function */
     if (NULL != janet_fiber_frame(fiber)->func)
         janet_env_detach(janet_fiber_frame(fiber)->env);
@@ -378,7 +375,7 @@ int janet_fiber_funcframe_tail(JanetFiber *fiber, JanetFunction *func) {
         stacksize = fiber->stacktop - fiber->stackstart;
     }
 
-    if (stacksize) memmove(stack, args, stacksize * sizeof(Janet));
+    if (stacksize) memmove(fiber->data + fiber->frame, fiber->data + fiber->stackstart, stacksize * sizeof(Janet));
 
     /* Nil unset locals (Needed for functional correctness) */
     for (i = fiber->frame + stacksize; i < nextframetop; ++i)

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -234,18 +234,22 @@
         }\
     }
 
-/* Trace a function call */
-static void vm_do_trace(JanetFunction *func, int32_t argc, const Janet *argv) {
-    if (func->def->name) {
-        janet_eprintf("trace (%S", func->def->name);
-    } else {
-        janet_eprintf("trace (%p", janet_wrap_function(func));
-    }
-    for (int32_t i = 0; i < argc; i++) {
-        janet_eprintf(" %p", argv[i]);
-    }
-    janet_eprintf(")\n");
-}
+/* Trace a function call.
+ * This is a macro to avoid stale argv if janet_eprintf resizes the stack
+ */
+#define vm_do_trace(func, argc, argv) do { \
+    JanetFunction* _func = (func);\
+    if (_func->def->name) {\
+        janet_eprintf("trace (%S", _func->def->name);\
+    } else {\
+        janet_eprintf("trace (%p", janet_wrap_function(_func));\
+    }\
+    int32_t _argc = (argc);\
+    for (int32_t i = 0; i < _argc; i++) {\
+        janet_eprintf(" %p", (argv)[i]);\
+    }\
+    janet_eprintf(")\n");\
+} while (0)
 
 /* Invoke a method once we have looked it up */
 static Janet janet_method_invoke(Janet method, int32_t argc, Janet *argv) {


### PR DESCRIPTION
Those cached pointers are not safe to use across Janet fiber operations, which may reallocate and invalidate those pointers.

Use the fields directly.

---

This fixes #1750 as well as one more location where stale `fiber->data` is used from my audit.

Codex was used to assist me in finding the invocations and flags to build and run Janet tests with ASAN, but the proposed fixes are all mine.