### PR TITLE
Improve docstrings of filter and friends

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1152,13 +1152,17 @@
   res)
 
 (defn filter
-  ``Given a predicate, take only elements from an array or tuple for
-  which `(pred element)` is truthy. Returns a new array.``
-  [pred ind]
+  ``
+  Given a predicate, take only elements from `x` for which `(pred
+  element)` is truthy. Returns a new array.
+
+  `x` can be a bytes, indexed, dictionary, fiber, or abstract type
+  with suitable `get` and `next` methods.
+  ``
+  [pred x]
   (def res @[])
-  (each item ind
-    (if (pred item)
-      (array/push res item)))
+  (each v x
+    (if (pred v) (array/push res v)))
   res)
 
 (defn count
@@ -1877,20 +1881,25 @@
   ret)
 
 (defn partition-by
-  ``Partition elements of a sequential data structure by a representative function `f`. Partitions
-  split when `(f x)` changes values when iterating to the next element `x` of `ind`. Returns a new array
-  of arrays.``
-  [f ind]
+  ``
+  Partition values of `x` by a function `f`. Partitions split when `f`
+  applied to a value changes result when iterating to the next value
+  of `x`. Returns a new array of arrays.
+
+  `x` can be a bytes, indexed, fiber, or abstract type with suitable
+  `get` and `next` methods.
+  ``
+  [f x]
   (def ret @[])
   (var span nil)
-  (var category nil)
-  (var is-new true)
-  (each x ind
-    (def y (f x))
+  (var categ nil)
+  (var new? true)
+  (each v x
+    (def y (f v))
     (cond
-      is-new (do (set is-new false) (set category y) (set span @[x]) (array/push ret span))
-      (= y category) (array/push span x)
-      (do (set category y) (set span @[x]) (array/push ret span))))
+      new? (do (set new? false) (set categ y) (set span @[v]) (array/push ret span))
+      (= categ y) (array/push span v)
+      (do (set categ y) (set span @[v]) (array/push ret span))))
   ret)
 
 (defn interleave
@@ -1944,24 +1953,28 @@
   ret)
 
 (defn interpose
-  ``Returns a sequence of the elements of `ind` separated by
-  `sep`. Returns a new array.``
-  [sep ind]
-  (var k (next ind nil))
+  ``
+  Returns an array of the values of `x` separated by `sep`.
+
+  `x` can be a bytes, indexed, fiber or abstract type with suitable
+  `get` and `next` methods.
+  ``
+  [sep x]
+  (var k (next x nil))
   (if (not= nil k)
-    (if (lengthable? ind)
+    (if (lengthable? x)
       (do
-        (def ret (array/new-filled (- (* 2 (length ind)) 1) sep))
+        (def ret (array/new-filled (- (* 2 (length x)) 1) sep))
         (var i 0)
         (while (not= nil k)
-          (put ret i (in ind k))
-          (set k (next ind k))
+          (put ret i (in x k))
+          (set k (next x k))
           (+= i 2))
         ret)
       (do
-        (def ret @[(in ind k)])
-        (while (not= nil (set k (next ind k)))
-          (array/push ret sep (in ind k)))
+        (def ret @[(in x k)])
+        (while (not= nil (set k (next x k)))
+          (array/push ret sep (in x k)))
         ret))
     @[]))
 
@@ -1980,13 +1993,20 @@
   ret)
 
 (defn partition
-  ``Partition an indexed data structure `ind` into tuples
-  of size `n`. Returns a new array.``
-  [n ind]
+  ``
+  Partition the values of `x` into tuples of size `n`. Returns a new
+  array.
+
+  `n` should be a non-negative integer.
+
+  `x` can be a bytes, indexed, fiber, or abstract type with suitable
+  `get` and `next` methods.
+  ``
+  [n x]
   (cond
-    (indexed? ind) (partition-slice tuple/slice n ind)
-    (bytes? ind) (partition-slice string/slice n ind)
-    (partition-slice tuple/slice n (values ind))))
+    (indexed? x) (partition-slice tuple/slice n x)
+    (bytes? x) (partition-slice string/slice n x)
+    (partition-slice tuple/slice n (values x))))
 
 ###
 ###


### PR DESCRIPTION
This PR is an attempt to clarify the terminology in some docstrings along with information about the handled types of the corresponding functions.

(This PR was constructed under the assumption that the following PRs are merged first:

* #1812
* #1813
* #1814

The aforementioned 3 PRs all have tests that would probably be better to have in place before this PR gets merged.)

Below is a list of the functions and links for corresponding PRs to add examples to the website.

* `filter` https://github.com/janet-lang/janet-lang.org/pull/390
* `interpose` https://github.com/janet-lang/janet-lang.org/pull/392
* `partition` https://github.com/janet-lang/janet-lang.org/pull/393
* `partition-by` https://github.com/janet-lang/janet-lang.org/pull/391

These functions all used `ind` as a parameter name and had docstrings that didn't mention that they could handle more types.  Instead of `ind`, I chose to use the name `x` as we've been doing elsewhere to indicate support for more types like bytes, fibers, and certain abstract types [1].

I also chose to rename some local names in `partition-by` (i.e. `is-new` -> `new?` and `category` -> `categ`) because the result seemed easier to perceive overall without introducing much extra puzzlement (e.g. I think `categ` is pretty obviously an abbreviation for "category").  `partition-by` had a few places where multiple forms were being placed on single lines so the shorter names seemed more in line with that.

---

[1] `filter` seems to be the only one of the four for which it made some sense to indicate that dictionaries are supported (I think sorting the results would still give results that could be useful).  The other three functions can technically take a dictionary but it was more questionable to me whether this should be advertised (so I didn't) because the order of the elements in the returned array seemed to be something one might care about (i.e. sorting seems like it could lose a fair bit of information) and value-order for dictionaries might change depending on the version of `janet` in use.