### PR TITLE
Change os/stat and os/lstat docstrings

### DIFF
--- a/src/core/os.c
+++ b/src/core/os.c
@@ -2534,30 +2534,34 @@ static Janet os_stat_or_lstat(int do_lstat, int32_t argc, Janet *argv) {
 }
 
 JANET_CORE_FN(os_stat,
-              "(os/stat path &opt tab|key)",
-              "Gets information about a file or directory. Returns a table unless the second argument is a keyword, "
-              "in which case it returns only that field/value from stat. If the file or directory does not exist, returns nil."
-              "The keys are:\n\n"
-              "* :dev - the device that the file is on\n\n"
-              "* :mode - the type of file, one of :file, :directory, :block, :character, :fifo, :socket, :link, or :other\n\n"
-              "* :int-permissions - A Unix permission integer like 8r744\n\n"
-              "* :permissions - A Unix permission string like \"rwxr--r--\"\n\n"
-              "* :uid - File uid\n\n"
-              "* :gid - File gid\n\n"
-              "* :nlink - number of links to file\n\n"
-              "* :rdev - Real device of file. 0 on Windows\n\n"
-              "* :size - size of file in bytes\n\n"
-              "* :blocks - number of blocks in file. 0 on Windows\n\n"
-              "* :blocksize - size of blocks in file. 0 on Windows\n\n"
-              "* :accessed - timestamp when file last accessed\n\n"
-              "* :changed - timestamp when file last changed (permissions changed)\n\n"
-              "* :modified - timestamp when file last modified (content changed)\n") {
+              "(os/stat path &opt tab-or-kwd)",
+              "Gets information about a file or directory. Returns a table "
+              "unless the second argument `tab-or-kwd` is a keyword, in "
+              "which case it returns only that field/value from `stat()`. "
+              "If `tab-or-kwd` is a table, reuses it as basis of the "
+              "returned table. If the file or directory does not exist, "
+              "returns nil. The keys are:\n"
+              "\n"
+              "* `:dev` - device that the file is on\n"
+              "* `:mode` - type of file, one of `:file`, `:directory`, `:block`, `:character`, `:fifo`, `:socket`, `:link`, or `:other`\n"
+              "* `:int-permissions` - a Unix permission integer like 8r744\n"
+              "* `:permissions` - a Unix permission string like \"rwxr--r--\"\n"
+              "* `:uid` - file uid\n"
+              "* `:gid` - file gid\n"
+              "* `:nlink` - number of links to file\n"
+              "* `:rdev` - real device of file. 0 on Windows\n"
+              "* `:size` - size of file in bytes\n"
+              "* `:blocks` - number of blocks in file. 0 on Windows\n"
+              "* `:blocksize` - size of blocks in file. 0 on Windows\n"
+              "* `:accessed` - timestamp when file last accessed\n"
+              "* `:changed` - timestamp when file last changed (permissions changed)\n"
+              "* `:modified` - timestamp when file last modified (content changed)") {
     return os_stat_or_lstat(0, argc, argv);
 }
 
 JANET_CORE_FN(os_lstat,
-              "(os/lstat path &opt tab|key)",
-              "Like os/stat, but don't follow symlinks.\n") {
+              "(os/lstat path &opt tab-or-kwd)",
+              "Like `os/stat`, but doesn't follow symlinks.\n") {
     return os_stat_or_lstat(1, argc, argv);
 }
 


### PR DESCRIPTION
The main motivation for this PR was to change the displayed parameter name `tab|key`.

Although an interesting idea, AFAIU `tab|key` is not a legitimate Janet symbol due to the use of `|`.  This PR suggests using the somewhat less elegant `tab-or-kwd`.

A motivation to use `kwd` instead of `key` is that `key` is used in a more general sense elsewhere to stand for the key of a dictionary.  Since dictionaries can use non-keyword values as keys, the choice of `key` there seems like a good fit.  Since `key` is used that way, I think `kwd` isn't a bad choice as a label for keyword.

Also, the case where `tab-or-kwd` is a table was not described in `os/stat`'s docstring so an attempt to cover that was made.

In addition to the changes above, the list markup for `os/stat` was modified so that the contained keywords were wrapped in backticks, each list item was reduced by one newline, and other minor changes were made.  `os/lstat` also had its reference to `os/stat` surrounded by backticks.