### PR TITLE
Improve docstring for describe

### DIFF
--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -317,10 +317,10 @@ JANET_CORE_FN(janet_core_native,
 
 JANET_CORE_FN(janet_core_describe,
               "(describe x)",
-              "Returns a string that is a human-readable description of `x`. "
-              "For recursive data structures, the string returned contains a "
-              "pointer value from which the identity of `x` "
-              "can be determined.") {
+              "Returns a string that is a human-readable description of "
+              "`x`. For indexed, dictionary, fiber, pointer, and some "
+              "abstract types, the string returned contains a pointer "
+              "value from which the identity of `x` can be determined.") {
     JanetBuffer *b = janet_buffer(0);
     for (int32_t i = 0; i < argc; ++i)
         janet_description_b(b, argv[i]);


### PR DESCRIPTION
This PR is an attempt to spell out more precisely which types of values yield strings that have pointer values in them.

Note there is a companion PR for associated examples: https://github.com/janet-lang/janet-lang.org/pull/417