### PR TITLE
fix(docs): remove generated timestamp from documentation

### DIFF
--- a/tools/gendoc.janet
+++ b/tools/gendoc.janet
@@ -75,9 +75,6 @@
   []
   (string "<h1>Janet Core API</h1>"
           "<p>Version " janet/version "-" janet/build "</p>"
-          "<p>Generated "
-          (nice-date)
-          "</p>"
           "<hr>"))
 
 (defn- emit-item


### PR DESCRIPTION
Remove the generated timestamp to make the documentation output reproducible between builds