### PR TITLE
Choose parameter names that don't shadow builtins

### DIFF
--- a/src/boot/boot.janet
+++ b/src/boot/boot.janet
@@ -244,33 +244,37 @@
   ~(if ,condition nil (do ,;body)))
 
 (defmacro cond
-  `Evaluates conditions sequentially until the first true condition
-  is found, and then executes the corresponding body. If there are an
-  odd number of forms, and no forms are matched, the last expression
-  is executed. If there are no matches, returns nil.`
-  [& pairs]
+  ``
+  Evaluates conditions sequentially until the first true condition is
+  found, and then executes the corresponding body. If there are an odd
+  number of forms, and no forms are matched, the last expression is
+  executed. If there are no matches, returns nil.
+  ``
+  [& clauses]
   (defn aux [i]
-    (def restlen (- (length pairs) i))
+    (def restlen (- (length clauses) i))
     (if (= restlen 0) nil
-      (if (= restlen 1) (in pairs i)
-        (tuple 'if (in pairs i)
-               (in pairs (+ i 1))
+      (if (= restlen 1) (in clauses i)
+        (tuple 'if (in clauses i)
+               (in clauses (+ i 1))
                (aux (+ i 2))))))
   (aux 0))
 
 (defmacro case
-  ``Select the body that equals the dispatch value. When `pairs`
-  has an odd number of elements, the last is the default expression.
-  If no match is found, returns nil.``
-  [dispatch & pairs]
+  ``
+  Select the body that equals the `dispatch` value. When `clauses` has
+  an odd number of elements, the last is the default expression. If no
+  match is found, returns nil.
+  ``
+  [dispatch & clauses]
   (def atm (idempotent? dispatch))
   (def sym (if atm dispatch (gensym)))
   (defn aux [i]
-    (def restlen (- (length pairs) i))
+    (def restlen (- (length clauses) i))
     (if (= restlen 0) nil
-      (if (= restlen 1) (in pairs i)
-        (tuple 'if (tuple = sym (in pairs i))
-               (in pairs (+ i 1))
+      (if (= restlen 1) (in clauses i)
+        (tuple 'if (tuple = sym (in clauses i))
+               (in clauses (+ i 1))
                (aux (+ i 2))))))
   (if atm
     (aux 0)
@@ -4296,14 +4300,15 @@
 (compwhen (dyn 'net/listen)
   (defn net/server
     ``
-    Starts a server with `net/listen`. Runs `net/accept-loop` asynchronously if
-    `handler` is set and `type` is `:stream` (the default). It is invalid to set
-    `handler` if `type` is `:datagram`. Returns the new server stream.
+    Starts a server with `net/listen`. Runs `net/accept-loop`
+    asynchronously if `handler` is set and `cntype` is `:stream` (the
+    default). It is invalid to set `handler` if `cntype` is
+    `:datagram`. Returns the new server stream.
     ``
-    [host port &opt handler type no-reuse]
-    (assert (not (and (= type :datagram) handler))
+    [host port &opt handler cntype no-reuse]
+    (assert (not (and (= cntype :datagram) handler))
             "handler not supported for :datagram servers")
-    (def s (net/listen host port type no-reuse))
+    (def s (net/listen host port cntype no-reuse))
     (if handler
       (ev/go (fn :net/server-handler [] (net/accept-loop s handler))))
     s))

--- a/src/core/net.c
+++ b/src/core/net.c
@@ -451,13 +451,16 @@ static struct addrinfo *janet_get_addrinfo(Janet *argv, int32_t offset, int sock
  */
 
 JANET_CORE_FN(cfun_net_sockaddr,
-              "(net/address host port &opt type multi)",
-              "Look up the connection information for a given hostname, port, and connection type. Returns "
-              "a handle that can be used to send datagrams over network without establishing a connection. "
-              "On Posix platforms, you can use :unix for host to connect to a unix domain socket, where the name is "
-              "given in the port argument. On Linux, abstract "
-              "unix domain sockets are specified with a leading '@' character in port. If `multi` is truthy, will "
-              "return all address that match in an array instead of just the first.") {
+              "(net/address host port &opt cntype multi)",
+              "Look up the connection information for a given `host`, "
+              "`port`, and connection type `cntype`. Returns a handle that "
+              "can be used to send datagrams over the network without "
+              "establishing a connection. On POSIX platforms, you can use "
+              "`:unix` for `host` to connect to a unix domain socket, where "
+              "the name is given in the `port` argument. On Linux, abstract "
+              "unix domain sockets are specified with a leading '@' "
+              "character in `port`. If `multi` is truthy, returns all "
+              "addresses that match in an array instead of just the first.") {
     janet_sandbox_assert(JANET_SANDBOX_NET_CONNECT); /* connect OR listen */
     janet_arity(argc, 2, 4);
     int socktype = janet_get_sockettype(argv, argc, 2);
@@ -499,12 +502,15 @@ JANET_CORE_FN(cfun_net_sockaddr,
 }
 
 JANET_CORE_FN(cfun_net_connect,
-              "(net/connect host port &opt type bindhost bindport)",
-              "Open a connection to communicate with a server. Returns a duplex stream "
-              "that can be used to communicate with the server. Type is an optional keyword "
-              "to specify a connection type, either :stream or :datagram. The default is :stream. "
-              "Bindhost is an optional string to select from what address to make the outgoing "
-              "connection, with the default being the same as using the OS's preferred address. ") {
+              "(net/connect host port &opt cntype bindhost bindport)",
+              "Open a connection to communicate with a server at `host` "
+              "`port`. Returns a duplex stream that can be used to "
+              "communicate with the server. `cntype` is an optional keyword "
+              "to specify a connection type, either `:stream` or "
+              "`:datagram`; the default is `:stream`. `bindhost` and "
+              "`bindport` are optional strings to select from what address "
+              "to make the outgoing connection; the default is the same as "
+              "using the OS's preferred address.") {
     janet_sandbox_assert(JANET_SANDBOX_NET_CONNECT);
     janet_arity(argc, 2, 5);
 
@@ -680,10 +686,11 @@ JANET_CORE_FN(cfun_net_connect,
 }
 
 JANET_CORE_FN(cfun_net_socket,
-              "(net/socket &opt type address-family)",
-              "Creates a new unbound socket. Type is an optional keyword, "
-              "either a :stream (usually tcp), or :datagram (usually udp). The default is :stream. "
-              "`address-family` should be one of :ipv4 or :ipv6.") {
+              "(net/socket &opt cntype address-family)",
+              "Creates a new unbound socket. `cntype` is an optional "
+              "keyword, either `:stream` (usually TCP), or `:datagram` "
+              "(usually UDP). The default is `:stream`. `address-family` "
+              "should be `:ipv4` or `:ipv6`.") {
     janet_arity(argc, 0, 2);
 
     int socktype = janet_get_sockettype(argv, argc, 0);
@@ -807,13 +814,17 @@ JANET_CORE_FN(cfun_net_shutdown,
 }
 
 JANET_CORE_FN(cfun_net_listen,
-              "(net/listen host port &opt type no-reuse)",
-              "Creates a server. Returns a new stream that is neither readable nor "
-              "writeable. Use net/accept or net/accept-loop be to handle connections and start the server. "
-              "The type parameter specifies the type of network connection, either "
-              "a :stream (usually tcp), or :datagram (usually udp). If not specified, the default is "
-              ":stream. The host and port arguments are the same as in net/address. The last boolean parameter `no-reuse` will "
-              "disable the use of `SO_REUSEADDR` and `SO_REUSEPORT` when creating a server on some operating systems.") {
+              "(net/listen host port &opt cntype no-reuse)",
+              "Creates a server. Returns a new stream that is neither "
+              "readable nor writeable. Use `net/accept` or "
+              "`net/accept-loop` to handle connections and start the "
+              "server. The `cntype` parameter specifies the connection "
+              "type, either `:stream` (usually TCP), or `:datagram` "
+              "(usually UDP). If not specified, the default is `:stream`. "
+              "The `host` and `port` arguments are the same as in "
+              "`net/address`. The last boolean parameter `no-reuse` "
+              "disables the use of `SO_REUSEADDR` and `SO_REUSEPORT` when "
+              "creating a server on some operating systems.") {
     janet_sandbox_assert(JANET_SANDBOX_NET_LISTEN);
     janet_arity(argc, 2, 4);
 

--- a/src/core/os.c
+++ b/src/core/os.c
@@ -797,13 +797,16 @@ static int get_signal_kw(const Janet *argv, int32_t n) {
 #endif
 
 JANET_CORE_FN(os_proc_kill,
-              "(os/proc-kill proc &opt wait signal)",
-              "Kill the subprocess `proc` by sending SIGKILL to it on POSIX systems, or by closing "
-              "the process handle on Windows. If `proc` has already completed, raise an error. If "
-              "`wait` is truthy, will wait for `proc` to complete and return the exit code (this "
-              "will raise an error if `proc` is being waited for). Otherwise, return `proc`. If "
-              "`signal` is provided, send it instead of SIGKILL. Signal keywords are named after "
-              "their C counterparts but in lowercase with the leading SIG stripped. `signal` is "
+              "(os/proc-kill proc &opt wait which)",
+              "Kill the subprocess `proc` by sending SIGKILL to it on POSIX "
+              "systems, or by closing the process handle on Windows. If "
+              "`proc` has already completed, raise an error. If `wait` is "
+              "truthy, waits for `proc` to complete and return the exit "
+              "code (this raises an error if `proc` is being waited for). "
+              "Otherwise, return `proc`. Optional argument `which` is a "
+              "keyword named after its C counterpart but in lowercase with "
+              "the leading SIG stripped. If `which` is provided, the "
+              "corresponding signal is sent instead of SIGKILL. `which` is "
               "ignored on Windows.") {
     janet_arity(argc, 1, 3);
     JanetProc *proc = janet_getabstract(argv, 0, &ProcAT);
@@ -2601,9 +2604,12 @@ JANET_CORE_FN(os_umask,
 #endif
 
 JANET_CORE_FN(os_dir,
-              "(os/dir dir &opt array)",
-              "Iterate over files and subdirectories in a directory. Returns an array of paths parts, "
-              "with only the file name or directory name and no prefix.") {
+              "(os/dir dir &opt arr)",
+              "Enumerate files and subdirectories in a directory `dir`. "
+              "Returns an array of paths relative to `dir` with only the "
+              "file or directory name with no prefix. If an array `arr` "
+              "is specified, append paths to it instead of creating a new "
+              "array.") {
     janet_sandbox_assert(JANET_SANDBOX_FS_READ);
     janet_arity(argc, 1, 2);
     const char *dir = janet_getcstring(argv, 0);


### PR DESCRIPTION
This PR suggests use of some parameter names that don't shadow those used by builtin constructs.

Alternatives include:

* `pairs` -> `clauses` (for `case` and `cond`)
* `type` -> `cntype` (for `net/` functions)
* `signal` -> `which` (for `os/proc-kill` - `which` matches what was chosen already in `os/sigaction`)
* `array` -> `arr` (for `os/dir`)

Some changes are suggested to the prose of the docstrings as well:

* The `bindport` argument is also mentioned now in `net/connect`'s docstring.
* `host` and `port` parameters were more clearly surfaced.
* Some keywords were wrapped in backticks.
* Whitespace and reflow changes