### PR TITLE
Improve completeness of some docstrings

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1344,14 +1344,24 @@
   (tuple 'fn :juxt (tuple '& $args) (tuple/slice parts 0)))
 
 (defn has-key?
-  "Check if a data structure `ds` contains the key `key`."
-  [ds key]
-  (not= nil (get ds key)))
+  ``
+  Check if `x` maps `key` to a non-nil value.
+
+  `x` can be a bytes, indexed, dictionary, fiber, or abstract type
+  with a suitable `get` method.
+  ``
+  [x key]
+  (not= nil (get x key)))
 
 (defn has-value?
-  "Check if a data structure `ds` contains the value `value`. Will run in time proportional to the size of `ds`."
-  [ds value]
-  (not= nil (index-of value ds)))
+  ``
+  Checks if `x` contains `value`.
+
+  `x` can be a bytes, indexed, dictionary, fiber, or abstract type with
+  suitable `get` and `next` methods.
+  ``
+  [x value]
+  (not= nil (index-of value x)))
 
 (defdyn *defdyn-prefix* ``Optional namespace prefix to add to keywords declared with `defdyn`.
   Use this to prevent keyword collisions between dynamic bindings.``)

--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -1175,12 +1175,16 @@ JanetTable *janet_core_env(JanetTable *replacements) {
                          "than x, and 0 otherwise. To return 0, x and y must be the exact same type."));
     janet_quick_asm(env, JANET_FUN_NEXT,
                     "next", 2, 1, 2, 2, next_asm, sizeof(next_asm),
-                    JDOC("(next ds &opt key)\n\n"
-                         "Gets the next key in a data structure. Can be used to iterate through "
-                         "the keys of a data structure in an unspecified order. Keys are guaranteed "
-                         "to be seen only once per iteration if the data structure is not mutated "
-                         "during iteration. If key is nil, next returns the first key. If next "
-                         "returns nil, there are no more keys to iterate through."));
+                    JDOC("(next x &opt key)\n\n"
+                         "Gets the next key in `x`. Can be used to iterate through "
+                         "the keys of `x` in an unspecified order. Keys are guaranteed "
+                         "to be seen only once per iteration if `x` is not mutated "
+                         "during iteration. If `key` is `nil`, returns the first key. "
+                         "If `nil` is returned, there are no more keys to iterate "
+                         "through.\n"
+                         "\n"
+                         "`x` can be a bytes, indexed, dictionary, fiber, or abstract "
+                         "type with a suitable `next` method."));
     janet_quick_asm(env, JANET_FUN_PROP,
                     "propagate", 2, 2, 2, 2, propagate_asm, sizeof(propagate_asm),
                     JDOC("(propagate x fiber)\n\n"
@@ -1221,18 +1225,26 @@ JanetTable *janet_core_env(JanetTable *replacements) {
                          "the fiber's dispatch function, or the value from the next yield call in fiber."));
     janet_quick_asm(env, JANET_FUN_IN,
                     "in", 3, 2, 3, 4, in_asm, sizeof(in_asm),
-                    JDOC("(in ds key &opt dflt)\n\n"
-                         "Get value in ds at key, works on associative data structures. Arrays, tuples, tables, structs, "
-                         "strings, symbols, and buffers are all associative and can be used. Arrays, tuples, strings, buffers, "
-                         "and symbols must use integer keys that are in bounds or an error is raised. Structs and tables can "
-                         "take any value as a key except nil and will return nil or dflt if not found."));
+                    JDOC("(in x key &opt dflt)\n\n"
+                         "Get value in `x` at `key`. For bytes and indexed "
+                         "types, `key` must be a non-negative interger in "
+                         "bounds or an error is raised. For dictionaries "
+                         "`key` must be a non-nil value and if not found, "
+                         "will return `dflt` if provided or `nil` otherwise.\n"
+                         "\n"
+                         "`x` can be a bytes, indexed, dictionary, fiber, or "
+                         "abstract type with a suitable `get` method."));
     janet_quick_asm(env, JANET_FUN_GET,
                     "get", 3, 2, 3, 4, get_asm, sizeof(in_asm),
-                    JDOC("(get ds key &opt dflt)\n\n"
-                         "Get the value mapped to key in data structure ds, and return dflt or nil if not found. "
-                         "Similar to in, but will not throw an error if the key is invalid for the data structure "
-                         "unless the data structure is an abstract type. In that case, the abstract type getter may throw "
-                         "an error."));
+                    JDOC("(get x key &opt dflt)\n\n"
+                         "Get the value mapped to `key` in `x`. Returns `dflt` "
+                         "or `nil` if `key` is not found. Similar to `in`, but "
+                         "will not throw an error if `key` is invalid for `x`. "
+                         "However, if `x` is an abstract type, its getter may "
+                         "throw an error.\n"
+                         "\n"
+                         "`x` can be a bytes, indexed, dictionary, fiber, or "
+                         "abstract type with a suitable `get` method."));
     janet_quick_asm(env, JANET_FUN_PUT,
                     "put", 3, 3, 3, 3, put_asm, sizeof(put_asm),
                     JDOC("(put ds key value)\n\n"


### PR DESCRIPTION
This PR is an attempt to spell out more fully which types of values can be handled for some functions.

Below is a list of the functions and links for corresponding PRs to add examples to the website in some cases and existing examples in others [1].

* `get` https://github.com/janet-lang/janet-lang.org/pull/363
* `has-key?` - [existing examples](https://janet-lang.org/1.41.2/api/index.html#has-key?)
* `has-value?` - [existing examples](https://janet-lang.org/1.41.2/api/index.html#has-value?)
* `in` https://github.com/janet-lang/janet-lang.org/pull/364
* `next` https://github.com/janet-lang/janet-lang.org/pull/365

---

[1] One purpose of the list is to make it a bit easier to look at docstrings alongside examples.  If / when various PRs are merged, the docstrings and corresponding examples should be viewable together on the [Core API page](https://janet-lang.org/api/index.html), but we are not there yet.