### PR TITLE
Modify some ffi/ docstrings

### DIFF
--- a/src/core/ffi.c
+++ b/src/core/ffi.c
@@ -466,24 +466,24 @@ static JanetFFIType decode_ffi_type(Janet x) {
     }
 }
 
-JANET_CORE_FN(cfun_ffi_struct,
-              "(ffi/struct & types)",
-              "Create a struct type definition that can be used to pass structs into native functions. ") {
+JANET_CORE_FN(cfun_ffi_struct, "(ffi/struct & ffi-types)",
+              "Create a struct type definition from `ffi-types` that can be "
+              "used to pass structs into native functions.") {
     janet_arity(argc, 1, -1);
     return janet_wrap_abstract(build_struct_type(argc, argv));
 }
 
 JANET_CORE_FN(cfun_ffi_size,
-              "(ffi/size type)",
-              "Get the size of an ffi type in bytes.") {
+              "(ffi/size ffi-type)",
+              "Get the size of an FFI type `ffi-type` in bytes.") {
     janet_fixarity(argc, 1);
     size_t size = type_size(decode_ffi_type(argv[0]));
     return janet_wrap_number((double) size);
 }
 
 JANET_CORE_FN(cfun_ffi_align,
-              "(ffi/align type)",
-              "Get the align of an ffi type in bytes.") {
+              "(ffi/align ffi-type)",
+              "Get the align of an FFI type `ffi-type` in bytes.") {
     janet_fixarity(argc, 1);
     size_t size = type_align(decode_ffi_type(argv[0]));
     return janet_wrap_number((double) size);
@@ -1666,9 +1666,10 @@ JANET_CORE_FN(cfun_ffi_jitfn,
 }
 
 JANET_CORE_FN(cfun_ffi_call,
-              "(ffi/call pointer signature & args)",
-              "Call a raw pointer as a function pointer. The function signature specifies "
-              "how Janet values in `args` are converted to native machine types.") {
+              "(ffi/call ptr signature & args)",
+              "Call a raw pointer `ptr` as a function pointer. The function "
+              "signature specifies how Janet values in `args` are converted "
+              "to native machine types.") {
     janet_sandbox_assert(JANET_SANDBOX_FFI_USE);
     janet_arity(argc, 2, -1);
     void *function_pointer = janet_ffi_get_callable_pointer(argv, 0);
@@ -1695,10 +1696,12 @@ JANET_CORE_FN(cfun_ffi_call,
 }
 
 JANET_CORE_FN(cfun_ffi_buffer_write,
-              "(ffi/write ffi-type data &opt buffer index)",
-              "Append a native type to a buffer such as it would appear in memory. This can be used "
-              "to pass pointers to structs in the ffi, or send C/C++/native structs over the network "
-              "or to files. Returns a modified buffer or a new buffer if one is not supplied.") {
+              "(ffi/write ffi-type data &opt buf index)",
+              "Append a native type, `ffi-type`, to a buffer as it would "
+              "appear in memory. This can be used to pass pointers to "
+              "structs in the ffi, or send C/C++/native structs over "
+              "the network or to files. Returns a modified buffer, `buf`, "
+              "or a new buffer if not supplied.") {
     janet_sandbox_assert(JANET_SANDBOX_FFI_USE);
     janet_arity(argc, 2, 4);
     JanetFFIType type = decode_ffi_type(argv[0]);
@@ -1827,8 +1830,9 @@ JANET_CORE_FN(cfun_ffi_malloc,
 }
 
 JANET_CORE_FN(cfun_ffi_free,
-              "(ffi/free pointer)",
-              "Free memory allocated with `ffi/malloc`. Returns nil.") {
+              "(ffi/free ptr)",
+              "Free memory reachable from `ptr` allocated with "
+              "`ffi/malloc`. Returns nil.") {
     janet_sandbox_assert(JANET_SANDBOX_FFI_USE);
     janet_fixarity(argc, 1);
     if (janet_checktype(argv[0], JANET_NIL)) return janet_wrap_nil();
@@ -1838,12 +1842,15 @@ JANET_CORE_FN(cfun_ffi_free,
 }
 
 JANET_CORE_FN(cfun_ffi_pointer_buffer,
-              "(ffi/pointer-buffer pointer capacity &opt count offset)",
-              "Create a buffer from a pointer. The underlying memory of the buffer will not be "
-              "reallocated or freed by the garbage collector, allowing unmanaged, mutable memory "
-              "to be manipulated with buffer functions. Attempts to resize or extend the buffer "
-              "beyond its initial capacity will raise an error. As with many FFI functions, this is memory "
-              "unsafe and can potentially allow out of bounds memory access. Returns a new buffer.") {
+              "(ffi/pointer-buffer ptr capacity &opt n offset)",
+              "Create a buffer from a pointer `ptr`. The underlying memory "
+              "of the buffer will not be reallocated or freed by the "
+              "garbage collector, allowing unmanaged, mutable memory to be "
+              "manipulated with buffer functions. Attempts to resize or "
+              "extend the buffer beyond its initial capacity will raise an "
+              "error. As with many FFI functions, this is memory unsafe and "
+              "can potentially allow out of bounds memory access. Returns a "
+              "new buffer.") {
     janet_sandbox_assert(JANET_SANDBOX_FFI_USE);
     janet_arity(argc, 2, 4);
     void *pointer = janet_getpointer(argv, 0);
@@ -1855,9 +1862,10 @@ JANET_CORE_FN(cfun_ffi_pointer_buffer,
 }
 
 JANET_CORE_FN(cfun_ffi_pointer_cfunction,
-              "(ffi/pointer-cfunction pointer &opt name source-file source-line)",
-              "Create a C Function from a raw pointer. Optionally give the cfunction a name and "
-              "source location for stack traces and debugging.") {
+              "(ffi/pointer-cfunction ptr &opt name source line)",
+              "Create a C Function from a raw pointer `ptr`. Optionally "
+              "give the cfunction a name and source location for stack "
+              "traces and debugging.") {
     janet_sandbox_assert(JANET_SANDBOX_FFI_USE);
     janet_arity(argc, 1, 4);
     void *pointer = janet_getpointer(argv, 0);
@@ -1872,11 +1880,14 @@ JANET_CORE_FN(cfun_ffi_pointer_cfunction,
 
 JANET_CORE_FN(cfun_ffi_supported_calling_conventions,
               "(ffi/calling-conventions)",
-              "Get an array of all supported calling conventions on the current architecture. Some architectures may have some FFI "
-              "functionality (ffi/malloc, ffi/free, ffi/read, ffi/write, etc.) but not support "
-              "any calling conventions. This function can be used to get all supported calling conventions "
-              "that can be used on this architecture. All architectures support the :none calling "
-              "convention which is a placeholder that cannot be used at runtime.") {
+              "Get an array of all supported calling conventions on the "
+              "current architecture. Some architectures may have some FFI "
+              "functionality (`ffi/malloc`, `ffi/free`, `ffi/read`, "
+              "`ffi/write`, etc.) but not support any calling conventions. "
+              "This function can be used to get all supported calling "
+              "conventions that can be used on this architecture. All "
+              "architectures support the `:none` calling convention which "
+              "is a placeholder that cannot be used at runtime.") {
     janet_fixarity(argc, 0);
     (void) argv;
     JanetArray *array = janet_array(4);


### PR DESCRIPTION
This PR mostly suggests some parameter name changes for "unshadowing" purposes.

Parameter name changes include:

* `buffer` -> `buf` (as being done elsewhere).  Changes to `ffi/write` were moved out of #1859 into this one to facilitate work,
* `type` -> `ffi-type` (reduces shadowing of `type`).  `ffi-type` was already being used by `ffi/read` and `ffi/write` so that seemed like an appropriate choice of name.
* `pointer` -> `ptr`.  `ptr` is shorter and use (at least as a suffix) appears common enough among C programmers.
* `count` -> `n`.  `n` is shorter and doesn't shadow an existing built-in name unlike `count`.
* `source-file` -> `source` and `source-line` -> `line`.  Both of these have precedent elsewhere.

Other changes include:

* Mentioning `ptr` in some docstrings.
* Wrapping some references to `ffi/` function names in backticks.
* Change caps of "ffi" to "FFI" (when used as a single word) for more consistency.
* Whitespace and reflow alterations.

(Note that it may be that some of these docstrings could use another pass regarding meaning and checking alignment with actual capabilities.  I'm primarily focused on more surface elements ATM, but if I see something that looks wrong I do try to attend to it.)