### PR TITLE
Improve docstring for interleave

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -2007,9 +2007,17 @@
   ret)
 
 (defn interleave
-  "Returns an array of the first elements of each col, then the second elements, etc."
-  [& cols]
-  (mapcat tuple ;cols))
+  ``
+  Returns an array of the values of each element of `xs`, interleaved.
+  If the elements of `xs` do not all have the same number of values,
+  the shortest element of `xs` determines the number of values from
+  each element of `xs` that are contained in the returned array.
+
+  Each element of `xs` can be a bytes, indexed, fiber, or abstract
+  type with suitable `get` and `next` methods.
+  ``
+  [& xs]
+  (mapcat tuple ;xs))
 
 (defn distinct
   "Returns an array of the deduplicated values in `xs`."


### PR DESCRIPTION
This PR is an attempt to spell out more fully which types of values can be handled by `interleave`, namely:

> bytes, indexed, fiber, or abstract type with suitable get and next methods

The parameter name `cols` was adjusted to be more in line with other recent docstring PRs. Namely `xs` is used instead of `cols` to be more indicative of a wider range of types that can be handled.

The general description of the function was also changed to spell out a bit more about what happens when the number of elements of each of the `xs` are not all the same.

Note there is a companion PR for associated examples: https://github.com/janet-lang/janet-lang.org/pull/416