### PR TITLE
Improve docstrings for reverse and reverse!

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1626,32 +1626,41 @@
   res)
 
 (defn reverse!
-  `Reverses the order of the elements in a given array or buffer and returns it
-  mutated.`
-  [t]
+  ``
+  Reverses the order of the values in `x` and returns it mutated.
+
+  `x` can be a buffer, array, or abstract type with suitable
+  `get`, `length`, and `put` methods.
+  ``
+  [x]
   (var i 0)
-  (var j (length t))
+  (var j (length x))
   (while (< i (-- j))
-    (def ti (in t i))
-    (put t i (in t j))
-    (put t j ti)
+    (def v (in x i))
+    (put x i (in x j))
+    (put x j v)
     (++ i))
-  t)
+  x)
 
 (defn reverse
-  `Reverses the order of the elements in a given array or tuple and returns
-  a new array. If a string or buffer is provided, returns a buffer instead.`
-  [t]
-  (if (lengthable? t)
+  ``
+  Reverses the order of the values in `x`. If `x` is a bytes type,
+  returns a buffer, otherwise returns an array.
+
+  `x` can be a bytes, indexed, fiber, or abstract type with suitable
+  `get` and `next` methods.
+  ``
+  [x]
+  (if (lengthable? x)
     (do
-      (var n (length t))
-      (def ret (if (bytes? t)
+      (var n (length x))
+      (def ret (if (bytes? x)
                  (buffer/new-filled n)
                  (array/new-filled n)))
-      (each v t
+      (each v x
         (put ret (-- n) v))
       ret)
-    (reverse! (seq [v :in t] v))))
+    (reverse! (seq [v :in x] v))))
 
 (defn invert
   ``


### PR DESCRIPTION
This PR is an attempt to expand on handled types in the docstrings of some functions.

Below is a list of the functions and links for corresponding PRs to add examples to the website.

* `reverse` https://github.com/janet-lang/janet-lang.org/pull/400
* `reverse!` https://github.com/janet-lang/janet-lang.org/pull/401

It turns out that these functions can work with suitable abstract types so this PR tries to reflect some of those details in the docstrings.

Also, the parameter name of `t` was replaced with `x` to be more consistent with the rest of `boot.janet` and follow what we've been doing recently in other docstrings to reflect that the functions can handle a variety of types.