### PR TITLE
Fix sorted-by failure when value changes

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -937,8 +937,8 @@
 (defmacro- sort-partition-template
   [ind before? left right pivot]
   ~(do
-     (while (,before? (in ,ind ,left) ,pivot) (++ ,left))
-     (while (,before? ,pivot (in ,ind ,right)) (-- ,right))))
+     (while (and (,before? (in ,ind ,left) ,pivot) (< ,left (- (length ,ind) 1))) (++ ,left))
+     (while (and (,before? ,pivot (in ,ind ,right)) (> ,right 0)) (-- ,right))))
 
 (defn- sort-help [a lo hi before?]
   (when (< lo hi)

--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -357,6 +357,8 @@
 (assert (deep= @[1 2 3 4 5] (sorted [5 3 4 1 2])) "sort 3")
 (assert (deep= @[{:a 1} {:a 4} {:a 7}]
                (sorted-by |($ :a) [{:a 4} {:a 7} {:a 1}])) "sort 4")
+(assert (deep= @[1 3 2]
+               (sorted-by |@[$] [1 3 2])) "sort 5")
 
 # Sort function
 # 2ca9300bf


### PR DESCRIPTION
In cases where the function provided to sorted-by changes the value every time, we need to protect against walking off the edge of the list. In this case every @[$] creates a new array with a new pointer used for comparison. This means the first sort condition never fails through the whole list and we reach the end.

This prevents us from failing, but since the values are effectively new every time sort sees them, they are not actually sorted.

Fixes: #1785