### PR TITLE
Add tests for find-index

### DIFF
--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -1058,4 +1058,10 @@
 (assert (deep= (distinct @{0 :a 1 :b 2 :b 3 :a}) @[:a :b]))
 (assert (deep= (distinct (coro (yield 8) (yield 11) (yield 8))) @[8 11]))
 
+# find-index
+(assert (= (find-index |(= (chr "c") $) "abc") 2))
+(assert (= (find-index |(= $ :goose) [:duck :duck :goose]) 2))
+(assert (= (find-index pos? @[-2 -1 0 -3] :surprise!) :surprise!))
+(assert (= (find-index zero? {:a 2 :b 1 :c 0}) :c))
+
 (end-suite)


### PR DESCRIPTION
This PR adds some tests for `find-index`. The tests are meant to reflect some intended use cases.

A couple of reasons for this PR include:

* `find-index` appears to lacks tests
* intending to tweak the implementation [1] in a subsequent PR, so having tests is supposed to be a little bit of insurance against potential breakage

---

[1] [`find-index` seems to have been added](https://github.com/janet-lang/janet/commit/73ead5c2de2bbd5af1f30857bfb862dd22b8194d) somewhat over 2 years before [`index-of` was](https://github.com/janet-lang/janet/commit/b564087db0dba83a5a80e15e5623f2c2938a7a6d).  It looks like `find-index`'s implementation can be made to look more similar to that of `index-of` in a way that will make it shorter and easier to understand.