### PR TITLE
Fix typos in mapat and count docstring

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1115,7 +1115,7 @@
   no `inds` are provided. Multiple data structures can be handled
   if each `inds` is a data structure and `f` is a function of
   arity one more than the number of `inds`. Note that `f` is only
-  applied to values at indeces up to the largest index of the
+  applied to values at indices up to the largest index of the
   shortest of `ind` and each of `inds`.
   ```
   [f ind & inds]
@@ -1140,7 +1140,7 @@
   provided. Multiple data structures can be handled if each `inds`
   is a data structure and `pred` is a function of arity one more
   than the number of `inds`. Note that `pred` is only applied to
-  values at indeces up to the largest index of the shortest of
+  values at indices up to the largest index of the shortest of
   `ind` and each of `inds`.
   ```
   [pred ind & inds]


### PR DESCRIPTION
Hello,

I've been working on getting the Debian package for Janet over the finish line. The Debian CI tooling caught these typos in `boot.janet`.