### PR TITLE
Rename fiber parameter as fib

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -3339,14 +3339,16 @@
 (var- debugger-on-status-var nil)
 
 (defn debugger
-  "Run a repl-based debugger on a fiber. Optionally pass in a level
-  to differentiate nested debuggers."
-  [fiber &opt level]
+  ``
+  Run a repl-based debugger on a fiber `fib`. Optionally pass in a level to
+  differentiate nested debuggers.
+  ``
+  [fib &opt level]
   (default level 1)
-  (def nextenv (make-env (fiber/getenv fiber)))
-  (put nextenv :fiber fiber)
+  (def nextenv (make-env (fiber/getenv fib)))
+  (put nextenv :fiber fib)
   (put nextenv :debug-level level)
-  (put nextenv :signal (fiber/last-value fiber))
+  (put nextenv :signal (fiber/last-value fib))
 
   (merge-into nextenv debugger-env)
   (defn debugger-chunks [buf p]

--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -1193,15 +1193,17 @@ JanetTable *janet_core_env(JanetTable *replacements) {
                          "type with a suitable `next` method."));
     janet_quick_asm(env, JANET_FUN_PROP,
                     "propagate", 2, 2, 2, 2, propagate_asm, sizeof(propagate_asm),
-                    JDOC("(propagate x fiber)\n\n"
-                         "Propagate a signal from a fiber to the current fiber and "
-                         "set the last value of the current fiber to `x`.  The signal "
-                         "value is then available as the status of the current fiber. "
-                         "The resulting stack trace from the current fiber will include "
-                         "frames from fiber. If fiber is in a state that can be resumed, "
-                         "resuming the current fiber will first resume `fiber`. "
-                         "This function can be used to re-raise an error without losing "
-                         "the original stack trace."));
+                    JDOC("(propagate x fib)\n\n"
+                         "Propagate a signal from a fiber `fib` to the "
+                         "current fiber and set the last value of the "
+                         "current fiber to `x`. The signal value is then "
+                         "available as the status of the current fiber. The "
+                         "resulting stack trace from the current fiber will "
+                         "include frames from `fib`. If `fib` is in a state "
+                         "that can be resumed, resuming the current fiber "
+                         "will first resume `fib`. This function can be "
+                         "used to re-raise an error without losing the "
+                         "original stack trace."));
     janet_quick_asm(env, JANET_FUN_DEBUG,
                     "debug", 1, 0, 1, 1, debug_asm, sizeof(debug_asm),
                     JDOC("(debug &opt x)\n\n"
@@ -1219,16 +1221,21 @@ JanetTable *janet_core_env(JanetTable *replacements) {
                          "return the value that was passed to resume."));
     janet_quick_asm(env, JANET_FUN_CANCEL,
                     "cancel", 2, 2, 2, 2, cancel_asm, sizeof(cancel_asm),
-                    JDOC("(cancel fiber err)\n\n"
-                         "Resume a fiber but have it immediately raise an error. This lets a programmer unwind a pending fiber. "
-                         "Returns the same result as resume."));
+                    JDOC("(cancel fib err)\n\n"
+                         "Resume a fiber `fib` but have it immediately "
+                         "raise an error. This enables unwinding a pending "
+                         "fiber. Returns same result as `resume`."));
     janet_quick_asm(env, JANET_FUN_RESUME,
                     "resume", 2, 1, 2, 2, resume_asm, sizeof(resume_asm),
-                    JDOC("(resume fiber &opt x)\n\n"
-                         "Resume a new or suspended fiber and optionally pass in a value to the fiber that "
-                         "will be returned to the last yield in the case of a pending fiber, or the argument to "
-                         "the dispatch function in the case of a new fiber. Returns either the return result of "
-                         "the fiber's dispatch function, or the value from the next yield call in fiber."));
+                    JDOC("(resume fib &opt x)\n\n"
+                         "Resume a new or suspended fiber `fib` and "
+                         "optionally pass in a value `x` to `fib` that "
+                         "is then returned to the last yield in the case of "
+                         "a pending fiber, or the argument to the dispatch "
+                         "function in the case of a new fiber. Returns "
+                         "either the return result of `fib`'s dispatch "
+                         "function, or the value from the next yield call "
+                         "in `fib`."));
     janet_quick_asm(env, JANET_FUN_IN,
                     "in", 3, 2, 3, 4, in_asm, sizeof(in_asm),
                     JDOC("(in x key &opt dflt)\n\n"

--- a/src/core/debug.c
+++ b/src/core/debug.c
@@ -402,10 +402,11 @@ JANET_CORE_FN(cfun_debug_stack,
 }
 
 JANET_CORE_FN(cfun_debug_stacktrace,
-              "(debug/stacktrace fiber &opt err prefix)",
-              "Prints a nice looking stacktrace for a fiber. Can optionally provide "
-              "an error value to print the stack trace with. If `prefix` is nil or not "
-              "provided, will skip the error line. Returns the fiber.") {
+              "(debug/stacktrace fib &opt err prefix)",
+              "Prints a nice looking stack trace for a fiber `fib`. "
+              "Optionally provide an error value `err` to print the "
+              "stack trace with. If `prefix` is nil or not provided, skips "
+              "the error line. Returns `fib`.") {
     janet_arity(argc, 1, 3);
     JanetFiber *fiber = janet_getfiber(argv, 0);
     Janet x = argc == 1 ? janet_wrap_nil() : argv[1];
@@ -415,10 +416,10 @@ JANET_CORE_FN(cfun_debug_stacktrace,
 }
 
 JANET_CORE_FN(cfun_debug_argstack,
-              "(debug/arg-stack fiber)",
-              "Gets all values currently on the fiber's argument stack. Normally, "
-              "this should be empty unless the fiber signals while pushing arguments "
-              "to make a function call. Returns a new array.") {
+              "(debug/arg-stack fib)",
+              "Gets all values currently on a fiber `fib`'s argument stack. "
+              "Normally this is empty unless `fib` signals while pushing "
+              "arguments to make a function call. Returns a new array.") {
     janet_fixarity(argc, 1);
     JanetFiber *fiber = janet_getfiber(argv, 0);
     JanetArray *array = janet_array(fiber->stacktop - fiber->stackstart);
@@ -430,10 +431,11 @@ JANET_CORE_FN(cfun_debug_argstack,
 }
 
 JANET_CORE_FN(cfun_debug_step,
-              "(debug/step fiber &opt x)",
-              "Run a fiber for one virtual instruction of the Janet machine. Can optionally "
-              "pass in a value that will be passed as the resuming value. Returns the signal value, "
-              "which will usually be nil, as breakpoints raise nil signals.") {
+              "(debug/step fib &opt x)",
+              "Run a fiber `fib` for one virtual instruction of the Janet "
+              "machine. Optionally pass in a value `x` that will be passed "
+              "as the resuming value. Returns the signal value, which is "
+              "usually nil, as breakpoints raise nil signals.") {
     janet_arity(argc, 1, 2);
     JanetFiber *fiber = janet_getfiber(argv, 0);
     Janet out = janet_wrap_nil();

--- a/src/core/ev.c
+++ b/src/core/ev.c
@@ -3388,9 +3388,10 @@ JANET_CORE_FN(cfun_ev_deadline,
 }
 
 JANET_CORE_FN(cfun_ev_cancel,
-              "(ev/cancel fiber err)",
-              "Cancel a suspended task fiber in the event loop. Differs from "
-              "`cancel` in that it returns the canceled fiber immediately.") {
+              "(ev/cancel fib err)",
+              "Cancel a suspended task fiber `fib` in the event loop. "
+              "Differs from `cancel` in that it returns the canceled "
+              "fiber immediately.") {
     janet_fixarity(argc, 2);
     JanetFiber *fiber = janet_getfiber(argv, 0);
     Janet err = argv[1];

--- a/src/core/fiber.c
+++ b/src/core/fiber.c
@@ -453,9 +453,9 @@ JanetFiber *janet_root_fiber(void) {
 /* CFuns */
 
 JANET_CORE_FN(cfun_fiber_getenv,
-              "(fiber/getenv fiber)",
-              "Gets the environment for a fiber. Returns nil if no such table is "
-              "set yet.") {
+              "(fiber/getenv fib)",
+              "Gets the environment for a fiber `fib`. Returns nil if no "
+              "such table is set yet.") {
     janet_fixarity(argc, 1);
     JanetFiber *fiber = janet_getfiber(argv, 0);
     return fiber->env ?
@@ -464,9 +464,9 @@ JANET_CORE_FN(cfun_fiber_getenv,
 }
 
 JANET_CORE_FN(cfun_fiber_setenv,
-              "(fiber/setenv fiber table)",
-              "Sets the environment table for a fiber. Set to nil to remove the current "
-              "environment.") {
+              "(fiber/setenv fib tab)",
+              "Sets the environment table for a fiber `fib` to `tab`. Set "
+              "to nil to remove the current environment.") {
     janet_fixarity(argc, 2);
     JanetFiber *fiber = janet_getfiber(argv, 0);
     if (janet_checktype(argv[1], JANET_NIL)) {
@@ -654,16 +654,16 @@ int janet_fiber_can_resume(JanetFiber *fiber) {
 }
 
 JANET_CORE_FN(cfun_fiber_can_resume,
-              "(fiber/can-resume? fiber)",
-              "Check if a fiber is finished and cannot be resumed.") {
+              "(fiber/can-resume? fib)",
+              "Check if a fiber `fib` is finished and cannot be resumed.") {
     janet_fixarity(argc, 1);
     JanetFiber *fiber = janet_getfiber(argv, 0);
     return janet_wrap_boolean(janet_fiber_can_resume(fiber));
 }
 
 JANET_CORE_FN(cfun_fiber_last_value,
-              "(fiber/last-value fiber)",
-              "Get the last value returned or signaled from the fiber.") {
+              "(fiber/last-value fib)",
+              "Get the last value returned or signaled from a fiber `fib`.") {
     janet_fixarity(argc, 1);
     JanetFiber *fiber = janet_getfiber(argv, 0);
     return fiber->last_value;


### PR DESCRIPTION
This PR mostly suggests changing the parameter name `fiber` to `fib`.

Changes include:

* Use `fib` as a parameter name instead of `fiber`.  `fib` was already in use (e.g. `debug/lineage`, `fiber/maxstack`, `fiber/setmaxstack`, `fiber/status`) and it's shorter than `fiber`.
* Mention the parameter `x` in a few functions where it was only in the signature.
* Use `tab` as a parameter name instead of `table`.  `tab` was already used elsewhere (e.g. in `merge-into`, `table/clear`, `table/clone`, etc.) and `table` shadows a built-in function.
* Shortened some text (e.g. "Optionally provide" instead of "Can optionally provide").
* Whitespace and reflow changes.