### PR TITLE
Improve docstrings for each and friends

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -598,14 +598,37 @@
   (for-template i start stop 1 < + body))
 
 (defmacro eachk
-  "Loop over each key in `ds`. Returns nil."
-  [x ds & body]
-  (each-template x ds :keys body))
+  ``
+  Loop over each key in `x` with each key bound to `binding` with
+  destructuring support. Returns `nil`.
+
+  `x` can be a bytes, indexed, dictionary, fiber, or abstract type
+  with a suitable `next` method.
+  ``
+  [binding x & body]
+  (each-template binding x :keys body))
 
 (defmacro eachp
-  "Loop over each (key, value) pair in `ds`. Returns nil."
-  [x ds & body]
-  (each-template x ds :pairs body))
+  ``
+  Loop over each (key, value) pair in `x` with each pair bound to
+  `binding` with destructuring support. Returns `nil`.
+
+  `x` can be a bytes, indexed, dictionary, fiber, or abstract type
+  with suitable `get` and `next` methods.
+  ``
+  [binding x & body]
+  (each-template binding x :pairs body))
+
+(defmacro each
+  ``
+  Loop over each value in `x` with each value of `x` bound to
+  `binding` with destructuring support. Returns `nil`.
+
+  `x` can be a bytes, indexed, dictionary, fiber, or abstract type
+  with suitable `get` and `next` methods.
+  ``
+  [binding x & body]
+  (each-template binding x :each body))
 
 (defmacro repeat
   "Evaluate body n times. If n is negative, body will be evaluated 0 times. Evaluates to nil."
@@ -617,11 +640,6 @@
   "Evaluate body forever in a loop, or until a break statement."
   [& body]
   ~(while true ,;body))
-
-(defmacro each
-  "Loop over each value in `ds`. Returns nil."
-  [x ds & body]
-  (each-template x ds :each body))
 
 (defn- check-empty-body
   [body]


### PR DESCRIPTION
This PR is an attempt to expand on handled types in the docstrings of some functions along with a minor move for `each`.

Below is a list of the functions and links for corresponding PRs to add examples to the website.

* `each` https://github.com/janet-lang/janet-lang.org/pull/389
* `eachk` https://github.com/janet-lang/janet-lang.org/pull/394
* `eachp` https://github.com/janet-lang/janet-lang.org/pull/395

These functions all used `ds` as a parameter name and had docstrings that didn't mention that they could handle more types.  Instead of `ds`, I chose to use the name `x` as we've been doing elsewhere to indicate support for more types such as bytes, indexed, dictionary, fibers, and certain abstract types.

Also, `each` decided to move back closer to her younger siblings as [they'd all spent some time together early on](https://github.com/janet-lang/janet/commit/064475cb8d20fdc336a9bd2d73b9a51444f67e54) until [their brothers showed up](https://github.com/janet-lang/janet/commit/803f17aa904d250b74d5938e8f038f01aaa59efa).
