### PR TITLE
Fix table/clone's docstring and link freeze, thaw and thaw-keep-keys'

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2507,9 +2507,9 @@
   res)
 
 (defn freeze
-  `Freeze an object (make it immutable) and do a deep copy, making
-  child values also immutable. Closures, fibers, and abstract types
-  will not be recursively frozen, but all other types will.`
+  ``Freeze an object (make it and any child values immutable) and do a deep
+  copy. Closures, fibers, and abstract types will not be recursively frozen,
+  but all other types will. `thaw` is the mutable version.``
   [x]
   (def tx (type x))
   (cond
@@ -2535,9 +2535,9 @@
 
 (defn thaw
   ```
-  Thaw an object (make it mutable) and do a deep copy, making
-  child values also mutable. Closures, fibers, and abstract
-  types will not be recursively thawed, but all other types will.
+  Thaw an object (make it and child values mutable) and do a deep copy. 
+  Closures, fibers, and abstract types will not be recursively thawed,
+  but all other types will. `freeze` is the mutable version.
   ```
   [ds]
   (case (type ds)

--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2509,7 +2509,11 @@
 (defn freeze
   ``Freeze an object (make it and any child values immutable) and do a deep
   copy. Closures, fibers, and abstract types will not be recursively frozen,
-  but all other types will. `thaw` is the mutable version.``
+  but all other types will. `thaw` is the mutable version.
+   
+  If no closures, fibers and abstract types, you may preserve children's mutability,
+  using:
+  * (unmarshal (marshal ds))``
   [x]
   (def tx (type x))
   (cond
@@ -2535,9 +2539,7 @@
 
 (defn thaw
   ```
-  Thaw an object (make it and child values mutable) and do a deep copy. 
-  Closures, fibers, and abstract types will not be recursively thawed,
-  but all other types will. `freeze` is the mutable version.
+  Similar to `freeze`, but mutable. Also see `thaw-keep-keys`.
   ```
   [ds]
   (case (type ds)
@@ -2550,7 +2552,7 @@
 
 (defn thaw-keep-keys
   ```
-  Similar to `thaw`, but do not modify table or struct keys.
+  Similar to `freeze`, but mutable, leaving table and struct keys unmodified.
   ```
   [ds]
   (case (type ds)

--- a/src/core/table.c
+++ b/src/core/table.c
@@ -405,7 +405,10 @@ JANET_CORE_FN(cfun_table_rawget,
 
 JANET_CORE_FN(cfun_table_clone,
               "(table/clone tab)",
-              "Create a shallow copy of table `tab`.") {
+              "Create a shallow copy of table `tab`.\n"
+              "If the table's values are references to child data structures, updates to"
+              "those children structures will change them in the new and old tables alike."
+              "To make a deep copy, refer to `thaw` or `(unmarshal (marshal tab))`.") {
     janet_fixarity(argc, 1);
     JanetTable *table = janet_gettable(argv, 0);
     return janet_wrap_table(janet_table_clone(table));

--- a/src/core/table.c
+++ b/src/core/table.c
@@ -405,8 +405,7 @@ JANET_CORE_FN(cfun_table_rawget,
 
 JANET_CORE_FN(cfun_table_clone,
               "(table/clone tab)",
-              "Create a copy of a table. Updates to the new table will not change the old table, "
-              "and vice versa.") {
+              "Create a shallow copy of table `tab`.") {
     janet_fixarity(argc, 1);
     JanetTable *table = janet_gettable(argv, 0);
     return janet_wrap_table(janet_table_clone(table));


### PR DESCRIPTION
We've had some confusion over the years about `table/clone`'s docstring:
- https://github.com/janet-lang/janet/issues/576
- https://janet.zulipchat.com/#narrow/channel/409517-help/topic/table.2Fclone.20doesn.27t.20make.20a.20deep.20copy.3F/with/617609043

The different commits represent increasing levels of "extremeness". The first simply removes the suggestion towards deepness, the next ones suggest alternatives etc. which I feel is more useful. So feel free to squash!