### PR TITLE
Add tests for distinct

### DIFF
--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -1040,4 +1040,10 @@
 (assert (deep= (frequencies (coro (yield 1) (yield 8) (yield 2) (yield 8)))
                @{1 1 2 1 8 2}))
 
+# distinct
+(assert (deep= (distinct :hello) @[104 101 108 111]))
+(assert (deep= (distinct [1 0 1 0 1 1 0 1 1 1]) @[1 0]))
+(assert (deep= (distinct @{0 :a 1 :b 2 :b 3 :a}) @[:a :b]))
+(assert (deep= (distinct (coro (yield 8) (yield 11) (yield 8))) @[8 11]))
+
 (end-suite)


### PR DESCRIPTION
This PR adds some tests for `distinct`. The tests are meant to reflect some intended use cases.

A couple of reasons for this PR include:

* `distinct` appears to lacks tests
* intending to tweak the implementation in a subsequent PR, so having tests is supposed to be a little bit of insurance against potential breakage
