### PR TITLE
FreeBSD should now use inotify

### DIFF
--- a/src/core/filewatch.c
+++ b/src/core/filewatch.c
@@ -29,7 +29,16 @@
 #ifdef JANET_EV
 #ifdef JANET_FILEWATCH
 
-#ifdef JANET_LINUX
+#if defined(JANET_APPLE) || defined(JANET_BSD)
+#define JANET_KQUEUE 1
+#endif
+#if defined(JANET_LINUX) || defined(__FreeBSD__)
+/* pull FreeBSD off JANET_KQUEUE as it has more functionality with inotify */
+#undef  JANET_KQUEUE
+#define JANET_INOTIFY 1
+#endif
+
+#ifdef JANET_INOTIFY
 #include <sys/inotify.h>
 #include <unistd.h>
 #endif
@@ -38,7 +47,7 @@
 #include <windows.h>
 #endif
 
-#if defined(JANET_APPLE) || defined(JANET_BSD)
+#ifdef JANET_KQUEUE
 #include <sys/event.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -60,7 +69,7 @@ typedef struct {
     int is_watching;
 } JanetWatcher;
 
-#ifdef JANET_LINUX
+#ifdef JANET_INOTIFY
 
 #include <sys/inotify.h>
 #include <unistd.h>
@@ -96,7 +105,7 @@ static uint32_t decode_watch_flags(const Janet *options, int32_t n) {
             sizeof(JanetWatchFlagName),
             keyw);
         if (!result) {
-            janet_panicf("unknown linux flag %v", options[i]);
+            janet_panicf("unknown inotify flag %v", options[i]);
         }
         flags |= result->flag;
     }
@@ -122,7 +131,8 @@ static void janet_watcher_add(JanetWatcher *watcher, const char *path, uint32_t 
     if (watcher->stream == NULL) janet_panic("watcher closed");
     int result;
     do {
-        result = inotify_add_watch(watcher->stream->handle, path, flags);
+        /* FreeBSD is not forgiving about returned-only flags, just make sure off */
+        result = inotify_add_watch(watcher->stream->handle, path, flags & ~(IN_IGNORED|IN_ISDIR|IN_Q_OVERFLOW|IN_UNMOUNT));
     } while (result == -1 && errno == EINTR);
     if (result == -1) {
         janet_panicv(janet_ev_lasterr());
@@ -514,7 +524,7 @@ static void janet_watcher_unlisten(JanetWatcher *watcher) {
     janet_gcunroot(janet_wrap_abstract(watcher));
 }
 
-#elif defined(JANET_APPLE) || defined(JANET_BSD)
+#elif JANET_KQUEUE
 
 /* kqueue implementation */
 

--- a/test/suite-filewatch.janet
+++ b/test/suite-filewatch.janet
@@ -25,9 +25,10 @@
 
 (def chan (ev/chan 1000))
 (var is-win (or (= :mingw (os/which)) (= :windows (os/which))))
-(var is-linux (= :linux (os/which)))
-(def bsds [:freebsd :macos :openbsd :bsd :dragonfly :netbsd])
-(var is-kqueue (index-of (os/which) bsds))
+(def inotifies [:linux :freebsd])
+(var is-inotify (index-of (os/which) inotifies))
+(def kqs [:macos :openbsd :bsd :dragonfly :netbsd])
+(var is-kqueue (index-of (os/which) kqs))
 
 # If not supported, exit early
 (def [supported msg] (protect (filewatch/new chan)))
@@ -95,7 +96,7 @@
 (when is-win
   (filewatch/add fw td1 :last-write :last-access :file-name :dir-name :size :attributes :recursive)
   (filewatch/add fw td2 :last-write :last-access :file-name :dir-name :size :attributes))
-(when is-linux
+(when is-inotify
   (filewatch/add fw (string td3 "/file3.txt") :close-write :create :delete)
   (filewatch/add fw td1 :close-write :create :delete)
   (filewatch/add fw td2 :close-write :create :delete :ignored))
@@ -155,7 +156,7 @@
 # Linux file writing
 #
 
-(when is-linux
+(when is-inotify
   (spit-file td1 "file1.txt")
   (expect :type :create :file-name "file1.txt" :dir-name td1)
   (expect :type :close-write)


### PR DESCRIPTION
I noticed a question about filewatch over on janet.zulipchat.com, which was actually about macos filewatch.

As promised I verified inotify(2) works on FreeBSD15. In theory this should now be all supported versions of FreeBSD. I did the meson build and `samu -C build test` and everything passes. I don't have linux/windows so they are not tested, ideally they were unchanged.

This did require turning off flags that FreeBSD maybe should ignore but isn't?
linking @markjdb as he woud know.