### PR TITLE
ev: bugfix for double free

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -2369,6 +2369,7 @@ void janet_ev_default_threaded_callback(JanetEVGenericMessage return_value) {
         /* Clean up */
         switch (return_value.tag) {
             default:
+                break;
             case JANET_EV_TCTAG_STRINGF:
             case JANET_EV_TCTAG_ERR_STRINGF:
                 janet_free(return_value.argp);
@@ -2379,6 +2380,7 @@ void janet_ev_default_threaded_callback(JanetEVGenericMessage return_value) {
     if (janet_fiber_can_resume(return_value.fiber)) {
         switch (return_value.tag) {
             default:
+                break;
             case JANET_EV_TCTAG_NIL:
                 janet_schedule(return_value.fiber, janet_wrap_nil());
                 break;
@@ -2407,6 +2409,7 @@ void janet_ev_default_threaded_callback(JanetEVGenericMessage return_value) {
     /* Clean up */
     switch (return_value.tag) {
         default:
+            break;
         case JANET_EV_TCTAG_STRINGF:
         case JANET_EV_TCTAG_ERR_STRINGF:
             janet_free(return_value.argp);

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -1623,6 +1623,7 @@ JANET_CORE_FN(os_posix_chroot,
 static JanetEVGenericMessage os_shell_subr(JanetEVGenericMessage args) {
     int stat = system((const char *) args.argp);
     janet_free(args.argp);
+    args.argp = NULL;
     if (args.argi) {
         args.tag = JANET_EV_TCTAG_INTEGER;
     } else {


### PR DESCRIPTION
I encountered this issue with `janet -e '(os/shell "echo")` on Mac, system malloc lib will complain as follows:

```
janet(42817,0x7ff854547780) malloc: *** error for object 0x60000000b730: pointer being freed was not allocated
janet(42817,0x7ff854547780) malloc: *** set a breakpoint in malloc_error_break to debug
```

So I followed the suggestion and here's the backtrace:

```
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
  * frame #0: 0x00007ff810cb6883 libsystem_malloc.dylib`malloc_error_break
    frame #1: 0x00007ff810ca76d3 libsystem_malloc.dylib`malloc_vreport + 761
    frame #2: 0x00007ff810caab31 libsystem_malloc.dylib`malloc_report + 151
    frame #3: 0x0000000100025402 janet`janet_ev_default_threaded_callback(return_value=JanetEVGenericMessage @ 0x00007ff7bfefad90) at ev.c:2412:13 [opt]
    frame #4: 0x0000000100024b1f janet`janet_loop1_impl [inlined] janet_ev_handle_selfpipe at ev.c:1643:13 [opt]
    frame #5: 0x0000000100024ac9 janet`janet_loop1_impl(has_timeout=<unavailable>, timeout=0) at ev.c:2028:13 [opt]
    frame #6: 0x0000000100024714 janet`janet_loop1 at ev.c:1588:13 [opt]
    frame #7: 0x00000001000497f5 janet`janet_loop_fiber at ev.c:1609:41 [opt]
    frame #8: 0x00000001000497b3 janet`janet_loop_fiber(fiber=0x0000600002903790) at run.c:150:5 [opt]
    frame #9: 0x0000000100075266 janet`main(argc=<unavailable>, argv=0x00007ff7bfeff210) at shell.c:1284:14 [opt]
    frame #10: 0x00007ff810b1041f dyld`start + 1903
```

Found out that it's actually a missing break in the code which leads to double free.

BTW, I'm thinking that if we can `make test RUN='valgrind --leak-check=full'` in the CI, so this kind of bugs can be captured earlier.


Change-Id: I74d324b70b39ddc7d6f509b0382e2be36a6a6964