### PR TITLE
free realpath() result with libc allocator

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -2677,7 +2677,7 @@ JANET_CORE_FN(os_realpath,
         janet_panicf("path does not exist: %v", ret);
     }
 #else
-    janet_free(dest);
+    free(dest);
 #endif
     return ret;
 #endif


### PR DESCRIPTION
`dest` is allocated with `realpath` in this case, which needs to be deallocated with `free` and not user overridable `janet_free`.