### PR TITLE
Improve docstrings of every? and any?

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1608,21 +1608,33 @@
     (fn :partial [& r] (f ;more ;r))))
 
 (defn every?
-  ``Evaluates to the last element of `ind` if all preceding elements are truthy,
-  otherwise evaluates to the first falsey element.``
-  [ind]
+  ``
+  Evaluates to the last element of `x` if all preceding elements are
+  truthy, true if `x` is empty, or otherwise to the first falsey
+  element.
+
+  `x` can be a bytes, indexed. dictionary, fiber, or abstract type
+  with suitable `get` and `next` methods.
+  ``
+  [x]
   (var res true)
-  (loop [x :in ind :while res]
-    (set res x))
+  (loop [v :in x :while res]
+    (set res v))
   res)
 
 (defn any?
-  ``Evaluates to the last element of `ind` if all preceding elements are falsey,
-  otherwise evaluates to the first truthy element.``
-  [ind]
+  ``
+  Evaluates to the last element of `x` if all preceding elements are
+  falsey, `nil` if `x` is empty, or otherwise to the first truthy
+  element.
+
+  `x` can be a bytes, indexed. dictionary, fiber, or abstract type
+  with suitable `get` and `next` methods.
+  ``
+  [x]
   (var res nil)
-  (loop [x :in ind :until res]
-    (set res x))
+  (loop [v :in x :until res]
+    (set res v))
   res)
 
 (defn reverse!


### PR DESCRIPTION
This PR is an attempt to expand on handled types in the docstrings of some functions.

Below is a list of the functions and links for corresponding PRs to add examples to the website.

* `every?` https://github.com/janet-lang/janet-lang.org/pull/402
* `any?` https://github.com/janet-lang/janet-lang.org/pull/403

It turns out that these functions can work with values that are:

> bytes, indexed. dictionary, fiber, or abstract type with suitable `get` and `next` methods

The docstrings were updated to spell these details out.

Also, the parameter name of `ind` was replaced with `x` to be more consistent with the rest of `boot.janet` and follow what we've been doing recently in other docstrings to reflect that the functions can handle a variety of types.