### PR TITLE
Remove dangling janet_getfloat declaration

### DIFF
--- a/src/include/janet.h
+++ b/src/include/janet.h
@@ -2219,7 +2219,6 @@ JANET_API void *janet_getpointer(const Janet *argv, int32_t n);
 
 JANET_API int32_t janet_getnat(const Janet *argv, int32_t n);
 JANET_API int32_t janet_getinteger(const Janet *argv, int32_t n);
-JANET_API float janet_getfloat(const Janet *argv, int32_t n);
 JANET_API int8_t janet_getinteger8(const Janet *argv, int32_t n);
 JANET_API int16_t janet_getinteger16(const Janet *argv, int32_t n);
 JANET_API int64_t janet_getinteger64(const Janet *argv, int32_t n);


### PR DESCRIPTION
It was not removed along with the function definition.

Fixes: ec48673f7c66 ("Revert float interface")
References: 23e4ad4bd3b4 ("Add ... float getters for consistency")