### PR TITLE
Add tests for find

### DIFF
--- a/test/suite-boot.janet
+++ b/test/suite-boot.janet
@@ -1064,4 +1064,14 @@
 (assert (= (find-index pos? @[-2 -1 0 -3] :surprise!) :surprise!))
 (assert (= (find-index zero? {:a 2 :b 1 :c 0}) :c))
 
+# find
+(assert (= (find |(= $ (chr "o")) "tomato") 111))
+(assert (= (find |(= $ (chr "m")) "potato") nil))
+(assert (= (find |(> $ (chr "y")) :ant :surprise) :surprise))
+(assert (= (find pos? [-1 0 11]) 11))
+(assert (= (find neg? @[0 1 2 3 5]) nil))
+(assert (= (find one? {:a 1 :b 2}) 1))
+(assert (= (find even? @{:x 11 :y 28 :z 33}) 28))
+(assert (= (find keyword? (coro (yield 'jump) (yield :wave))) :wave))
+
 (end-suite)


### PR DESCRIPTION
This PR adds some tests for `find`. The tests are meant to reflect some intended use cases.

A couple of reasons for this PR include:

* `find` appears to lacks tests
* intending to tweak the implementation [1] in a subsequent PR, so having tests is supposed to be a little bit of insurance against potential breakage

[1] [find seems to have been added](https://github.com/janet-lang/janet/commit/73ead5c2de2bbd5af1f30857bfb862dd22b8194d) somewhat over 2 years before [index-of was](https://github.com/janet-lang/janet/commit/b564087db0dba83a5a80e15e5623f2c2938a7a6d). It looks like `find`'s implementation [2] can be made to look more similar to that of `index-of` in a way that will make it shorter and easier to understand.  Note that if these changes (and the other related efforts) are successful, `find`, `find-index`, and `index-of` should have fairly similar implementations.

[2] It seems to have changed in [this commit](https://github.com/janet-lang/janet/commit/25ded775ad322756241c08d380169e2d71a80c11) to not rely on `index-of`.