### PR TITLE
Improve docstring for zipcoll

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -1788,8 +1788,14 @@
   ret)
 
 (defn zipcoll
-  `Creates a table from two arrays/tuples.
-  Returns a new table.`
+  ``
+  Creates a table from `ks` and `vs` by pairing values at the same
+  index from each. If `ks` or `vs` has more values than the other, the
+  extra values are ignored. Returns a new table.
+
+  `ks` and `vs` can by bytes, indexed, fibers, or abstract types with
+  suitable `get` and `next` methods.
+  ``
   [ks vs]
   (def res @{})
   (var kk nil)


### PR DESCRIPTION
This PR is an attempt to spell out more fully which types of values can be handled by `zipcoll`, namely:

> bytes, indexed, fiber, or abstract types with suitable `get` and `next` methods

Additional suggestions include:

* Mentioning the names, `ks` and `vs`, of the parameters.
* Specifying behavior for when `ks` and `vs` do not have the same length.
* Spelling out a bit how the items in `ks` and `vs` are paired together.

Note there is a companion PR for associated examples: https://github.com/janet-lang/janet-lang.org/pull/444