### PR TITLE
Modify some marshal docstrings

### DIFF
--- a/src/core/marsh.c
+++ b/src/core/marsh.c
@@ -1670,22 +1670,26 @@ Janet janet_unmarshal(
 
 JANET_CORE_FN(cfun_env_lookup,
               "(env-lookup env)",
-              "Creates a forward lookup table for unmarshalling from an environment. "
-              "To create a reverse lookup table, use the invert function to swap keys "
-              "and values in the returned table.") {
+              "Creates a forward lookup table for unmarshalling from an "
+              "environment `env`. To create a reverse lookup table, use "
+              "`invert` to swap keys and values in the returned table.") {
     janet_fixarity(argc, 1);
     JanetTable *env = janet_gettable(argv, 0);
     return janet_wrap_table(janet_env_lookup(env));
 }
 
 JANET_CORE_FN(cfun_marshal,
-              "(marshal x &opt reverse-lookup buffer no-cycles)",
-              "Marshal a value into a buffer and return the buffer. The buffer "
-              "can then later be unmarshalled to reconstruct the initial value. "
-              "Optionally, one can pass in a reverse lookup table to not marshal "
-              "aliased values that are found in the table. Then a forward "
-              "lookup table can be used to recover the original value when "
-              "unmarshalling.") {
+              "(marshal x &opt rev-lookup buf no-cycles)",
+              "Marshal a value, `x`, into a buffer and return the buffer. "
+              "The buffer can then later be unmarshalled to reconstruct the "
+              "initial value. Optionally, pass in a table, `rev-lookup`, to "
+              "specify aliased values to not marshal. Then a forward lookup "
+              "table can be used to recover the original value when "
+              "unmarshalling. If optional argument `buf` is provided, "
+              "marshal into and return that instead. The optional "
+              "`no-cycles` parameter will make `unmarshal` faster if it is "
+              "known that there are no cycles; will error if there are "
+              "cycles.") {
     janet_arity(argc, 1, 4);
     JanetBuffer *buffer;
     JanetTable *rreg = NULL;
@@ -1706,10 +1710,10 @@ JANET_CORE_FN(cfun_marshal,
 }
 
 JANET_CORE_FN(cfun_unmarshal,
-              "(unmarshal buffer &opt lookup)",
-              "Unmarshal a value from a buffer. An optional lookup table "
-              "can be provided to allow for aliases to be resolved. Returns the value "
-              "unmarshalled from the buffer.") {
+              "(unmarshal buf &opt lookup)",
+              "Unmarshal a value from a buffer, `buf`. Optionally provide "
+              "a table, `lookup`, to allow for aliases to be resolved. "
+              "Returns the value unmarshalled from `buf`.") {
     janet_sandbox_assert(JANET_SANDBOX_UNMARSHAL);
     janet_arity(argc, 1, 2);
     JanetByteView view = janet_getbytes(argv, 0);


### PR DESCRIPTION
This PR suggests some changes to the docstrings of functions in `marsh.c`.

Changes include:

* Use `buf` instead of `buffer` as a parameter name.  This is part of the effort in #1858 and #1859.
* Use `rev-lookup` instead of `reverse-lookup`.  It is shorter and seem unambiguous.
* Surround the reference to `invert` with backticks.
* More parameter names are also now mentioned in the docstrings (e.g. `env`, `x`, `buf`, `no-cycles`, and `lookup`).

It's possible the `no-cycles` parameter's description could be improved.  See #1861 and [this comment](https://github.com/janet-lang/janet/pull/1859#discussion_r3987383169).