### PR TITLE
Document built-in functions that support polymorphic `compare`

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -915,12 +915,35 @@
   [& xs]
   (compare-reduce >= xs))
 
-(defn zero? "Check if x is zero." [x] (= (compare x 0) 0))
-(defn pos? "Check if x is greater than 0." [x] (= (compare x 0) 1))
-(defn neg? "Check if x is less than 0." [x] (= (compare x 0) -1))
-(defn one? "Check if x is equal to 1." [x] (= (compare x 1) 0))
-(defn even? "Check if x is even." [x] (= 0 (compare 0 (mod x 2))))
-(defn odd? "Check if x is odd." [x] (= 0 (compare 1 (mod x 2))))
+(defn zero?
+  "Check if x is zero. If x is a table or struct, uses polymorphic `compare`."
+  [x]
+  (= (compare x 0) 0))
+
+(defn pos?
+  "Check if x is greater than 0. If x is a table or struct, uses polymorphic `compare`."
+  [x]
+  (= (compare x 0) 1))
+
+(defn neg?
+  "Check if x is less than 0. If x is a table or struct, uses polymorphic `compare`."
+  [x]
+  (= (compare x 0) -1))
+
+(defn one?
+  "Check if x is equal to 1. If x is a table or struct, uses polymorphic `compare`."
+  [x]
+  (= (compare x 1) 0))
+
+(defn even?
+  "Check if x is even. If x is a table or struct, uses polymorphic `compare`."
+  [x]
+  (= 0 (compare 0 (mod x 2))))
+
+(defn odd?
+  "Check if x is odd. If x is a table or struct, uses polymorphic `compare`."
+  [x]
+  (= 0 (compare 1 (mod x 2))))
 
 ###
 ###


### PR DESCRIPTION
Janet for Mortals chapter 8 discusses this behavior for some built-in functions.

https://janet.guide/tables-and-polymorphism/
> In fact the only built-in functions that use polymorphic compare are zero?, pos?, neg?, one?, even?, and odd? ...

Later in that chapter...
> Tables and abstract types are the only polymorphic values in Janet.

However, tested working for structs:
```janet
# create a prototype with compare function

(def my-proto
	{:compare (fn [self other] (compare (self :v) other))})

# define a function to create a struct with the above prototype

(defn make-test-struct [v]
	(struct/with-proto my-proto :v v))

# make some test structs

(def test-struct-1 (make-test-struct 0))
(def test-struct-2 (make-test-struct 5))

# test polymorphic compare on structs

(print (zero? test-struct-1)) # => true
(print (zero? test-struct-2)) # => false

For 

```