### PR TITLE
Improve index-of docstring

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1226,15 +1226,20 @@
   ret)
 
 (defn index-of
-  ``Find the first key associated with a value x in a data structure, acting like a reverse lookup.
-  Will not look at table prototypes.
-  Returns `dflt` if not found.``
-  [x ind &opt dflt]
-  (var k (next ind nil))
+  ``
+  Find the first key associated with a value `val` in `x`, acting like
+  a reverse lookup. Will not look at dictionary prototypes. If not
+  found, returns `dflt` if provided and `nil` otherwise.
+
+  `x` can be a bytes, indexed, dictionary, fiber, or abstract type
+  with suitable `get` and `next` methods.
+  ``
+  [val x &opt dflt]
+  (var k (next x nil))
   (var ret dflt)
   (while (not= nil k)
-    (when (= (in ind k) x) (set ret k) (break))
-    (set k (next ind k)))
+    (when (= (in x k) val) (set ret k) (break))
+    (set k (next x k)))
   ret)
 
 (defn- take-n-slice


### PR DESCRIPTION
This PR is an attempt to spell out more fully which types of values can be handled by `index-of`, namely:

> bytes, indexed, dictionary, fiber, or abstract type with suitable `get` and `next` methods

The parameter names were adjusted to be more in line with other recent docstring PRs.  Namely `x` is used instead of `ind` to be more indicative of a wider range of types that can be handled.  

Also, I chose `val` (short for "value") to represent the value whose index is being searched for [1].  I will be trying to reflect these two choices in other docstrings where appropriate [2].

Another reason for this PR is to prepare for the tweaking of the implementations of `find` and `find-index`.  I think the similarities will be more obvious once all of the efforts are complete as the names and docstrings will be more in alignment.

Note there is a companion PR for associated examples: https://github.com/janet-lang/janet-lang.org/pull/388

---

[1] `val` for "value" is convenient because among other aspects, it also covers the dictionary case ("value" as opposed to "key").

[2] When practical, using a convention for names seems to have a variety of benefits, one such being that certain patterns are more apparent across multiple bits of code.  This kind of practice was already being used in a variety of spots (e.g. use of `xs`).  It might be possible to spell some of these out so that they can be applied where doable.