### PR TITLE
Add bash, zsh, and fish shell completions for janet

### DIFF
--- a/misc/completion/README.md
+++ b/misc/completion/README.md
@@ -1,0 +1,33 @@
+# Shell completions for Janet
+
+This directory contains shell completion scripts for the `janet` interpreter.
+
+## Bash
+
+```sh
+# Temporary (current session only)
+source /path/to/janet.bash
+
+# Permanent (system-wide)
+sudo cp janet.bash /etc/bash_completion.d/janet
+
+# Permanent (user only)
+cp janet.bash ~/.local/share/bash-completion/completions/janet
+```
+
+## Zsh
+
+```sh
+# Copy to a directory in your $fpath, e.g.:
+cp janet.zsh ~/.zsh/completions/_janet
+
+# Ensure the directory is in $fpath (add to ~/.zshrc if needed):
+# fpath=(~/.zsh/completions $fpath)
+# autoload -Uz compinit && compinit
+```
+
+## Fish
+
+```sh
+cp janet.fish ~/.config/fish/completions/janet.fish
+```

--- a/misc/completion/janet.bash
+++ b/misc/completion/janet.bash
@@ -1,0 +1,42 @@
+# Bash completion for janet
+# Install: source this file, or place it in /etc/bash_completion.d/janet
+# or ~/.local/share/bash-completion/completions/janet
+
+_janet() {
+    local cur prev words cword
+    _init_completion || return
+
+    local flags="-h -v -s -e -E -d -n -N -r -R -p -q -k -m -c -i -l -w -x --"
+
+    case "$prev" in
+        -e|-E)
+            # Argument is Janet source code — no file completion
+            return
+            ;;
+        -m)
+            # syspath: complete directories
+            _filedir -d
+            return
+            ;;
+        -c|-l)
+            # source file: complete .janet files
+            _filedir janet
+            return
+            ;;
+        -w|-x)
+            # linting level
+            COMPREPLY=($(compgen -W ":none :relaxed :normal :strict" -- "$cur"))
+            return
+            ;;
+    esac
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "$flags" -- "$cur"))
+        return
+    fi
+
+    # Default: complete .janet files and directories
+    _filedir janet
+}
+
+complete -F _janet janet

--- a/misc/completion/janet.fish
+++ b/misc/completion/janet.fish
@@ -1,0 +1,28 @@
+# Fish completion for janet
+
+# Disable file completion by default; re-enable for specific flags
+complete -c janet -f
+
+# Flags
+complete -c janet -s h -d 'Show usage and exit'
+complete -c janet -s v -d 'Show version and exit'
+complete -c janet -s s -d 'Read raw stdin (no readline features)'
+complete -c janet -s e -r -d 'Execute Janet source string'
+complete -c janet -s E -r -d 'Execute Janet expression as short-fn with remaining args'
+complete -c janet -s d -d 'Enable debug mode'
+complete -c janet -s n -d 'Disable ANSI colors in REPL'
+complete -c janet -s N -d 'Enable ANSI colors in REPL'
+complete -c janet -s r -d 'Open REPL after executing sources'
+complete -c janet -s R -d 'Disable loading user profile in REPL'
+complete -c janet -s p -d 'Persistent mode (continue after errors)'
+complete -c janet -s q -d 'Hide logo in REPL'
+complete -c janet -s k -d 'Compile only (lint), do not execute'
+complete -c janet -s i -d 'Treat script as a .jimage file'
+complete -c janet -s m -r -d 'Set syspath for module loading' -a '(__fish_complete_directories)'
+complete -c janet -s c -r -d 'Precompile source to .jimage'
+complete -c janet -s l -r -d 'Import module before script/REPL' -a '(find . -name "*.janet" -printf "%f\n" 2>/dev/null)'
+complete -c janet -s w -r -d 'Set warning linting level' -a ':none :relaxed :normal :strict'
+complete -c janet -s x -r -d 'Set error linting level' -a ':none :relaxed :normal :strict'
+
+# File arguments: .janet files and directories
+complete -c janet -F -a '*.janet'

--- a/misc/completion/janet.zsh
+++ b/misc/completion/janet.zsh
@@ -1,0 +1,35 @@
+#compdef janet
+
+# Zsh completion for janet
+
+_janet() {
+    local -a opts
+
+    opts=(
+        '-h[Show usage and exit]'
+        '-v[Show version and exit]'
+        '-s[Read raw stdin (no readline features)]'
+        '-e[Execute Janet source string]:source code:'
+        '-E[Execute Janet expression as short-fn with remaining args]:expression:'
+        '-d[Enable debug mode]'
+        '-n[Disable ANSI colors in REPL]'
+        '-N[Enable ANSI colors in REPL]'
+        '-r[Open REPL after executing sources]'
+        '-R[Disable loading user profile in REPL]'
+        '-p[Persistent mode (continue after errors)]'
+        '-q[Hide logo in REPL]'
+        '-k[Compile only (lint), do not execute]'
+        '-i[Treat script as a .jimage file]'
+        '-m[Set syspath for module loading]:syspath:_directories'
+        '-c[Precompile source to .jimage]:source:_files -g "*.janet" :output:_files'
+        '-l[Import module before script/REPL]:module:_files -g "*.janet"'
+        '-w[Set warning linting level]:level:(none relaxed normal strict)'
+        '-x[Set error linting level]:level:(none relaxed normal strict)'
+        '--[End of options]'
+        '*:script:_files -g "*.janet"'
+    )
+
+    _arguments -s $opts
+}
+
+_janet "$@"


### PR DESCRIPTION
Closes #1567

Adds shell completion scripts for the `janet` interpreter in `misc/completion/`:

- `janet.bash` — bash completion (compatible with bash-completion framework)
- `janet.zsh` — zsh completion using `_arguments`
- `janet.fish` — fish completion
- `README.md` — installation instructions for each shell

All flags from the man page are covered with appropriate argument handling:
- `-m` completes directories (syspath)
- `-c` and `-l` complete `.janet` files
- `-w` and `-x` complete linting levels (`:none :relaxed :normal :strict`)
- default argument completes `.janet` files