### PR TITLE
Improve docstring for struct/with-proto

### DIFF
--- a/src/core/struct.c
+++ b/src/core/struct.c
@@ -206,8 +206,8 @@ JanetTable *janet_struct_to_table(const JanetKV *st) {
 
 JANET_CORE_FN(cfun_struct_with_proto,
               "(struct/with-proto proto & kvs)",
-              "Create a structure, as with the usual struct constructor but set the "
-              "struct prototype as well.") {
+              "Create a struct using the `proto` argument as the struct's "
+              "prototype. `kvs` are as in the `struct` function.") {
     janet_arity(argc, 1, -1);
     JanetStruct proto = janet_optstruct(argv, argc, 0, NULL);
     if (!(argc & 1))


### PR DESCRIPTION
This PR is an attempt to spell out some more detail for the `struct/with-proto` function.

Specifically, the `proto` and `kvs` arguments are mentioned.  The purpose of `proto` is explained and a reference is made to the `struct` function for `kvs`.

Note there is a companion PR for associated examples: https://github.com/janet-lang/janet-lang.org/pull/425