### PR TITLE
Tweak ffi/defbind-alias docstring

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -4344,8 +4344,8 @@
 
   (defmacro ffi/defbind-alias :flycheck
     "Generate bindings for native functions in a convenient manner.
-     Similar to defbind but allows for the janet function name to be
-     different than the FFI function."
+     Similar to `ffi/defbind` but allows for the janet function name
+     to be different than the FFI function."
     [name alias ret-type & body]
     (def real-ret-type (eval ret-type))
     (def meta (slice body 0 -2))


### PR DESCRIPTION
This PR is a minor tweak for `ffi/defbind-alias` that just replaces mention of `defbind` with `ffi/defbind`.