### PR TITLE
Add tests for partition-by

### DIFF
--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -1040,4 +1040,10 @@
 (assert (deep= (frequencies (coro (yield 1) (yield 8) (yield 2) (yield 8)))
                @{1 1 2 1 8 2}))
 
+# partition-by
+(assert (deep= (partition-by even? "hello")
+               @[@[104] @[101] @[108 108] @[111]]))
+(assert (deep= (partition-by keyword? [:a "b" 'c :d])
+               @[@[:a] @["b" 'c] @[:d]]))
+
 (end-suite)


### PR DESCRIPTION
This PR adds some tests for `partition-by`.  The tests are meant to reflect some intended use cases.

A couple of reasons for this PR include:

* `partition-by` appears to lacks tests
* intending to tweak the implementation in a subsequent PR, so having tests is supposed to be a little bit of insurance against potential breakage