### PR TITLE
Fix misc docstring typos

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -49,10 +49,12 @@
   (apply defn name :macro more))
 
 (defmacro as-macro
-  ``Use a function or macro literal `f` as a macro. This lets
-  any function be used as a macro. Inside a quasiquote, the
-  idiom `(as-macro ,my-custom-macro arg1 arg2...)` can be used
-  to avoid unwanted variable capture of `my-custom-macro`.``
+  ``
+  Use a function or macro literal `f` as a macro. This allows any
+  function to be used as a macro. Inside a quasiquote, the idiom
+  `(as-macro ,my-custom-macro arg1 arg2...)` can be used to avoid
+  unwanted variable capture of `my-custom-macro`.
+  ``
   [f & args]
   (f ;args))
 
@@ -177,7 +179,7 @@
   "The current lint error level. The error level is the lint level at which compilation will exit with an error and not continue.")
 
 (defdyn *lint-warn*
-  "The current lint warning level. The warning level is the lint level at which and error will be printed but compilation will continue as normal.")
+  "The current lint warning level. The warning level is the lint level at which an error will be printed but compilation will continue as normal.")
 
 (defdyn *lint-levels*
   "A table of keyword alias to numbers denoting a lint level. Can be used to provided custom aliases for numeric lint levels.")
@@ -4180,7 +4182,7 @@
   (defmacro ev/spawn
     ``
     Run some code in a new task fiber. This is shorthand for
-    `(ev/go (fn [] ;body))`."
+    `(ev/go (fn [] ;body))`.
     ``
     [& body]
     ~(,ev/go (fn :spawn [&] ,;body)))
@@ -4322,7 +4324,7 @@
 
 (compwhen (dyn 'ffi/native)
 
-  (defdyn *ffi-context* " Current native library for ffi/bind and other settings")
+  (defdyn *ffi-context* " Current native library for ffi/defbind and other settings")
 
   (defn- default-mangle
     [name &]

--- a/src/core/array.c
+++ b/src/core/array.c
@@ -385,7 +385,7 @@ JANET_CORE_FN(cfun_array_trim,
 
 JANET_CORE_FN(cfun_array_clear,
               "(array/clear arr)",
-              "Empties an array, setting it's count to 0 but does not free the backing capacity. "
+              "Empties an array, setting its count to 0 but does not free the backing capacity. "
               "Returns the modified array.") {
     janet_fixarity(argc, 1);
     JanetArray *array = janet_getarray(argv, 0);

--- a/src/core/buffer.c
+++ b/src/core/buffer.c
@@ -368,7 +368,7 @@ static void reverse_u64(uint8_t bytes[8]) {
 JANET_CORE_FN(cfun_buffer_push_uint16,
               "(buffer/push-uint16 buffer order data)",
               "Push a 16 bit unsigned integer data onto the end of the buffer. "
-              "Returns the modified buffer."
+              "Returns the modified buffer. "
               "Expands the buffer as necessary. Throws an error if size limit is exceeded.") {
     janet_fixarity(argc, 3);
     JanetBuffer *buffer = janet_getbuffer(argv, 0);
@@ -388,7 +388,7 @@ JANET_CORE_FN(cfun_buffer_push_uint16,
 JANET_CORE_FN(cfun_buffer_push_uint32,
               "(buffer/push-uint32 buffer order data)",
               "Push a 32 bit unsigned integer data onto the end of the buffer. "
-              "Returns the modified buffer."
+              "Returns the modified buffer. "
               "Expands the buffer as necessary. Throws an error if size limit is exceeded.") {
     janet_fixarity(argc, 3);
     JanetBuffer *buffer = janet_getbuffer(argv, 0);
@@ -405,7 +405,7 @@ JANET_CORE_FN(cfun_buffer_push_uint32,
 JANET_CORE_FN(cfun_buffer_push_uint64,
               "(buffer/push-uint64 buffer order data)",
               "Push a 64 bit unsigned integer data onto the end of the buffer. "
-              "Returns the modified buffer."
+              "Returns the modified buffer. "
               "Expands the buffer as necessary. Throws an error if size limit is exceeded.") {
     janet_fixarity(argc, 3);
     JanetBuffer *buffer = janet_getbuffer(argv, 0);
@@ -422,7 +422,7 @@ JANET_CORE_FN(cfun_buffer_push_uint64,
 JANET_CORE_FN(cfun_buffer_push_float32,
               "(buffer/push-float32 buffer order data)",
               "Push the underlying bytes of a 32 bit float data onto the end of the buffer. "
-              "Returns the modified buffer."
+              "Returns the modified buffer. "
               "Expands the buffer as necessary. Throws an error if size limit is exceeded.") {
     janet_fixarity(argc, 3);
     JanetBuffer *buffer = janet_getbuffer(argv, 0);
@@ -439,7 +439,7 @@ JANET_CORE_FN(cfun_buffer_push_float32,
 JANET_CORE_FN(cfun_buffer_push_float64,
               "(buffer/push-float64 buffer order data)",
               "Push the underlying bytes of a 64 bit float data onto the end of the buffer. "
-              "Returns the modified buffer."
+              "Returns the modified buffer. "
               "Expands the buffer as necessary. Throws an error if size limit is exceeded.") {
     janet_fixarity(argc, 3);
     JanetBuffer *buffer = janet_getbuffer(argv, 0);


### PR DESCRIPTION
This PR is an attempt to address a collection of minor docstring issues.

Some suggested changes include:

* Change wording a bit
* Spelling changes
* Stray double-quote removal
* Insertion of whitespace