### PR TITLE
Improve docstring for table/to-struct

### DIFF
--- a/src/core/table.c
+++ b/src/core/table.c
@@ -384,7 +384,11 @@ JANET_CORE_FN(cfun_table_setproto,
 
 JANET_CORE_FN(cfun_table_tostruct,
               "(table/to-struct tab &opt proto)",
-              "Convert a table to a struct. Returns a new struct.") {
+              "Create and return a struct based on a table `tab`. "
+              "If given, the optional argument `proto` specifies "
+              "a struct to be used as the newly created struct's "
+              "prototype. Note that if `proto` is not specified, "
+              "the newly created struct will not have a prototype.") {
     janet_arity(argc, 1, 2);
     JanetTable *t = janet_gettable(argv, 0);
     JanetStruct proto = janet_optstruct(argv, argc, 1, NULL);


### PR DESCRIPTION
This PR is an attempt to spell out the behavior of `table/to-struct` more fully.

Specifically, it mentions the optional `proto` argument and that it should be a struct.  Also, I added text pointing out that not specifying the optional argument will result in a struct with no prototype [1].

Note there is a companion PR for associated examples: https://github.com/janet-lang/janet-lang.org/pull/423

---

[1] One of the examples in the companion PR demonstrates that passing in a table with a prototype results in a struct with no prototype.