### PR TITLE
Make table/to-struct's docstring less wordy

### DIFF
--- a/src/core/table.c
+++ b/src/core/table.c
@@ -384,11 +384,11 @@ JANET_CORE_FN(cfun_table_setproto,
 
 JANET_CORE_FN(cfun_table_tostruct,
               "(table/to-struct tab &opt proto)",
-              "Create and return a struct based on a table `tab`. "
-              "If given, the optional argument `proto` specifies "
-              "a struct to be used as the newly created struct's "
-              "prototype. Note that if `proto` is not specified, "
-              "the newly created struct will not have a prototype.") {
+              "Return a struct based on a table `tab`. If given, "
+              "the optional argument `proto` specifies the new "
+              "struct's prototype. Note that if `proto` is not "
+              "specified, the new struct will not have a "
+              "prototype.") {
     janet_arity(argc, 1, 2);
     JanetTable *t = janet_gettable(argv, 0);
     JanetStruct proto = janet_optstruct(argv, argc, 1, NULL);


### PR DESCRIPTION
This PR is an attempt to address [a recent comment](https://github.com/janet-lang/janet/pull/1831#issuecomment-5431740270) regarding the docstring content of a previous attempt being a bit redundant.

I think this new attempt is a bit better.  At minimum, it should be shorter :)