### PR TITLE
Clarify float check

### DIFF
--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -956,7 +956,7 @@ JANET_API int janet_checkint64(Janet x);
 JANET_API int janet_checkuint64(Janet x);
 JANET_API int janet_checksize(Janet x);
 JANET_API JanetAbstract janet_checkabstract(Janet x, const JanetAbstractType *at);
-#define janet_checkfloatrange(x) ((x) >= FLT_MIN && (x) <= FLT_MAX && (x) == (float)(x))
+#define janet_checkfloatrange(x) ((x) >= -FLT_MAX && (x) <= FLT_MAX)
 #define janet_checkint8range(x) ((x) >= INT8_MIN && (x) <= INT8_MAX && (x) == (int8_t)(x))
 #define janet_checkuint8range(x) ((x) >= 0 && (x) <= UINT8_MAX && (x) == (uint8_t)(x))
 #define janet_checkint16range(x) ((x) >= INT16_MIN && (x) <= INT16_MAX && (x) == (int16_t)(x))


### PR DESCRIPTION
`FLT_MIN` is not opposite to `FLT_MAX`, but it is rather smallest float, close to zero, which can be written to variable of type `float`.

Also, `janet_checkfloatrange()` is called with `x` of type `double`, so comparison `(x) == (float)(x)` does not true for non-integer values.

This PR fixes an issue.