### PR TITLE
Tweak some buffer parameter docstrings

### DIFF
--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -3408,13 +3408,14 @@ JANET_CORE_FN(janet_cfun_stream_close,
 }
 
 JANET_CORE_FN(janet_cfun_stream_read,
-              "(ev/read stream n &opt buffer timeout)",
-              "Read up to n bytes into a buffer asynchronously from a stream. `n` can also be the keyword "
-              "`:all` to read into the buffer until end of stream. "
-              "Optionally provide a buffer to write into "
-              "as well as a timeout in seconds after which to cancel the operation and raise an error. "
-              "Returns the buffer if the read was successful or nil if end-of-stream reached. Will raise an "
-              "error if there are problems with the IO operation.") {
+              "(ev/read stream n &opt buf timeout)",
+              "Read at most `n` bytes into a buffer asynchronously from a "
+              "stream. `n` can also be `:all` to read into the buffer until "
+              "end of stream. Optionally provide a buffer, `buf`, to write "
+              "into and `timeout` in seconds after which to cancel the "
+              "operation and raise an error. Returns the buffer if the read "
+              "was successful or nil if end-of-stream reached. Raises "
+              "an error if there were problems with the IO operation.") {
     janet_arity(argc, 2, 4);
     JanetStream *stream = janet_getabstract(argv, 0, &janet_stream_type);
     janet_stream_flags(stream, JANET_STREAM_READABLE);
@@ -3431,9 +3432,10 @@ JANET_CORE_FN(janet_cfun_stream_read,
 }
 
 JANET_CORE_FN(janet_cfun_stream_chunk,
-              "(ev/chunk stream n &opt buffer timeout)",
-              "Same as ev/read, but will not return early if less than n bytes are available. If an end of "
-              "stream is reached, will also return early with the collected bytes.") {
+              "(ev/chunk stream n &opt buf timeout)",
+              "Same as `ev/read`, but does not return early if less than "
+              "`n` bytes are available. If an end-of-stream is reached, "
+              "returns early with the collected bytes.") {
     janet_arity(argc, 2, 4);
     JanetStream *stream = janet_getabstract(argv, 0, &janet_stream_type);
     janet_stream_flags(stream, JANET_STREAM_READABLE);

--- a/src/core/inttypes.c
+++ b/src/core/inttypes.c
@@ -235,14 +235,17 @@ JANET_CORE_FN(cfun_to_number,
 }
 
 JANET_CORE_FN(cfun_to_bytes,
-              "(int/to-bytes value &opt endianness buffer)",
-              "Write the bytes of an `int/s64` or `int/u64` into a buffer.\n"
-              "The `buffer` parameter specifies an existing buffer to write to, if unset a new buffer will be created.\n"
+              "(int/to-bytes val &opt endianness buf)",
+              "Write the bytes of an `int/s64` or `int/u64`, `val`, into a "
+              "buffer. The optional `buf` parameter is an existing buffer "
+              "to write to; if not provided, a new buffer will be created. "
               "Returns the modified buffer.\n"
+              "\n"
               "The `endianness` parameter indicates the byte order:\n"
-              "- `nil` (unset): system byte order\n"
-              "- `:le`: little-endian, least significant byte first\n"
-              "- `:be`: big-endian, most significant byte first\n") {
+              "\n"
+              "- `:be` - big-endian, most significant byte first\n"
+              "- `:le` - little-endian, least significant byte first\n"
+              "- `nil` or unset - system byte order\n") {
     janet_arity(argc, 1, 3);
     if (janet_is_int(argv[0]) == JANET_INT_NONE) {
         janet_panicf("int/to-bytes: expected an int/s64 or int/u64, got %q", argv[0]);


### PR DESCRIPTION
This PR has suggestions for some functions that currently have `buffer` as a parameter name (but are not `buffer/` functions as there is a [separate PR](https://github.com/janet-lang/janet/pull/1858) for those).

Some changes include:

* As with https://github.com/janet-lang/janet/pull/1858, the parameter name `buf` is used instead of `buffer`.  This is slightly shorter but also avoids a string that is used for a built-in function [1].
* Some other parameter names were also shortened (e.g. `value` -> `val`).
* `val` is now mentioned in a docstrings for a bit more clarity.
* "end of stream" was changed to "end-of-stream" so that `ev/read` and `ev/chunk` were a little more consistent.
* Wording was altered in a few locations to decrease some docstring lengths (e.g. "Will raise" -> "Raises")
* Ordering and formatting of `int/to-bytes` was changed a bit to make reading the source a bit easier.  Also, `-` was used in the list as a separator between names and descriptions to be more consistent with most of the other docstrings.

---

[1] As mentioned in #1858, this can be nicer for searching as well.