### PR TITLE
int8_t, uint8_t and float getters

### DIFF
--- a/src/core/capi.c
+++ b/src/core/capi.c
@@ -346,6 +346,29 @@ uint16_t janet_getuinteger16(const Janet *argv, int32_t n) {
     return (uint16_t) janet_unwrap_number(x);
 }
 
+int8_t janet_getinteger8(const Janet *argv, int32_t n) {
+    Janet x = argv[n];
+    if (!janet_checkint8(x)) {
+        janet_panicf("bad slot #%d, expected 8 bit signed integer, got %v", n, x);
+    }
+    return (int16_t) janet_unwrap_number(x);
+}
+
+uint8_t janet_getuinteger8(const Janet *argv, int32_t n) {
+    Janet x = argv[n];
+    if (!janet_checkuint8(x)) {
+        janet_panicf("bad slot #%d, expected 8 bit unsigned integer, got %v", n, x);
+    }
+    return (uint16_t) janet_unwrap_number(x);
+}
+
+float janet_getfloat(const Janet *argv, int32_t n) {
+    Janet x = argv[n];
+    if (!janet_checkfloat(x)) {
+        janet_panicf("bad slot #%d, expected float number, got %v", n, x);
+    }
+    return (float) janet_unwrap_number(x);
+}
 
 int64_t janet_getinteger64(const Janet *argv, int32_t n) {
 #ifdef JANET_INT_TYPES

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -50,6 +50,7 @@
 #endif
 
 #include <inttypes.h>
+#include <float.h>
 
 /* Base 64 lookup table for digits */
 const char janet_base64[65] =
@@ -910,6 +911,27 @@ int janet_checkuint16(Janet x) {
         return 0;
     double dval = janet_unwrap_number(x);
     return janet_checkuint16range(dval);
+}
+
+int janet_checkint8(Janet x) {
+    if (!janet_checktype(x, JANET_NUMBER))
+        return 0;
+    double dval = janet_unwrap_number(x);
+    return janet_checkint8range(dval);
+}
+
+int janet_checkuint8(Janet x) {
+    if (!janet_checktype(x, JANET_NUMBER))
+        return 0;
+    double dval = janet_unwrap_number(x);
+    return janet_checkuint8range(dval);
+}
+
+int janet_checkfloat(Janet x) {
+    if (!janet_checktype(x, JANET_NUMBER))
+        return 0;
+    double dval = janet_unwrap_number(x);
+    return janet_checkfloatrange(dval);
 }
 
 int janet_checksize(Janet x) {

--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -940,6 +940,9 @@ JANET_API Janet janet_nanbox32_from_tagp(uint32_t tag, void *pointer);
 /* End of tagged union implementation */
 #endif
 
+JANET_API int janet_checkfloat(Janet x);
+JANET_API int janet_checkint8(Janet x);
+JANET_API int janet_checkuint8(Janet x);
 JANET_API int janet_checkint16(Janet x);
 JANET_API int janet_checkuint16(Janet x);
 JANET_API int janet_checkint(Janet x);
@@ -948,6 +951,9 @@ JANET_API int janet_checkint64(Janet x);
 JANET_API int janet_checkuint64(Janet x);
 JANET_API int janet_checksize(Janet x);
 JANET_API JanetAbstract janet_checkabstract(Janet x, const JanetAbstractType *at);
+#define janet_checkfloatrange(x) ((x) >= FLT_MIN && (x) <= FLT_MAX && (x) == (float)(x))
+#define janet_checkint8range(x) ((x) >= INT8_MIN && (x) <= INT8_MAX && (x) == (int8_t)(x))
+#define janet_checkuint8range(x) ((x) >= 0 && (x) <= UINT8_MAX && (x) == (uint8_t)(x))
 #define janet_checkint16range(x) ((x) >= INT16_MIN && (x) <= INT16_MAX && (x) == (int16_t)(x))
 #define janet_checkuint16range(x) ((x) >= 0 && (x) <= UINT16_MAX && (x) == (uint16_t)(x))
 #define janet_checkintrange(x) ((x) >= INT32_MIN && (x) <= INT32_MAX && (x) == (int32_t)(x))
@@ -2209,9 +2215,12 @@ JANET_API void *janet_getpointer(const Janet *argv, int32_t n);
 
 JANET_API int32_t janet_getnat(const Janet *argv, int32_t n);
 JANET_API int32_t janet_getinteger(const Janet *argv, int32_t n);
+JANET_API float janet_getfloat(const Janet *argv, int32_t n);
+JANET_API int8_t janet_getinteger8(const Janet *argv, int32_t n);
 JANET_API int16_t janet_getinteger16(const Janet *argv, int32_t n);
 JANET_API int64_t janet_getinteger64(const Janet *argv, int32_t n);
 JANET_API uint32_t janet_getuinteger(const Janet *argv, int32_t n);
+JANET_API uint8_t janet_getuinteger8(const Janet *argv, int32_t n);
 JANET_API uint16_t janet_getuinteger16(const Janet *argv, int32_t n);
 JANET_API uint64_t janet_getuinteger64(const Janet *argv, int32_t n);
 JANET_API size_t janet_getsize(const Janet *argv, int32_t n);


### PR DESCRIPTION
# What's included

For consistency with other numeric types and for better usability during natives creation this PR adds type getter for:
* `int8_t`
* `uint8_t`
* `float`
