### PR TITLE
Align local names in merge and merge-into

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1898,9 +1898,9 @@
   previous ones. Returns `tab`.
   ``
   [tab & dicts]
-  (loop [c :in dicts
-         key :keys c]
-    (put tab key (in c key)))
+  (loop [d :in dicts
+         key :keys d]
+    (put tab key (in d key)))
   tab)
 
 (defn merge
@@ -1911,9 +1911,9 @@
   ``
   [& dicts]
   (def container @{})
-  (loop [c :in dicts
-         key :keys c]
-    (put container key (in c key)))
+  (loop [d :in dicts
+         key :keys d]
+    (put container key (in d key)))
   container)
 
 (defn keys


### PR DESCRIPTION
This PR is a follow-up to https://github.com/janet-lang/janet/pull/1794.

In #1794, I renamed `colls` to `dicts` but did not rename `c` (an individual `colls`) to `d` (an individual `dicts`).  This made the existing code a bit less clear.  This PR "completes" the "unfinished business" by renaming `c` to `d`.

Sorry I missed this earlier :sweat_smile: 