### PR TITLE
Improve docstring for loop

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -647,75 +647,85 @@
     (maclintf :normal "empty loop body")))
 
 (defmacro loop
-  ```
-  A general purpose loop macro. This macro is similar to the Common Lisp loop
-  macro, although intentionally much smaller in scope.  The head of the loop
-  should be a tuple that contains a sequence of either bindings or
-  conditionals. A binding is a sequence of three values that define something
-  to loop over. Bindings are written in the format:
+  ``
+  A general purpose loop macro. This macro is similar to the Common
+  Lisp `loop` macro, although intentionally much smaller in scope.
+
+  The first argument, `head`, should be a tuple that contains a
+  sequence of either bindings or conditionals. A binding is a sequence
+  of three values that define something to loop over. Bindings are
+  written in the format:
 
       binding :verb object/expression
 
-  where `binding` is a binding as passed to def, `:verb` is one of a set of
-  keywords, and `object` is any expression. Each subsequent binding creates a
-  nested loop within the loop created by the previous binding.
+  where `binding` is a binding as passed to `def`, `:verb` is one of a
+  set of keywords, and `object` is any expression. Each subsequent
+  binding creates a nested loop within the loop created by the
+  previous binding.
 
   The available verbs are:
 
-  * `:iterate` -- repeatedly evaluate and bind to the expression while it is
-    truthy.
+  * `:iterate` -- repeatedly evaluate and bind to the expression while
+    it is truthy.
 
-  * `:range` -- loop over a range. The object should be a two-element tuple with
-    a start and end value, and an optional positive step. The range is half
-    open, [start, end).
+  * `:range` -- loop over a range. The object should be a two-element
+    tuple with a start and end value, and an optional positive
+    step. The range is half open, [start, end).
 
-  * `:range-to` -- same as :range, but the range is inclusive [start, end].
+  * `:range-to` -- same as `:range`, but the range is inclusive
+    [start, end].
 
-  * `:down` -- loop over a range, stepping downwards. The object should be a
-    two-element tuple with a start and (exclusive) end value, and an optional
-    (positive!) step size.
+  * `:down` -- loop over a range, stepping downwards. The object
+    should be a two-element tuple with a start and end value, and an
+    optional positive step size.  The range is half open, [start,
+    end).
 
-  * `:down-to` -- same as :down, but the range is inclusive [start, end].
+  * `:down-to` -- same as `:down`, but the range is inclusive [start,
+    end].
 
-  * `:keys` -- iterate over the keys in a data structure.
+  * `:keys` -- iterate over the keys in a bytes, indexed, dictionary,
+    fiber, or abstract type with a suitable `next` method.
 
-  * `:pairs` -- iterate over the key-value pairs as tuples in a data structure.
+  * `:pairs` -- iterate over the key-value pairs as tuples in a bytes,
+    indexed, dictionary, fiber, or abstract type with suitable `get`
+    and `next` methods.
 
-  * `:in` -- iterate over the values in a data structure or fiber.
+  * `:in` -- iterate over the values in a bytes, indexed, dictionary,
+    fiber, or abstract type with suitable `get` and `next` methods.
 
-  `loop` also accepts conditionals to refine the looping further. Conditionals are of
-  the form:
+  `loop` also accepts conditionals to refine the looping
+  further. Conditionals are of the form:
 
       :modifier argument
 
-  where `:modifier` is one of a set of keywords, and `argument` is keyword-dependent.
-  `:modifier` can be one of:
+  where `:modifier` is one of a set of keywords, and `argument` is
+  keyword-dependent. `:modifier` can be one of:
 
-  * `:while expression` -- breaks from the current loop if `expression` is
-    falsey.
+  * `:while expression` -- breaks from the current loop if
+    `expression` is falsey.
 
-  * `:until expression` -- breaks from the current loop if `expression` is
-    truthy.
+  * `:until expression` -- breaks from the current loop if
+    `expression` is truthy.
 
-  * `:let bindings` -- defines bindings inside the current loop as passed to the
-    `let` macro.
+  * `:let bindings` -- defines bindings inside the current loop as
+    passed to the `let` macro.
 
-  * `:before form` -- evaluates a form for a side effect before the next inner
-    loop.
-
-  * `:after form` -- same as `:before`, but the side effect happens after the
+  * `:before form` -- evaluates a form for a side effect before the
     next inner loop.
+
+  * `:after form` -- same as `:before`, but the side effect happens
+    after the next inner loop.
 
   * `:repeat n` -- repeats the next inner loop `n` times.
 
-  * `:when condition` -- only evaluates the current loop body when `condition`
-    is truthy.
+  * `:when condition` -- only evaluates the current loop body when
+    `condition` is truthy.
 
-  * `:unless condition` -- only evaluates the current loop body when `condition`
-    is falsey.
+  * `:unless condition` -- only evaluates the current loop body when
+    `condition` is falsey.
 
-  The `loop` macro always evaluates to nil.
-  ```
+  The `loop` macro always evaluates to `nil`.
+  ``
   [head & body]
   (loop1 body head 0))
 


### PR DESCRIPTION
This PR is an attempt to spell out more fully which types of values can be handled by `loop` as well as make some minor tweaks.

Some changes include:

* Which values can be used with `:keys`, `:pairs`, and `:in` are more explicitly described.
* For `:down`, that `start` and `end` are interpreted as endpoints of a half open interval is mentioned (similar to what was already the case for `:range`).  This was part of making the text a bit more similar to `:range`.
* Backticks were used to surround a few more terms (e.g. `def`)
* Some reflow was done to make future comparison a bit easier