### PR TITLE
Rename some parameters

### DIFF
--- a/src/core/corelib.c
+++ b/src/core/corelib.c
@@ -260,8 +260,9 @@ JANET_CORE_FN(janet_core_expand_path,
 }
 
 JANET_CORE_FN(janet_core_dyn,
-              "(dyn key &opt default)",
-              "Get a dynamic binding. Returns the default value (or nil) if no binding found.") {
+              "(dyn key &opt dflt)",
+              "Get a dynamic binding value for `key`. If no binding found, "
+              "returns `dflt` (or nil).") {
     janet_arity(argc, 1, 2);
     Janet value;
     if (janet_vm.fiber->env) {
@@ -276,8 +277,8 @@ JANET_CORE_FN(janet_core_dyn,
 }
 
 JANET_CORE_FN(janet_core_setdyn,
-              "(setdyn key value)",
-              "Set a dynamic binding. Returns value.") {
+              "(setdyn key val)",
+              "Set a dynamic binding for `key` to `val`. Returns `val`.") {
     janet_fixarity(argc, 2);
     if (!janet_vm.fiber->env) {
         janet_vm.fiber->env = janet_table(2);
@@ -399,14 +400,14 @@ JANET_CORE_FN(janet_core_scannumber,
 }
 
 JANET_CORE_FN(janet_core_tuple,
-              "(tuple & items)",
-              "Creates a new tuple that contains items. Returns the new tuple.") {
+              "(tuple & xs)",
+              "Creates and returns a tuple that contains values from `xs`.") {
     return janet_wrap_tuple(janet_tuple_n(argv, argc));
 }
 
 JANET_CORE_FN(janet_core_array,
-              "(array & items)",
-              "Create a new array that contains items. Returns the new array.") {
+              "(array & xs)",
+              "Creates and returns an array that contains values from `xs`.") {
     JanetArray *array = janet_array(argc);
     array->count = argc;
     safe_memcpy(array->data, argv, argc * sizeof(Janet));
@@ -613,11 +614,14 @@ JANET_CORE_FN(janet_core_hash,
 }
 
 JANET_CORE_FN(janet_core_getline,
-              "(getline &opt prompt buf env)",
-              "Reads a line of input into a buffer, including the newline character, using a prompt. "
-              "An optional environment table can be provided for auto-complete. "
-              "Returns the modified buffer. "
-              "Use this function to implement a simple interface for a terminal program.") {
+              "(getline &opt prmpt buf env)",
+              "Reads a line of input into a buffer (including the "
+              "newline character) showing a prompt `prmpt` if specified. "
+              "Optional argument `buf` specifies a buffer; if not set, "
+              "a new buffer is created. Provide an optional environment "
+              "table `env` for auto-complete. Returns the modified buffer. "
+              "Use this function to implement a simple interface for a "
+              "terminal program.") {
     FILE *in = janet_dynfile("in", stdin);
     FILE *out = janet_dynfile("out", stdout);
     janet_arity(argc, 0, 3);

--- a/src/core/math.c
+++ b/src/core/math.c
@@ -149,9 +149,10 @@ JANET_CORE_FN(cfun_rng_uniform,
 }
 
 JANET_CORE_FN(cfun_rng_int,
-              "(math/rng-int rng &opt max)",
-              "Extract a random integer in the range [0, max) for max > 0 from the RNG.  "
-              "If max is 0, return 0.  If no max is given, the default is 2^31 - 1."
+              "(math/rng-int rng &opt lim)",
+              "Get a random integer in the range [0, `lim`) for a positive "
+              "integer `lim` using the RNG `rng`. If `lim` not given, the "
+              "default is 2^31 - 1."
              ) {
     janet_arity(argc, 1, 2);
     JanetRNG *rng = janet_getabstract(argv, 0, &janet_rng_type);

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -465,10 +465,11 @@ JANET_CORE_FN(cfun_string_split,
 }
 
 JANET_CORE_FN(cfun_string_checkset,
-              "(string/check-set set str)",
-              "Checks that the string `str` only contains bytes that appear in the string `set`. "
-              "Returns true if all bytes in `str` appear in `set`, false if some bytes in `str` do "
-              "not appear in `set`.") {
+              "(string/check-set bytes str)",
+              "Checks that the string `str` only contains bytes that appear "
+              "in the string `bytes`. Returns true if all bytes in `str` "
+              "appear in `bytes`, false if some bytes in `str` do not appear "
+              "in `bytes`.") {
     uint32_t bitset[8] = {0, 0, 0, 0, 0, 0, 0, 0};
     janet_fixarity(argc, 2);
     JanetByteView set = janet_getbytes(argv, 0);
@@ -602,9 +603,10 @@ static void trim_help_args(int32_t argc, Janet *argv, JanetByteView *str, JanetB
 }
 
 JANET_CORE_FN(cfun_string_trim,
-              "(string/trim str &opt set)",
-              "Trim leading and trailing whitespace from a byte sequence. If the argument "
-              "`set` is provided, consider only characters in `set` to be whitespace.") {
+              "(string/trim str &opt bytes)",
+              "Trim leading and trailing whitespace from a byte sequence "
+              "`str`. If argument `bytes` is provided, treat only "
+              "characters in `bytes` as whitespace.") {
     JanetByteView str, set;
     trim_help_args(argc, argv, &str, &set);
     int32_t left_edge = trim_help_leftedge(str, set);
@@ -615,9 +617,10 @@ JANET_CORE_FN(cfun_string_trim,
 }
 
 JANET_CORE_FN(cfun_string_triml,
-              "(string/triml str &opt set)",
-              "Trim leading whitespace from a byte sequence. If the argument "
-              "`set` is provided, consider only characters in `set` to be whitespace.") {
+              "(string/triml str &opt bytes)",
+              "Trim leading whitespace from a byte sequence `str`. If "
+              "argument `bytes` is provided, treat only characters in "
+              "`bytes` as whitespace.") {
     JanetByteView str, set;
     trim_help_args(argc, argv, &str, &set);
     int32_t left_edge = trim_help_leftedge(str, set);
@@ -625,9 +628,10 @@ JANET_CORE_FN(cfun_string_triml,
 }
 
 JANET_CORE_FN(cfun_string_trimr,
-              "(string/trimr str &opt set)",
-              "Trim trailing whitespace from a byte sequence. If the argument "
-              "`set` is provided, consider only characters in `set` to be whitespace.") {
+              "(string/trimr str &opt bytes)",
+              "Trim trailing whitespace from a byte sequence `str`. If "
+              "argument `bytes` is provided, treat only characters in "
+              "`bytes` as whitespace.") {
     JanetByteView str, set;
     trim_help_args(argc, argv, &str, &set);
     int32_t right_edge = trim_help_rightedge(str, set);


### PR DESCRIPTION
This PR mostly suggests changing some parameter names to not shadow some built-in constructs.

Changes to prevent shadowing include:

* `default` -> `dflt`: also shorter
* `max` -> `lim`
* `prompt` -> `prmpt`: also shorter
* `set` -> `bytes`

Changes not related to shadowing but reduce name length and follow more closely recent decisions:

* `items` -> `xs`
* `value` -> `val`

Some rewording, and whitespace / reflow changes are also included.