### PR TITLE
Improve docstring for getproto

### DIFF
--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -494,8 +494,9 @@ JANET_CORE_FN(janet_core_table,
 }
 
 JANET_CORE_FN(janet_core_getproto,
-              "(getproto x)",
-              "Get the prototype of a table or struct. Will return nil if `x` has no prototype.") {
+              "(getproto dict)",
+              "Get the prototype of a dictionary `dict`. Returns `nil` if "
+              "`dict` has no prototype.") {
     janet_fixarity(argc, 1);
     if (janet_checktype(argv[0], JANET_TABLE)) {
         JanetTable *t = janet_unwrap_table(argv[0]);


### PR DESCRIPTION
This PR is an attempt to adjust the docstring for `getproto`.

Primarily, it's following up on https://github.com/janet-lang/janet/issues/1780, but it also includes a bit of rewording and reflow as well.