### PR TITLE
Improve completeness of sort* docstrings

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -980,29 +980,44 @@
   a)
 
 (defn sort
-  ``Sorts `ind` in-place, and returns it. Uses quick-sort and is not a stable sort.
-  If a `before?` comparator function is provided, sorts elements using that,
-  otherwise uses `<`.``
-  [ind &opt before?]
+  ``
+  Sorts `x` in-place, and returns it. Uses quick-sort and is not a
+  stable sort. If a `before?` comparator function is provided, sorts
+  elements using that, otherwise uses `<`.
+
+  `x` can be a buffer, array, or abstract type with suitable `get`,
+  `put`, and `length` methods.
+  ``
+  [x &opt before?]
   (default before? <)
-  (sort-help ind 0 (- (length ind) 1) before?))
+  (sort-help x 0 (- (length x) 1) before?))
 
 (defn sort-by
-  ``Sorts `ind` in-place by calling a function `f` on each element and
-  comparing the result with `<`.``
-  [f ind]
-  (sort ind (fn :sort-by-comp [x y] (< (f x) (f y)))))
+  ``
+  Sorts `x` in-place by calling a function `f` on each element and
+  comparing the results with `<`.
+
+  `x` can be a buffer, array, or abstract type with suitable `get`,
+  `put`, and `length` methods.
+  ``
+  [f x]
+  (sort x (fn :sort-by-comp [i j] (< (f i) (f j)))))
 
 (defn sorted
-  ``Returns a new sorted array without modifying the old one.
-  If a `before?` comparator function is provided, sorts elements using that,
-  otherwise uses `<`.``
+  ``
+  Returns a new sorted array based on an indexed type `ind`. If a
+  `before?` comparator function is provided, sorts elements using
+  that, otherwise uses `<`.
+  ``
   [ind &opt before?]
   (sort (array/slice ind) before?))
 
 (defn sorted-by
-  ``Returns a new sorted array that compares elements by invoking
-  a function `f` on each element and comparing the result with `<`.``
+  ``
+  Returns a new sorted array based on an indexed type `ind`.
+  Comparison is done by invoking a function `f` on each element and
+  comparing the results with `<`.
+  ``
   [f ind]
   (sorted ind (fn :sorted-by-comp [x y] (< (f x) (f y)))))
 


### PR DESCRIPTION
This PR is an attempt to spell out more fully which types are handled for the `sort*` family of functions.

Below is a list of the functions and links for corresponding PRs to add examples to the website.

* `sort` https://github.com/janet-lang/janet-lang.org/pull/372
* `sort-by` https://github.com/janet-lang/janet-lang.org/pull/373
* `sorted` https://github.com/janet-lang/janet-lang.org/pull/374
* `sorted-by` https://github.com/janet-lang/janet-lang.org/pull/375

Since `sort` and `sort-by` can take a variety of types (buffers, arrays, or appropriate abstract types) the parameter that represents one of those was named `x`.

Since `sorted` and `sorted-by` by can take indexed types (tuples and arrays) only, the corresponding parameter was left as `ind` (for "indexed type").

As with #1791, links to the corresponding PRs for examples are given for convenience in reviewing.