### PR TITLE
Improve docstring for last

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -899,9 +899,14 @@
   (get x 0))
 
 (defn last
-  "Get the last element from an indexed data structure."
-  [xs]
-  (get xs (- (length xs) 1)))
+  ``
+  Get the final element from `x`.
+
+  `x` can be a bytes, indexed, or abstract type value with suitable
+  `get` and `length` methods.
+  ``
+  [x]
+  (get x (- (length x) 1)))
 
 ## Polymorphic comparisons
 


### PR DESCRIPTION
This PR is an attempt to spell out more fully which types of values can be handled by `last`, namely:

> bytes, indexed, or abstract type with a suitable length method

The parameter name `xs` was replaced with `x` to be more in line with other recent docstring PRs.

Note there is a companion PR for associated examples: https://github.com/janet-lang/janet-lang.org/pull/420