### PR TITLE
Improve comprehensiveness of first docstring

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -841,9 +841,22 @@
   [args] (do-extreme < args))
 
 (defn first
-  "Get the first element from an indexed data structure."
-  [xs]
-  (get xs 0))
+  ``
+  Get the first value in `x`.
+
+  If `x` is a non-empty bytes or indexed type value, return the first
+  element.
+
+  If `x` is a fiber, return the fiber's last value or `nil` if there
+  isn't one yet.
+
+  If `x` is an abstract type value with a `get` method, call the method
+  with a key of `0`.
+
+  In all other cases, return `nil`.
+  ``
+  [x]
+  (get x 0))
 
 (defn last
   "Get the last element from an indexed data structure."


### PR DESCRIPTION
This PR is an attempt to improve the comprehensiveness of the docstring for `first` based on exploration and discussion at our Zulip instance [1].

Highlights for the candidate in this PR include:

* avoids the use of the term "indexed data structure"
* enumerates the specific kinds of values that are non-trivially handled (including fibers and abstract types)
* spells out that `nil` is returned for other cases
* aligns better with the newly added website docs examples in [this PR](https://github.com/janet-lang/janet-lang.org/pull/357)

Thanks to all discussion participants.  Hopefully this PR is seen as acceptable :crossed_fingers: 

---

[1] Discussion is mostly between [here](https://janet.zulipchat.com/#narrow/channel/399615-general/topic/Janet.20Documentation.20Improvements/near/612804458) and [here](https://janet.zulipchat.com/#narrow/channel/399615-general/topic/Janet.20Documentation.20Improvements/near/613426047).