### PR TITLE
Tweak flatten* docstrings

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1867,20 +1867,24 @@
   ret)
 
 (defn flatten-into
-  ``Takes a nested array (tree) `xs` and appends the depth first traversal of
-  `xs` to array `into`. Returns `into`.``
-  [into xs]
-  (each x xs
-    (if (indexed? x)
-      (flatten-into into x)
-      (array/push into x)))
+  ``
+  Appends the depth-first traversal of an indexed type `ind` into a
+  given array `into`. Returns `into`.
+  ``
+  [into ind]
+  (each elt ind
+    (if (indexed? elt)
+      (flatten-into into elt)
+      (array/push into elt)))
   into)
 
 (defn flatten
-  ``Takes a nested array (tree) `xs` and returns the depth first traversal of
-  it. Returns a new array.``
-  [xs]
-  (flatten-into @[] xs))
+  ``
+  Returns a depth-first traversal of an indexed type `ind` as a new
+  array.
+  ``
+  [ind]
+  (flatten-into @[] ind))
 
 (defn kvs
   ``Takes a table or struct and returns a new array of key value pairs


### PR DESCRIPTION
This PR is an attempt to clarify the terminology in some docstrings along with information about the handled types of the corresponding functions.

Below is a list of the functions and links for corresponding PRs to add examples to the website.

* `flatten-into` https://github.com/janet-lang/janet-lang.org/pull/382
* `flatten` https://github.com/janet-lang/janet-lang.org/pull/381

---

A common thread among these docstrings was the use of the phrase "nested array (tree)". It turns out that the functions support tuples as well, so the term "indexed type" was used instead along with renaming the parameter `xs` as `ind`.