### PR TITLE
Modify debug/unbreak and tuple/setmap docstrings

### DIFF
--- a/src/core/debug.c
+++ b/src/core/debug.c
@@ -232,10 +232,10 @@ JANET_CORE_FN(cfun_debug_break,
 }
 
 JANET_CORE_FN(cfun_debug_unbreak,
-              "(debug/unbreak source line column)",
-              "Remove a breakpoint with a source key at a given line and column. "
-              "Will throw an error if the breakpoint "
-              "cannot be found.") {
+              "(debug/unbreak source line col)",
+              "Remove a breakpoint from `source` at a given `line` and "
+              "`col`. Will throw an error if the breakpoint cannot be "
+              "found.") {
     JanetFuncDef *def;
     int32_t offset = 0;
     helper_find(argc, argv, &def, &offset);

--- a/src/core/tuple.c
+++ b/src/core/tuple.c
@@ -106,9 +106,9 @@ JANET_CORE_FN(cfun_tuple_sourcemap,
 }
 
 JANET_CORE_FN(cfun_tuple_setmap,
-              "(tuple/setmap tup line column)",
-              "Set the sourcemap metadata on a tuple. line and column indicate "
-              "should be integers.") {
+              "(tuple/setmap tup line col)",
+              "Set the sourcemap metadata on a tuple, `tup`. `line` and "
+              "`col` should be integers.") {
     janet_fixarity(argc, 3);
     const Janet *tup = janet_gettuple(argv, 0);
     janet_tuple_head(tup)->sm_line = janet_getinteger(argv, 1);


### PR DESCRIPTION
This PR suggests changes to the docstrings of `debug/unbreak` and `tuple/setmap` docstrings.

Changes include:

* Uses the parameter `col` instead of `column`.  This name is used elsewhere in a similar fashion (e.g. `bad-compile`, `debug/break`, `parser/where`, and `warn-compile`) and it's shorter :)
* `tup` is now mentioned in `tuple/setmap`'s docstring.
* A number of items were surrounded in backticks.

Regarding the `source` parameter (hi @pepe!), what this can be is not described in this docstring, but it's somewhat demonstrated in that of `debug/break`.  I intend to return to `debug/unbreak`'s docstring after or around the time I work on `debug/break`, so for the moment, my plan is to not explain what `source` is in this PR.